### PR TITLE
listen http2 deprecated nginx (updating documentation)

### DIFF
--- a/changelog.d/16831.doc
+++ b/changelog.d/16831.doc
@@ -1,0 +1,1 @@
+NGINX listen http2 deprecation in documentation template for reverse proxy

--- a/changelog.d/16831.doc
+++ b/changelog.d/16831.doc
@@ -1,1 +1,1 @@
-NGINX listen http2 deprecation in documentation template for reverse proxy
+NGINX listen http2 deprecation in documentation template for reverse proxy.

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -58,12 +58,12 @@ reverse proxy is using.
 
 ```nginx
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
 
     # For the federation port
-    listen 8448 ssl http2 default_server;
-    listen [::]:8448 ssl http2 default_server;
+    listen 8448 ssl default_server;
+    listen [::]:8448 ssl default_server;
 
     server_name matrix.example.com;
 


### PR DESCRIPTION
# Listen HTTP2 deprecated since nginx 1.25.1

More info [here](https://www.nginx.com/blog/nginx-plus-r30-released/).

Nginx threw error's at me when I used all the options of the doc