### PR TITLE
Filter destination rooms in admin API

### DIFF
--- a/changelog.d/16882.bugfix
+++ b/changelog.d/16882.bugfix
@@ -1,0 +1,1 @@
+Fixed returning all rooms in the admin API when asking for federated rooms by destination.

--- a/synapse/storage/databases/main/transactions.py
+++ b/synapse/storage/databases/main/transactions.py
@@ -600,6 +600,7 @@ class TransactionWorkerStore(CacheInvalidationWorkerStore):
                     start=start,
                     limit=limit,
                     retcols=("room_id", "stream_ordering"),
+                    keyvalues={"destination": destination},
                     order_direction=order,
                 ),
             )


### PR DESCRIPTION
No filtering was done, so all rooms were returned when hitting `/_synapse/admin/v1/federation/destinations/<destination>/rooms`

Fixes: https://github.com/element-hq/synapse/issues/16883

Note: feel free to re-create this, or amend it in any way - I'm not willing to provide a legal name for the CLA

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
