### PR TITLE
Add recursion_depth to /relations if recursing

### DIFF
--- a/changelog.d/16775.bugfix
+++ b/changelog.d/16775.bugfix
@@ -1,0 +1,1 @@
+Adds the recursion_depth parameter to the response of the /relations endpoint if MSC3981 recursion is being performed.

--- a/synapse/handlers/relations.py
+++ b/synapse/handlers/relations.py
@@ -180,6 +180,10 @@ class RelationsHandler:
                 config=serialize_options,
             ),
         }
+
+        if recurse:
+            return_value["recursion_depth"] = 3
+
         if include_original_event:
             # Do not bundle aggregations when retrieving the original event because
             # we want the content before relations are applied to it.


### PR DESCRIPTION
This is an extra response parameter just added to MSC3981. In the current impl, the recursion depth is always 3, so this just returns a static 3 if the recurse parameter is supplied.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
