### PR TITLE
Fix broken links on docs

### DIFF
--- a/docs/development/contributing_guide.md
+++ b/docs/development/contributing_guide.md
@@ -329,7 +329,7 @@ This configuration should generally cover your needs.
 - To run with Postgres, supply the `-e POSTGRES=1 -e MULTI_POSTGRES=1` environment flags.
 - To run with Synapse in worker mode, supply the `-e WORKERS=1 -e REDIS=1` environment flags (in addition to the Postgres flags).
 
-For more details about other configurations, see the [Docker-specific documentation in the SyTest repo](https://github.com/vector-im/sytest/blob/develop/docker/README.md).
+For more details about other configurations, see the [Docker-specific documentation in the SyTest repo](https://github.com/matrix-org/sytest/blob/develop/docker/README.md).
 
 
 ## Run the integration tests ([Complement](https://github.com/matrix-org/complement)).

--- a/docs/other/running_synapse_on_single_board_computers.md
+++ b/docs/other/running_synapse_on_single_board_computers.md
@@ -12,7 +12,7 @@ This is the main reason people have a poor matrix experience on resource constra
 
 While synapse does have some performance issues with presence [#3971](https://github.com/matrix-org/synapse/issues/3971), the fundamental problem is that this is an easy feature to implement for a centralised service at nearly no overhead, but federation makes it combinatorial [#8055](https://github.com/matrix-org/synapse/issues/8055). There is also a client-side config option which disables the UI and idle tracking [enable_presence_by_hs_url] to blacklist the largest instances but I didn't notice much difference, so I recommend disabling the feature entirely at the server level as well.
 
-[enable_presence_by_hs_url]: https://github.com/vector-im/element-web/blob/v1.7.8/config.sample.json#L45
+[enable_presence_by_hs_url]: https://github.com/element-hq/element-web/blob/v1.7.8/config.sample.json#L45
 
 ### Joining
 

--- a/docs/setup/turn/coturn.md
+++ b/docs/setup/turn/coturn.md
@@ -136,8 +136,8 @@ This will install and start a systemd service called `coturn`.
     NB: If your TLS certificate was provided by Let's Encrypt, TLS/DTLS will
     not work with any Matrix client that uses Chromium's WebRTC library. This
     currently includes Element Android & iOS; for more details, see their
-    [respective](https://github.com/vector-im/element-android/issues/1533)
-    [issues](https://github.com/vector-im/element-ios/issues/2712) as well as the underlying
+    [respective](https://github.com/element-hq/element-android/issues/1533)
+    [issues](https://github.com/element-hq/element-ios/issues/2712) as well as the underlying
     [WebRTC issue](https://bugs.chromium.org/p/webrtc/issues/detail?id=11710).
     Consider using a ZeroSSL certificate for your TURN server as a working alternative.
 

--- a/docs/setup/turn/eturnal.md
+++ b/docs/setup/turn/eturnal.md
@@ -137,8 +137,8 @@ must be edited:
     NB: If your TLS certificate was provided by Let's Encrypt, TLS/DTLS will
     not work with any Matrix client that uses Chromium's WebRTC library. This
     currently includes Element Android & iOS; for more details, see their
-    [respective](https://github.com/vector-im/element-android/issues/1533)
-    [issues](https://github.com/vector-im/element-ios/issues/2712) as well as the underlying
+    [respective](https://github.com/element-hq/element-android/issues/1533)
+    [issues](https://github.com/element-hq/element-ios/issues/2712) as well as the underlying
     [WebRTC issue](https://bugs.chromium.org/p/webrtc/issues/detail?id=11710).
     Consider using a ZeroSSL certificate for your TURN server as a working alternative.
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -629,7 +629,7 @@ worker application type.
 
 You can designate generic worker to sending push notifications to
 a [push gateway](https://spec.matrix.org/v1.5/push-gateway-api/) such as
-[sygnal](https://github.com/vector-im/sygnal) and email.
+[sygnal](https://github.com/matrix-org/sygnal) and email.
 
 This will stop the main process sending push notifications.
 


### PR DESCRIPTION
Some links seemed to be incorrect (vector-im/sygnal and vector-im/sytest have never been A Thing iirc) so pointed them back to matrix-org/*).