### PR TITLE
Fix sample config doc CI

### DIFF
--- a/changelog.d/16758.misc
+++ b/changelog.d/16758.misc
@@ -1,0 +1,1 @@
+Fix sample config doc CI.

--- a/docs/.sample_config_header.yaml
+++ b/docs/.sample_config_header.yaml
@@ -9,3 +9,4 @@
 # https://element-hq.github.io/synapse/latest/setup/installation.html.
 #
 ################################################################################
+


### PR DESCRIPTION
I accidentally broke it during the move by removing a trailing new line.