### PR TITLE
Refactor the `configure_workers_and_start.py` script used internally by Complement.

### DIFF
--- a/changelog.d/16803.misc
+++ b/changelog.d/16803.misc
@@ -1,0 +1,1 @@
+Refactor the `configure_workers_and_start.py` script used internally by Complement.

--- a/docker/conf-workers/synapse.supervisord.conf.j2
+++ b/docker/conf-workers/synapse.supervisord.conf.j2
@@ -6,7 +6,7 @@ command=/usr/local/bin/python -m synapse.app.complement_fork_starter
   --config-path="{{ main_config_path }}"
   --config-path=/conf/workers/shared.yaml
   {%- for worker in workers %}
-    -- {{ worker.app }}
+    -- synapse.app.generic_worker
     --config-path="{{ main_config_path }}"
     --config-path=/conf/workers/shared.yaml
     --config-path=/conf/workers/{{ worker.name }}.yaml
@@ -36,7 +36,7 @@ exitcodes=0
 
   {% for worker in workers %}
 [program:synapse_{{ worker.name }}]
-command=/usr/local/bin/prefix-log /usr/local/bin/python -m {{ worker.app }}
+command=/usr/local/bin/prefix-log /usr/local/bin/python -m synapse.app.generic_worker
   --config-path="{{ main_config_path }}"
   --config-path=/conf/workers/shared.yaml
   --config-path=/conf/workers/{{ worker.name }}.yaml

--- a/docker/conf-workers/worker.yaml.j2
+++ b/docker/conf-workers/worker.yaml.j2
@@ -3,7 +3,7 @@
 # Values will be change depending on whichever workers are selected when
 # running that image.
 
