### PR TITLE
Simplify internal metadata class.

### DIFF
--- a/changelog.d/16762.misc
+++ b/changelog.d/16762.misc
@@ -1,0 +1,1 @@
+Simplify event internal metadata class.

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -42,7 +42,7 @@ from unpaddedbase64 import encode_base64
 
 from synapse.api.constants import RelationTypes
 from synapse.api.room_versions import EventFormatVersions, RoomVersion, RoomVersions
-from synapse.types import JsonDict, RoomStreamToken, StrCollection
+from synapse.types import JsonDict, StrCollection
 from synapse.util.caches import intern_dict
 from synapse.util.frozenutils import freeze
 from synapse.util.stringutils import strtobool
@@ -210,12 +210,6 @@ class _EventInternalMetadata:
 
     device_id: DictProperty[str] = DictProperty("device_id")
     """The device ID of the user who sent this event, if any."""
-
-    # XXX: These are set by StreamWorkerStore._set_before_and_after.
-    # I'm pretty sure that these are never persisted to the database, so shouldn't
-    # be here
-    before: DictProperty[RoomStreamToken] = DictProperty("before")
-    after: DictProperty[RoomStreamToken] = DictProperty("after")
 
     def get_dict(self) -> JsonDict:
         return dict(self._dict)

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -216,7 +216,6 @@ class _EventInternalMetadata:
     # be here
     before: DictProperty[RoomStreamToken] = DictProperty("before")
     after: DictProperty[RoomStreamToken] = DictProperty("after")
-    order: DictProperty[Tuple[int, int]] = DictProperty("order")
 
     def get_dict(self) -> JsonDict:
         return dict(self._dict)

--- a/synapse/handlers/admin.py
+++ b/synapse/handlers/admin.py
@@ -208,7 +208,12 @@ class AdminHandler:
                 if not events:
                     break
 
-                from_key = events[-1].internal_metadata.after
+                last_event = events[-1]
+                assert last_event.internal_metadata.stream_ordering
+                from_key = RoomStreamToken(
+                    stream=last_event.internal_metadata.stream_ordering,
+                    topological=last_event.depth,
+                )
 
                 events = await filter_events_for_client(
                     self._storage_controllers, user_id, events

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1754,7 +1754,6 @@ class RoomEventSource(EventSource[RoomStreamToken, EventBase]):
                 assert last_event.internal_metadata.stream_ordering
                 end_key = RoomStreamToken(
                     stream=last_event.internal_metadata.stream_ordering,
-                    topological=last_event.depth,
                 )
             else:
                 end_key = to_key

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1750,7 +1750,12 @@ class RoomEventSource(EventSource[RoomStreamToken, EventBase]):
                 events[:] = events[:limit]
 
             if events:
-                end_key = events[-1].internal_metadata.after
+                last_event = events[-1]
+                assert last_event.internal_metadata.stream_ordering
+                end_key = RoomStreamToken(
+                    stream=last_event.internal_metadata.stream_ordering,
+                    topological=last_event.depth,
+                )
             else:
                 end_key = to_key
 

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1744,7 +1744,7 @@ class RoomEventSource(EventSource[RoomStreamToken, EventBase]):
 
             # We know stream_ordering must be not None here, as its been
             # persisted, but mypy doesn't know that
-            events.sort(key=lambda e: e.internal_metadata.stream_ordering or 0)
+            events.sort(key=lambda e: cast(int, e.internal_metadata.stream_ordering))
 
             if limit:
                 events[:] = events[:limit]

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1742,7 +1742,9 @@ class RoomEventSource(EventSource[RoomStreamToken, EventBase]):
             events = list(room_events)
             events.extend(e for evs, _ in room_to_events.values() for e in evs)
 
-            events.sort(key=lambda e: e.internal_metadata.order)
+            # We know stream_ordering must be not None here, as its been
+            # persisted, but mypy doesn't know that
+            events.sort(key=lambda e: e.internal_metadata.stream_ordering or 0)
 
             if limit:
                 events[:] = events[:limit]

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -601,7 +601,10 @@ class SyncHandler:
             if not limited or block_all_timeline:
                 prev_batch_token = upto_token
                 if recents:
-                    room_key = recents[0].internal_metadata.before
+                    assert recents[0].internal_metadata.stream_ordering
+                    room_key = RoomStreamToken(
+                        stream=recents[0].internal_metadata.stream_ordering - 1
+                    )
                     prev_batch_token = upto_token.copy_and_replace(
                         StreamKeyType.ROOM, room_key
                     )
@@ -689,7 +692,10 @@ class SyncHandler:
             if len(recents) > timeline_limit:
                 limited = True
                 recents = recents[-timeline_limit:]
-                room_key = recents[0].internal_metadata.before
+                assert recents[0].internal_metadata.stream_ordering
+                room_key = RoomStreamToken(
+                    stream=recents[0].internal_metadata.stream_ordering - 1
+                )
 
             prev_batch_token = upto_token.copy_and_replace(StreamKeyType.ROOM, room_key)
 

--- a/synapse/storage/databases/main/stream.py
+++ b/synapse/storage/databases/main/stream.py
@@ -1117,7 +1117,6 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
             internal = event.internal_metadata
             internal.before = RoomStreamToken(topological=topo, stream=stream - 1)
             internal.after = RoomStreamToken(topological=topo, stream=stream)
-            internal.order = (int(topo) if topo else 0, int(stream))
 
     async def get_events_around(
         self,


### PR DESCRIPTION
We remove these fields as they're just duplicating data the event already stores, and (for reasons :shushing_face:) I'd like to simplify the class to only store simple types.

I'm not entirely convinced that we shouldn't instead add helper methods to the event class to generate stream tokens, but I don't really think that's where they belong either