### PR TITLE
Add metric for emails sent

### DIFF
--- a/changelog.d/16881.feature
+++ b/changelog.d/16881.feature
@@ -1,0 +1,1 @@
+A metric was added for emails sent by Synapse, broken down by type: `synapse_emails_sent_total`. Contributed by Remi Rampin.

--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, TypeVar
 import bleach
 import jinja2
 from markupsafe import Markup
+from prometheus_client import Counter
 
 from synapse.api.constants import EventTypes, Membership, RoomTypes
 from synapse.api.errors import StoreError
@@ -55,6 +56,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+emails_sent_counter = Counter(
+    "synapse_emails_sent_total",
+    "Emails sent by type",
+    ["type"],
+)
 
 
 CONTEXT_BEFORE = 1
@@ -130,6 +137,8 @@ class Mailer:
 
         logger.info("Created Mailer for app_name %s" % app_name)
 
+    emails_sent_counter.labels("password_reset")
+
     async def send_password_reset_mail(
         self, email_address: str, token: str, client_secret: str, sid: str
     ) -> None:
@@ -153,12 +162,16 @@ class Mailer:
 
         template_vars: TemplateVars = {"link": link}
 
+        emails_sent_counter.labels("password_reset").inc()
+
         await self.send_email(
             email_address,
             self.email_subjects.password_reset
             % {"server_name": self.hs.config.server.server_name, "app": self.app_name},
             template_vars,
         )
+
+    emails_sent_counter.labels("registration")
 
     async def send_registration_mail(
         self, email_address: str, token: str, client_secret: str, sid: str
@@ -183,12 +196,16 @@ class Mailer:
 
         template_vars: TemplateVars = {"link": link}
 
+        emails_sent_counter.labels("registration").inc()
+
         await self.send_email(
             email_address,
             self.email_subjects.email_validation
             % {"server_name": self.hs.config.server.server_name, "app": self.app_name},
             template_vars,
         )
+
+    emails_sent_counter.labels("add_threepid")
 
     async def send_add_threepid_mail(
         self, email_address: str, token: str, client_secret: str, sid: str
@@ -214,12 +231,16 @@ class Mailer:
 
         template_vars: TemplateVars = {"link": link}
 
+        emails_sent_counter.labels("add_threepid").inc()
+
         await self.send_email(
             email_address,
             self.email_subjects.email_validation
             % {"server_name": self.hs.config.server.server_name, "app": self.app_name},
             template_vars,
         )
+
+    emails_sent_counter.labels("notification")
 
     async def send_notification_mail(
         self,
@@ -314,6 +335,8 @@ class Mailer:
             "rooms": rooms,
             "reason": reason,
         }
+
+        emails_sent_counter.labels("notification").inc()
 
         await self.send_email(
             email_address, summary_text, template_vars, unsubscribe_link


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

### Description

This adds a counter `synapse_emails_sent_total` for emails sent. They are broken down by `type`, which are `password_reset`, `registration`, `add_threepid`, `notification` (matching the methods of `Mailer`).