### PR TITLE
Correctly handle OIDC config with no `client_secret` set

### DIFF
--- a/changelog.d/16806.misc
+++ b/changelog.d/16806.misc
@@ -1,0 +1,1 @@
+Reject OIDC config when `client_secret` isn't specified, but the auth method requires one.

--- a/synapse/config/oidc.py
+++ b/synapse/config/oidc.py
@@ -299,6 +299,19 @@ def _parse_oidc_config_dict(
                 config_path + ("client_secret",),
             )
 
+    # If no client secret is specified then the auth method must be None
+    client_auth_method = oidc_config.get("client_auth_method")
+    if client_secret is None and client_secret_jwt_key is None:
+        if client_auth_method is None:
+            client_auth_method = "none"
+        elif client_auth_method != "none":
+            raise ConfigError(
+                "No 'client_secret' is set in OIDC config, and 'client_auth_method' is not set to 'none'"
+            )
+
+    if client_auth_method is None:
+        client_auth_method = "client_secret_basic"
+
     return OidcProviderConfig(
         idp_id=idp_id,
         idp_name=oidc_config.get("idp_name", "OIDC"),
@@ -309,7 +322,7 @@ def _parse_oidc_config_dict(
         client_id=oidc_config["client_id"],
         client_secret=client_secret,
         client_secret_jwt_key=client_secret_jwt_key,
-        client_auth_method=oidc_config.get("client_auth_method", "client_secret_basic"),
+        client_auth_method=client_auth_method,
         pkce_method=oidc_config.get("pkce_method", "auto"),
         scopes=oidc_config.get("scopes", ["openid"]),
         authorization_endpoint=oidc_config.get("authorization_endpoint"),


### PR DESCRIPTION
In previous versions of authlib using `client_secret_basic` without a `client_secret` would result in an invalid auth header.  Since authlib 1.3 it throws an exception.

The configuration may be accepted in by very lax servers, so we don't want to deny it outright. Instead, let's default the `client_auth_method` to `none`, which does the right thing. If the config specifies `client_auth_method` and no `client_secret` then that is going to be bogus and we should reject it