### PR TITLE
Accept unprefixed form of MSC3981 recurse parameter

### DIFF
--- a/changelog.d/16842.misc
+++ b/changelog.d/16842.misc
@@ -1,0 +1,1 @@
+Accept the unprefixed form on the recurse parameter on the /relations API.

--- a/changelog.d/16842.misc
+++ b/changelog.d/16842.misc
@@ -1,1 +1,1 @@
-Accept the unprefixed form on the recurse parameter on the /relations API.
+Add support for stabilised [MSC3981](https://github.com/matrix-org/matrix-spec-proposals/pull/3981) that adds a `recurse` parameter on the `/relations` API.

--- a/synapse/rest/client/relations.py
+++ b/synapse/rest/client/relations.py
@@ -71,7 +71,7 @@ class RelationPaginationServlet(RestServlet):
             self._store, request, default_limit=5, default_dir=Direction.BACKWARDS
         )
         if self._support_recurse:
-            recurse = parse_boolean(
+            recurse = parse_boolean(request, "recurse", default=False) or parse_boolean(
                 request, "org.matrix.msc3981.recurse", default=False
             )
         else:


### PR DESCRIPTION
Now that the MSC3981 has passed FCP

https://github.com/matrix-org/matrix-js-sdk/pull/4023 marks the API as stable in 1.10 so js-sdk will start sending it unprefixed when we advertise 1.10 support.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
