### PR TITLE
Filter out rooms from the room directory being served to other homeservers when those rooms block that homeserver by their Access Control Lists.

### DIFF
--- a/changelog.d/16759.feature
+++ b/changelog.d/16759.feature
@@ -1,0 +1,1 @@
+Filter out rooms from the room directory being served to other homeservers when those rooms block that homeserver by their Access Control Lists.

--- a/synapse/federation/transport/server/__init__.py
+++ b/synapse/federation/transport/server/__init__.py
@@ -154,7 +154,10 @@ class PublicRoomList(BaseFederationServlet):
             limit = None
 
         data = await self.handler.get_local_public_room_list(
-            limit, since_token, network_tuple=network_tuple, from_federation=True
+            limit,
+            since_token,
+            network_tuple=network_tuple,
+            from_federation_origin=origin,
         )
         return 200, data
 
@@ -195,7 +198,7 @@ class PublicRoomList(BaseFederationServlet):
             since_token=since_token,
             search_filter=search_filter,
             network_tuple=network_tuple,
-            from_federation=True,
+            from_federation_origin=origin,
         )
 
         return 200, data

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -176,8 +176,16 @@ class RoomListHandler:
             forwards = True
             has_batch_token = False
 
-        # we request one more than wanted to see if there are more pages to come
-        probing_limit = limit + 1
+        if from_federation_origin is None:
+            # Client-Server API:
+            # we request one more than wanted to see if there are more pages to come
+            probing_limit = limit + 1
+        else:
+            # Federation API:
+            # we request a handful more in case any get filtered out by ACLs
+            # as a best easy effort attempt to return the full number of entries
+            # specified by `limit`.
+            probing_limit = limit + 10
 
         results = await self.store.get_largest_public_rooms(
             network_tuple,

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -103,9 +103,10 @@ class RoomListHandler:
             network_tuple,
         )
 
-        if search_filter:
+        if search_filter and from_federation_origin is not None:
             # We explicitly don't bother caching searches or requests for
             # appservice specific lists.
+            # We also don't bother caching requests from federated homeservers.
             logger.info("Bypassing cache as search request.")
 
             return await self._get_public_room_list(

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -284,14 +284,13 @@ class RoomListHandler:
             else:
                 # If we didn't find any results this time,
                 # we don't have an actual room ID to put in the token.
-                # So instead we re-use the room ID from last time but make the
-                # bound inclusive, by tacking on a 0x01 byte at the end
-                # (s+"\x00" is the first string following s, but we can't use "\x00"
-                # in Postgres, so use "\x01" anyway.)
-                assert batch_token is not None
+                # But since `first_considered_room` is None, we know that we have
+                # reached the end of the results.
+                # So we can use a token of (0, empty room ID) to paginate from the end
+                # next time.
                 response["prev_batch"] = RoomListNextBatch(
-                    last_joined_members=batch_token.last_joined_members,
-                    last_room_id=batch_token.last_room_id + "\x01",
+                    last_joined_members=0,
+                    last_room_id="",
                     direction_is_forward=False,
                 ).to_token()
 

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -103,7 +103,7 @@ class RoomListHandler:
             network_tuple,
         )
 
-        if search_filter and from_federation_origin is not None:
+        if search_filter or from_federation_origin is not None:
             # We explicitly don't bother caching searches or requests for
             # appservice specific lists.
             # We also don't bother caching requests from federated homeservers.

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -116,7 +116,7 @@ class RoomListHandler:
             # We explicitly don't bother caching searches or requests for
             # appservice specific lists.
             # We also don't bother caching requests from federated homeservers.