-worker_app: "{{ app }}"
+worker_app: "synapse.app.generic_worker"
 worker_name: "{{ name }}"
 
 worker_listeners:

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -98,12 +98,7 @@ class WorkerTemplate:
 
 
 WORKERS_CONFIG: Dict[str, WorkerTemplate] = {
-    "pusher": WorkerTemplate(
-        listener_resources=[],
-        endpoint_patterns=[],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
-    ),
+    "pusher": WorkerTemplate(),
     "user_dir": WorkerTemplate(
         listener_resources=["client"],
         endpoint_patterns=[
@@ -112,7 +107,6 @@ WORKERS_CONFIG: Dict[str, WorkerTemplate] = {
         shared_extra_conf=lambda worker_name: {
             "update_user_directory_from_worker": worker_name
         },
-        worker_extra_conf="",
     ),
     "media_repository": WorkerTemplate(
         listener_resources=["media"],
@@ -132,19 +126,11 @@ WORKERS_CONFIG: Dict[str, WorkerTemplate] = {
         worker_extra_conf="enable_media_repo: true",
     ),
     "appservice": WorkerTemplate(
-        listener_resources=[],
-        endpoint_patterns=[],
         shared_extra_conf=lambda worker_name: {
             "notify_appservices_from_worker": worker_name
         },
-        worker_extra_conf="",
     ),
-    "federation_sender": WorkerTemplate(
-        listener_resources=[],
-        endpoint_patterns=[],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
-    ),
+    "federation_sender": WorkerTemplate(),
     "synchrotron": WorkerTemplate(
         listener_resources=["client"],
         endpoint_patterns=[
@@ -153,8 +139,6 @@ WORKERS_CONFIG: Dict[str, WorkerTemplate] = {
             "^/_matrix/client/(api/v1|r0|v3)/initialSync$",
             "^/_matrix/client/(api/v1|r0|v3)/rooms/[^/]+/initialSync$",
         ],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
     ),
     "client_reader": WorkerTemplate(
         listener_resources=["client"],
@@ -187,8 +171,6 @@ WORKERS_CONFIG: Dict[str, WorkerTemplate] = {
             "^/_matrix/client/(r0|v3|unstable)/capabilities$",
             "^/_matrix/client/(r0|v3|unstable)/notifications$",
         ],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
     ),
     "federation_reader": WorkerTemplate(
         listener_resources=["federation"],
@@ -213,28 +195,18 @@ WORKERS_CONFIG: Dict[str, WorkerTemplate] = {
             "^/_matrix/federation/(v1|v2)/get_groups_publicised$",
             "^/_matrix/key/v2/query",
         ],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
     ),
     "federation_inbound": WorkerTemplate(
         listener_resources=["federation"],
         endpoint_patterns=["/_matrix/federation/(v1|v2)/send/"],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
     ),
     "event_persister": WorkerTemplate(
         listener_resources=["replication"],
-        endpoint_patterns=[],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
     ),
     "background_worker": WorkerTemplate(
-        listener_resources=[],
-        endpoint_patterns=[],
         # This worker cannot be sharded. Therefore, there should only ever be one
         # background worker. This is enforced for the safety of your database.
         shared_extra_conf=lambda worker_name: {"run_background_tasks_on": worker_name},
-        worker_extra_conf="",
     ),
     "event_creator": WorkerTemplate(
         listener_resources=["client"],
@@ -246,14 +218,10 @@ WORKERS_CONFIG: Dict[str, WorkerTemplate] = {
             "^/_matrix/client/(api/v1|r0|v3|unstable)/knock/",
             "^/_matrix/client/(api/v1|r0|v3|unstable)/profile/",
         ],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
     ),
     "frontend_proxy": WorkerTemplate(
         listener_resources=["client", "replication"],
         endpoint_patterns=["^/_matrix/client/(api/v1|r0|v3|unstable)/keys/upload"],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
     ),
     "account_data": WorkerTemplate(
         listener_resources=["client", "replication"],
@@ -261,14 +229,10 @@ WORKERS_CONFIG: Dict[str, WorkerTemplate] = {
             "^/_matrix/client/(r0|v3|unstable)/.*/tags",
             "^/_matrix/client/(r0|v3|unstable)/.*/account_data",
         ],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
     ),
     "presence": WorkerTemplate(
         listener_resources=["client", "replication"],
         endpoint_patterns=["^/_matrix/client/(api/v1|r0|v3|unstable)/presence/"],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
     ),
     "receipts": WorkerTemplate(
         listener_resources=["client", "replication"],
@@ -276,20 +240,14 @@ WORKERS_CONFIG: Dict[str, WorkerTemplate] = {
             "^/_matrix/client/(r0|v3|unstable)/rooms/.*/receipt",
             "^/_matrix/client/(r0|v3|unstable)/rooms/.*/read_markers",
         ],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
     ),
     "to_device": WorkerTemplate(
         listener_resources=["client", "replication"],
         endpoint_patterns=["^/_matrix/client/(r0|v3|unstable)/sendToDevice/"],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
     ),
     "typing": WorkerTemplate(
         listener_resources=["client", "replication"],
         endpoint_patterns=["^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/typing"],
-        shared_extra_conf=lambda _worker_name: {},
-        worker_extra_conf="",
     ),
 }
 

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -358,7 +358,8 @@ def merge_into(dest: Any, new: Any) -> None:
 
 def merged(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
     """
-    Merges `b` into `a` and returns `a`.
+    Merges `b` into `a` and returns `a`. Here because we can't use `merge_into`
+    in a lamba conveniently.
     """
     merge_into(a, b)
     return a

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -81,6 +81,10 @@ MAIN_PROCESS_REPLICATION_PORT = 9093
 MAIN_PROCESS_UNIX_SOCKET_PUBLIC_PATH = "/run/main_public.sock"
 MAIN_PROCESS_UNIX_SOCKET_PRIVATE_PATH = "/run/main_private.sock"
 
+# We place a file at this path to indicate that the script has already been
+# run and should not be run again.
+MARKER_FILE_PATH = "/conf/workers_have_been_configured"
+
 
 @dataclass
 class WorkerTemplate:
@@ -980,8 +984,8 @@ def main(args: List[str], environ: MutableMapping[str, str]) -> None:
         log("Base homeserver config exists—not regenerating")
     # This script may be run multiple times (mostly by Complement, see note at top of
     # file). Don't re-configure workers in this instance.
-    mark_filepath = "/conf/workers_have_been_configured"
-    if not os.path.exists(mark_filepath):
+
+    if not os.path.exists(MARKER_FILE_PATH):
         # Collect and validate worker_type requests
         # Read the desired worker configuration from the environment
         worker_types_env = environ.get("SYNAPSE_WORKER_TYPES", "").strip()
@@ -1000,7 +1004,7 @@ def main(args: List[str], environ: MutableMapping[str, str]) -> None:
         generate_worker_files(environ, config_path, data_dir, requested_worker_types)
 
         # Mark workers as being configured
-        with open(mark_filepath, "w") as f:
+        with open(MARKER_FILE_PATH, "w") as f:
             f.write("")
     else:
         log("Worker config exists—not regenerating")

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -53,6 +53,7 @@ import platform
 import re
 import subprocess
 import sys
+from argparse import ArgumentParser
 from collections import defaultdict
 from dataclasses import dataclass, field
 from itertools import chain
@@ -968,6 +969,14 @@ def generate_worker_log_config(
 
 
 def main(args: List[str], environ: MutableMapping[str, str]) -> None:
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--generate-only",
+        action="store_true",
+        help="Only generate configuration; don't run Synapse.",
+    )
+    opts = parser.parse_args(args)
+
     config_dir = environ.get("SYNAPSE_CONFIG_DIR", "/data")
     config_path = environ.get("SYNAPSE_CONFIG_PATH", config_dir + "/homeserver.yaml")
     data_dir = environ.get("SYNAPSE_DATA_DIR", "/data")
@@ -1009,6 +1018,10 @@ def main(args: List[str], environ: MutableMapping[str, str]) -> None:
     else:
         log("Worker config exists—not regenerating")
 
+    if opts.generate_only:
+        log("--generate-only: won't run Synapse")
+        return
+
     # Lifted right out of start.py
     jemallocpath = "/usr/lib/%s-linux-gnu/libjemalloc.so.2" % (platform.machine(),)
 
@@ -1031,4 +1044,4 @@ def main(args: List[str], environ: MutableMapping[str, str]) -> None:
 
 
 if __name__ == "__main__":
-    main(sys.argv, os.environ)
+    main(sys.argv[1:], os.environ)

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -89,6 +89,14 @@ MARKER_FILE_PATH = "/conf/workers_have_been_configured"
 
 @dataclass
 class WorkerTemplate:
+    """
+    A definition of individual settings for a specific worker type.
+    A worker name can be fed into the template in order to generate a config.
+
+    These worker templates can be merged with `merge_worker_template_configs`
+    in order for a single worker to be made from multiple templates.
+    """
+
     listener_resources: Set[str] = field(default_factory=set)
     endpoint_patterns: Set[str] = field(default_factory=set)
     # (worker_name) -> {config}

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -82,21 +82,21 @@ MAIN_PROCESS_UNIX_SOCKET_PUBLIC_PATH = "/run/main_public.sock"
 MAIN_PROCESS_UNIX_SOCKET_PRIVATE_PATH = "/run/main_private.sock"
 
 
+@dataclass
+class WorkerTemplate:
+    listener_resources: Set[str] = field(default_factory=set)
+    endpoint_patterns: Set[str] = field(default_factory=set)
+    # (worker_name) -> {config}
+    shared_extra_conf: Callable[[str], Dict[str, Any]] = lambda _worker_name: {}
+    worker_extra_conf: str = ""
+
+
 # Workers with exposed endpoints needs either "client", "federation", or "media" listener_resources
 # Watching /_matrix/client needs a "client" listener
 # Watching /_matrix/federation needs a "federation" listener
 # Watching /_matrix/media and related needs a "media" listener
 # Stream Writers require "client" and "replication" listeners because they
 #   have to attach by instance_map to the master process and have client endpoints.
-@dataclass
-class WorkerTemplate:
-    listener_resources: Set[str] = field(default_factory=set)
-    endpoint_patterns: Set[str] = field(default_factory=set)
-    # (worker_name) -> {}
-    shared_extra_conf: Callable[[str], Dict[str, Any]] = lambda _worker_name: {}
-    worker_extra_conf: str = ""
-
-
 WORKERS_CONFIG: Dict[str, WorkerTemplate] = {
     "pusher": WorkerTemplate(),
     "user_dir": WorkerTemplate(

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -784,10 +784,9 @@ def generate_worker_files(
             {"name": worker_name, "port": str(worker_port), "config_path": config_path}
         )
 
-        # Update the shared config with any worker_type specific options. The first of a
-        # given worker_type needs to stay assigned and not be replaced.
-        worker_config["shared_extra_conf"].update(shared_config)
-        shared_config = worker_config["shared_extra_conf"]
+        # Update the shared config with any options needed to enable this worker.
+        merge_into(shared_config, worker_config["shared_extra_conf"])
+
         if using_unix_sockets:
             healthcheck_urls.append(
                 f"--unix-socket /run/worker.{worker_port} http://localhost/health"

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -90,14 +90,12 @@ WORKER_PLACEHOLDER_NAME = "placeholder_name"
 #   have to attach by instance_map to the master process and have client endpoints.
 WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
     "pusher": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": [],
         "endpoint_patterns": [],
         "shared_extra_conf": {},
         "worker_extra_conf": "",
     },
     "user_dir": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["client"],
         "endpoint_patterns": [
             "^/_matrix/client/(api/v1|r0|v3|unstable)/user_directory/search$"
@@ -108,7 +106,6 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
         "worker_extra_conf": "",
     },
     "media_repository": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["media"],
         "endpoint_patterns": [
             "^/_matrix/media/",
@@ -126,7 +123,6 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
         "worker_extra_conf": "enable_media_repo: true",
     },
     "appservice": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": [],
         "endpoint_patterns": [],
         "shared_extra_conf": {
@@ -135,14 +131,12 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
         "worker_extra_conf": "",
     },
     "federation_sender": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": [],
         "endpoint_patterns": [],
         "shared_extra_conf": {},
         "worker_extra_conf": "",
     },
     "synchrotron": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["client"],
         "endpoint_patterns": [
             "^/_matrix/client/(v2_alpha|r0|v3)/sync$",
@@ -154,7 +148,6 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
         "worker_extra_conf": "",
     },
     "client_reader": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["client"],
         "endpoint_patterns": [
             "^/_matrix/client/(api/v1|r0|v3|unstable)/publicRooms$",
@@ -189,7 +182,6 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
         "worker_extra_conf": "",
     },
     "federation_reader": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["federation"],
         "endpoint_patterns": [
             "^/_matrix/federation/(v1|v2)/event/",
@@ -216,21 +208,18 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
         "worker_extra_conf": "",
     },
     "federation_inbound": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["federation"],
         "endpoint_patterns": ["/_matrix/federation/(v1|v2)/send/"],
         "shared_extra_conf": {},
         "worker_extra_conf": "",
     },
     "event_persister": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["replication"],
         "endpoint_patterns": [],
         "shared_extra_conf": {},
         "worker_extra_conf": "",
     },
     "background_worker": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": [],
         "endpoint_patterns": [],
         # This worker cannot be sharded. Therefore, there should only ever be one
@@ -239,7 +228,6 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
         "worker_extra_conf": "",
     },
     "event_creator": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["client"],
         "endpoint_patterns": [
             "^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/redact",
@@ -253,14 +241,12 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
         "worker_extra_conf": "",
     },
     "frontend_proxy": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["client", "replication"],
         "endpoint_patterns": ["^/_matrix/client/(api/v1|r0|v3|unstable)/keys/upload"],
         "shared_extra_conf": {},
         "worker_extra_conf": "",
     },
     "account_data": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["client", "replication"],
         "endpoint_patterns": [
             "^/_matrix/client/(r0|v3|unstable)/.*/tags",
@@ -270,14 +256,12 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
         "worker_extra_conf": "",
     },
     "presence": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["client", "replication"],
         "endpoint_patterns": ["^/_matrix/client/(api/v1|r0|v3|unstable)/presence/"],
         "shared_extra_conf": {},
         "worker_extra_conf": "",
     },
     "receipts": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["client", "replication"],
         "endpoint_patterns": [
             "^/_matrix/client/(r0|v3|unstable)/rooms/.*/receipt",
@@ -287,14 +271,12 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
         "worker_extra_conf": "",
     },
     "to_device": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["client", "replication"],
         "endpoint_patterns": ["^/_matrix/client/(r0|v3|unstable)/sendToDevice/"],
         "shared_extra_conf": {},
         "worker_extra_conf": "",
     },
     "typing": {
-        "app": "synapse.app.generic_worker",
         "listener_resources": ["client", "replication"],
         "endpoint_patterns": [
             "^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/typing"

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -283,6 +283,31 @@ def flush_buffers() -> None:
     sys.stderr.flush()
 
 
+def merge_into(dest: Any, new: Any) -> None:
+    """
+    Merges `new` into `dest` with the following rules:
+
+    - dicts: values with the same key will be merged recursively
+    - lists: `new` will be appended to `dest`
+    - primitives: they will be checked for equality and inequality will result
+        in a ValueError
+
+    It is an error for `dest` and `new` to be of different types.
+    """
+    if isinstance(dest, dict) and isinstance(new, dict):
+        for k, v in new.items():
+            if k in dest:
+                merge_into(dest[k], v)
+            else:
+                dest[k] = v
+    elif isinstance(dest, list) and isinstance(new, list):
+        dest.extend(new)
+    elif type(dest) != type(new):
+        raise TypeError(f"Cannot merge {type(dest).__name__} and {type(new).__name__}")
+    elif dest != new:
+        raise ValueError(f"Cannot merge primitive values: {dest!r} != {new!r}")
+
+
 def convert(src: str, dst: str, **template_vars: object) -> None:
     """Generate a file from a template
 

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -450,21 +450,22 @@ def merge_worker_template_configs(
     )
 
 
-def insert_worker_name_for_worker_config(
-    existing_template: WorkerTemplate, worker_name: str
+def instantiate_worker_template(
+    template: WorkerTemplate, worker_name: str
 ) -> Dict[str, Any]:
-    """Insert a given worker name into the worker's configuration dict.
+    """Given a worker template, instantiate it into a worker configuration
+    (which is currently represented as a dictionary).
 
     Args:
-        existing_template: The WorkerTemplate that is imported into shared_config.
-        worker_name: The name of the worker to insert.
-    Returns: Copy of the dict with newly inserted worker name
+        template: The WorkerTemplate to template
+        worker_name: The name of the worker to use.
+    Returns: worker configuration dictionary
     """
-    dict_to_edit = dataclasses.asdict(existing_template)
-    dict_to_edit["shared_extra_conf"] = existing_template.shared_extra_conf(worker_name)
-    dict_to_edit["endpoint_patterns"] = sorted(existing_template.endpoint_patterns)
-    dict_to_edit["listener_resources"] = sorted(existing_template.listener_resources)
-    return dict_to_edit
+    worker_config_dict = dataclasses.asdict(template)
+    worker_config_dict["shared_extra_conf"] = template.shared_extra_conf(worker_name)
+    worker_config_dict["endpoint_patterns"] = sorted(template.endpoint_patterns)
+    worker_config_dict["listener_resources"] = sorted(template.listener_resources)
+    return worker_config_dict
 
 
 def apply_requested_multiplier_for_worker(worker_types: List[str]) -> List[str]:
@@ -781,7 +782,7 @@ def generate_worker_files(
             )
 
         # Replace placeholder names in the config template with the actual worker name.
-        worker_config: Dict[str, Any] = insert_worker_name_for_worker_config(
+        worker_config: Dict[str, Any] = instantiate_worker_template(
             worker_template, worker_name
         )
 


### PR DESCRIPTION
Revival of https://github.com/matrix-org/synapse/pull/16650

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Remove obsolete `"app"` from worker templates 

</li>
<li>

Convert worker templates into dataclass 

</li>
<li>

Use a lambda for the worker name rather than search and replace later 

</li>
<li>

Collapse WORKERS_CONFIG by removing entries with defaults 

</li>
<li>

Convert listener_resources and endpoint_patterns to Set[str] 

</li>
<li>

Tweak comments 

</li>
<li>

Add `merge_into` 

</li>
<li>

Remove special logic for adding stream_writers: just make it part of the extra config template 

</li>
<li>

Rename function to add_worker_to_instance_map given reduction of scope 

</li>
<li>

Add `sharding_allowed` to the WorkerTemplate rather than having a separate function for that 

</li>
<li>

Use `merge_into` when adding workers to the shared config 

</li>
<li>

Promote mark_filepath to constant 

</li>
<li>

Add a --generate-only option 

</li>
<li>

Docstring on WorkerTemplate 

</li>
<li>

Fix comment and mutation bug on merge_worker_template_configs 

</li>
<li>

Update comment on `merged` 

</li>
<li>

Tweak `instantiate_worker_template`, both in name, description and variable names 

</li>
</ol>
