### PR TITLE
Add a link to the Request log format page from Logging Sample Config

### DIFF
--- a/changelog.d/16778.doc
+++ b/changelog.d/16778.doc
@@ -1,0 +1,1 @@
+Add a link to the "Request log format" explainer on the "Logging sample config" documentation page.

--- a/docs/usage/configuration/logging_sample_config.md
+++ b/docs/usage/configuration/logging_sample_config.md
@@ -11,6 +11,9 @@ Note that a default logging configuration (shown below) is created automatically
 the homeserver config when following the [installation instructions](../../setup/installation.md).
 It should be named `<SERVERNAME>.log.config` by default.
 
+Hint: If you're looking for a guide on what each of the fields in the "Processed request" log lines mean,
+see [Request log format](../administration/request_log).
+
 ```yaml
 {{#include ../../sample_log_config.yaml}}
 ```

--- a/docs/usage/configuration/logging_sample_config.md
+++ b/docs/usage/configuration/logging_sample_config.md
@@ -12,7 +12,7 @@ the homeserver config when following the [installation instructions](../../setup
 It should be named `<SERVERNAME>.log.config` by default.
 
 Hint: If you're looking for a guide on what each of the fields in the "Processed request" log lines mean,
-see [Request log format](../administration/request_log).
+see [Request log format](../administration/request_log.md).
 
 ```yaml
 {{#include ../../sample_log_config.yaml}}


### PR DESCRIPTION
This PR adds a link to the Request Log Format page from the Logging Sample Config page. I observed someone find one, but not the other, so this is to add a helpful bridge.

At a glance, I think ideally both of these pages would be combined, or made sub-pages of a general "Logging" page. But this is a quick fix for now.