-            logger.info("Bypassing cache as search request.")
+            logger.debug("Bypassing cache as search or federation request.")
 
             return await self._get_public_room_list(
                 capped_limit,

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -137,7 +137,7 @@ class RoomListHandler:
 
     async def _get_public_room_list(
         self,
-        limit: Optional[int] = None,
+        limit: int,
         since_token: Optional[str] = None,
         search_filter: Optional[dict] = None,
         network_tuple: Optional[ThirdPartyInstanceID] = EMPTY_THIRD_PARTY_ID,
@@ -176,7 +176,7 @@ class RoomListHandler:
             has_batch_token = False
 
         # we request one more than wanted to see if there are more pages to come
-        probing_limit = limit + 1 if limit is not None else None
+        probing_limit = limit + 1
 
         results = await self.store.get_largest_public_rooms(
             network_tuple,
@@ -208,16 +208,14 @@ class RoomListHandler:
 
         response: JsonDict = {}
         num_results = len(results)
-        if limit is not None:
-            more_to_come = num_results == probing_limit
 
-            # Depending on direction we trim either the front or back.
-            if forwards:
-                results = results[:limit]
-            else:
-                results = results[-limit:]
+        more_to_come = num_results == probing_limit
+
+        # Depending on direction we trim either the front or back.
+        if forwards:
+            results = results[:limit]
         else:
-            more_to_come = False
+            results = results[-limit:]
 
         if num_results > 0:
             final_entry = results[-1]

--- a/tests/handlers/test_room_list.py
+++ b/tests/handlers/test_room_list.py
@@ -1,0 +1,88 @@
+from http import HTTPStatus
+from typing import Optional, Set
+
+from synapse.rest import admin
+from synapse.rest.client import directory, login, room
+from synapse.types import JsonDict
+
+from tests import unittest
+
+
+class RoomListHandlerTestCase(unittest.HomeserverTestCase):
+    servlets = [
+        admin.register_servlets,
+        login.register_servlets,
+        room.register_servlets,
+        directory.register_servlets,
+    ]
+
+    def _create_published_room(
+        self, tok: str, extra_content: Optional[JsonDict] = None
+    ) -> str:
+        room_id = self.helper.create_room_as(tok=tok, extra_content=extra_content)
+        channel = self.make_request(
+            "PUT",
+            f"/_matrix/client/v3/directory/list/room/{room_id}?access_token={tok}",
+            content={
+                "visibility": "public",
+            },
+        )
+        assert channel.code == HTTPStatus.OK, f"couldn't publish room: {channel.result}"
+        return room_id
+
+    def test_acls_applied_to_room_directory_results(self) -> None:
+        """
+        Creates 3 rooms. Room 2 has an ACL that only permits the homeservers
+        `test` and `test2` to access it.
+
+        We then simulate `test2` and `test3` requesting the room directory and assert
+        that `test3` does not see room 2, but `test2` sees all 3.
+        """
+        self.register_user("u1", "p1")
+        u1tok = self.login("u1", "p1")
+        room1 = self._create_published_room(u1tok)
+
+        room2 = self._create_published_room(
+            u1tok,
+            extra_content={
+                "initial_state": [
+                    {
+                        "type": "m.room.server_acl",
+                        "content": {
+                            "allow": ["test", "test2"],
+                        },
+                    }
+                ]
+            },
+        )
+
+        room3 = self._create_published_room(u1tok)
+
+        room_list = self.get_success(
+            self.hs.get_room_list_handler().get_local_public_room_list(
+                limit=50, from_federation_origin="test2"
+            )
+        )
+        room_ids_in_test2_list: Set[str] = {
+            entry["room_id"] for entry in room_list["chunk"]
+        }
+
+        room_list = self.get_success(
+            self.hs.get_room_list_handler().get_local_public_room_list(
+                limit=50, from_federation_origin="test3"
+            )
+        )
+        room_ids_in_test3_list: Set[str] = {
+            entry["room_id"] for entry in room_list["chunk"]
+        }
+
+        self.assertEqual(
+            room_ids_in_test2_list,
+            {room1, room2, room3},
+            "test2 should be able to see all 3 rooms",
+        )
+        self.assertEqual(
+            room_ids_in_test3_list,
+            {room1, room3},
+            "test3 should be able to see only 2 rooms",
+        )


### PR DESCRIPTION
The idea here being that the directory server shouldn't advertise rooms to a requesting server is the requesting server would not be allowed to join or participate in the room.

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Pass `from_federation_origin` down into room list retrieval code 

</li>
<li>

Don't cache /publicRooms response for inbound federated requests 

</li>
<li>

fixup! Don't cache /publicRooms response for inbound federated requests 

</li>
<li>

Cap the number of /publicRooms entries to 100 

</li>
<li>

Simplify code now that you can't request unlimited rooms 

</li>
<li>

Filter out rooms from federated requests that don't have the correct ACL 

</li>
<li>

Request a handful more when filtering ACLs so that we can try to avoid shortchanging the requester 

</li>
</ol>
