### PR TITLE
Add query to update local cache of a remote user's device list to docs

### DIFF
--- a/changelog.d/16892.doc
+++ b/changelog.d/16892.doc
@@ -1,0 +1,1 @@
+Add a query to force a refresh of a remote user's device list to the "Useful SQL for Admins" documentation page.

--- a/docs/usage/administration/useful_sql_for_admins.md
+++ b/docs/usage/administration/useful_sql_for_admins.md
@@ -205,3 +205,12 @@ SELECT user_id, device_id, user_agent, TO_TIMESTAMP(last_seen / 1000) AS "last_s
   FROM devices
   WHERE last_seen < DATE_PART('epoch', NOW() - INTERVAL '3 month') * 1000;
 ```
+
+## Clear the cache of a remote user's device list
+
+Forces the resync of a remote user's device list - if you have somehow cached a bad state, and the remote server is
+will not send out a device list update.
+```sql
+INSERT INTO device_lists_remote_resync
+VALUES ('USER_ID', (EXTRACT(epoch FROM NOW()) * 1000)::BIGINT);
+```


### PR DESCRIPTION
Originally taken from https://github.com/matrix-org/synapse/issues/7418#issuecomment-632166605. Motivated by a recent session of needing to quickly dig this query out to fix a running deployment.