### PR TITLE
Fix release announcements docker link

### DIFF
--- a/changelog.d/16808.misc
+++ b/changelog.d/16808.misc
@@ -1,0 +1,1 @@
+Fix release announcements docker link.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -659,7 +659,7 @@ def _announce() -> None:
 Hi everyone. Synapse {current_version} has just been released.
 
 [notes](https://github.com/element-hq/synapse/releases/tag/{tag_name}) | \
-[docker](https://hub.docker.com/r/vectorim/synapse/tags?name={tag_name}) | \
+[docker](https://hub.docker.com/r/matrixdotorg/synapse/tags?name={tag_name}) | \
 [debs](https://packages.matrix.org/debian/) | \
 [pypi](https://pypi.org/project/matrix-synapse/{current_version}/)"""
     )


### PR DESCRIPTION
We still publish to the old place.