### PR TITLE
Only do one concurrent fetch per server in keyring

### DIFF
--- a/changelog.d/16894.bugfix
+++ b/changelog.d/16894.bugfix
@@ -1,0 +1,1 @@
+Do not send multiple concurrent requests for keys for the same server.

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -844,9 +844,7 @@ class ServerKeyFetcher(BaseV2KeyFetcher):
 
         results = {}
 
-        async def get_keys(key_to_fetch_item: _FetchKeyRequest) -> None:
-            server_name = key_to_fetch_item.server_name
-
+        async def get_keys(server_name: str) -> None:
             try:
                 keys = await self.get_server_verify_keys_v2_direct(server_name)
                 results[server_name] = keys

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -839,6 +839,9 @@ class ServerKeyFetcher(BaseV2KeyFetcher):
             Map from server_name -> key_id -> FetchKeyResult
         """
 
+        # We only need to do one request per server.
+        servers_to_fetch = {k.server_name for k in keys_to_fetch}
+
         results = {}
 
         async def get_keys(key_to_fetch_item: _FetchKeyRequest) -> None:
@@ -852,7 +855,7 @@ class ServerKeyFetcher(BaseV2KeyFetcher):
             except Exception:
                 logger.exception("Error getting keys from %s", server_name)
 
-        await yieldable_gather_results(get_keys, keys_to_fetch)
+        await yieldable_gather_results(get_keys, servers_to_fetch)
         return results
 
     async def get_server_verify_keys_v2_direct(


### PR DESCRIPTION
Otherwise if we've stacked a bunch of requests for the keys of a server, we'll end up sending lots of concurrent requests for its keys, needlessly.