### PR TITLE
Increase batching when fetching auth chains

### DIFF
--- a/changelog.d/16893.bugfix
+++ b/changelog.d/16893.bugfix
@@ -1,0 +1,1 @@
+Fix performance regression when fetching auth chains from the DB. Introduced in v1.100.0.

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -310,7 +310,7 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
         # Add all linked chains reachable from initial set of chains.
         chains_to_fetch = set(event_chains.keys())
         while chains_to_fetch:
-            batch2 = tuple(itertools.islice(chains_to_fetch, 100))
+            batch2 = tuple(itertools.islice(chains_to_fetch, 1000))
             chains_to_fetch.difference_update(batch2)
             clause, args = make_in_list_sql_clause(
                 txn.database_engine, "origin_chain_id", batch2
@@ -593,7 +593,7 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
         # the loop)
         chains_to_fetch = set(seen_chains)
         while chains_to_fetch:
-            batch2 = tuple(itertools.islice(chains_to_fetch, 100))
+            batch2 = tuple(itertools.islice(chains_to_fetch, 1000))
             clause, args = make_in_list_sql_clause(
                 txn.database_engine, "origin_chain_id", batch2
             )


### PR DESCRIPTION
This basically reverts a change that was in https://github.com/element-hq/synapse/pull/16833, where we reduced the batching. 

The smaller batching can cause performance issues on busy servers and databases.