### PR TITLE
Pull less state out if we fail to backfill

### DIFF
--- a/changelog.d/16788.misc
+++ b/changelog.d/16788.misc
@@ -1,0 +1,1 @@
+Pull less state out of the DB when we retry fetching old events during backfill.

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1307,7 +1307,7 @@ class FederationEventHandler:
                 destination=destination, room_id=room_id, event_ids=missing_event_ids
             )
 
-        # We now need to fill out the state map, which involves loading the local state.he
+        # We now need to fill out the state map, which involves loading the local state.
         # type and state key for each event ID in the state.
         state_map = {}
 

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1141,11 +1141,6 @@ class FederationEventHandler:
             partial_state_flags = await self._store.get_partial_state_events(seen)
             partial_state = any(partial_state_flags.values())
 
-            # Get the state of the events we know about
-            ours = await self._state_storage_controller.get_state_groups_ids(
-                room_id, seen, await_full_state=False
-            )
-
             # state_maps is a list of mappings from (type, state_key) to event_id
             state_maps: List[StateMap[str]] = []
 

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1302,7 +1302,7 @@ class FederationEventHandler:
                 destination=destination, room_id=room_id, event_ids=missing_event_ids
             )
 
-        # We now need to fill out the state map, which involves loading the local state.
+        # We now need to fill out the state map, which involves fetching the
         # type and state key for each event ID in the state.
         state_map = {}
 


### PR DESCRIPTION
Sometimes we fail to fetch events during backfill due to missing state, and we often end up querying the same bad events periodically (as people backpaginate). In such cases its likely we will continue to fail to get the state, and therefore we should try *before* loading the state that we have from the DB (as otherwise it's wasted DB and memory).