### PR TITLE
Downgrade the `download-artifact` and `upload-artifact` actions to v3 due to breaking changes.

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -92,7 +92,7 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Upload debs as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3 # Don't upgrade to v4; broken: https://github.com/actions/upload-artifact#breaking-changes
         with:
           name: debs
           path: debs/*
@@ -156,7 +156,7 @@ jobs:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
           CIBW_ENVIRONMENT_PASS_LINUX: CARGO_NET_GIT_FETCH_WITH_CLI
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3 # Don't upgrade to v4; broken: https://github.com/actions/upload-artifact#breaking-changes
         with:
           name: Wheel
           path: ./wheelhouse/*.whl
@@ -177,7 +177,7 @@ jobs:
       - name: Build sdist
         run: python -m build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3 # Don't upgrade to v4; broken: https://github.com/actions/upload-artifact#breaking-changes
         with:
           name: Sdist
           path: dist/*.tar.gz
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3 # Don't upgrade to v4, it should match upload-artifact
       - name: Build a tarball for the debs
         run: tar -cvJf debs.tar.xz debs
       - name: Attach to release

--- a/changelog.d/16847.misc
+++ b/changelog.d/16847.misc
@@ -1,0 +1,1 @@
+Downgrade the `download-artifact` and `upload-artifact` actions to v3 due to breaking changes.


### PR DESCRIPTION
Partially reverts #16796

This is causing errors of the form:

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

for the debs and wheels stages.


There were breaking changes that weren't included in the dependabot changelog (:/): https://github.com/actions/upload-artifact#breaking-changes


<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `release-v1.100` <!-- git-stack-base-branch:release-v1.100 -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Downgrade the `upload-artifact` and `download-artifact` actions to v3 

</li>
</ol>
