### PR TITLE
Speed up e2e device keys queries for bot accounts

### DIFF
--- a/changelog.d/16841.misc
+++ b/changelog.d/16841.misc
@@ -1,0 +1,1 @@
+Speed up e2e device keys queries for bot accounts.


### PR DESCRIPTION
This helps with bot accounts with lots of non-e2e devices.

The change is basically to change the order of the join for the case of using `INNER JOIN`