### PR TITLE
Add a config to not send out device list updates for specific users

### DIFF
--- a/changelog.d/16909.misc
+++ b/changelog.d/16909.misc
@@ -1,0 +1,1 @@
+Add experimental config option to not send device list updates for specific users.

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -237,7 +237,7 @@ class RegistrationConfig(Config):
 
         self.inhibit_user_in_use_error = config.get("inhibit_user_in_use_error", False)
 
-        # List of users not to send out device list updates for when they
+        # List of user IDs not to send out device list updates for when they
         # register new devices. This is useful to handle bot accounts.
         #
         # Note: This will still send out device list updates if the device is

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -237,6 +237,14 @@ class RegistrationConfig(Config):
 
         self.inhibit_user_in_use_error = config.get("inhibit_user_in_use_error", False)
 
+        # List of users not to send out device list updates for when they
+        # register new devices. This is useful to handle bot accounts.
+        #
+        # Note: This will still send out device list updates if the device is
+        # later updated, e.g. end to end keys are added.
+        dont_notify_new_devices_for = config.get("dont_notify_new_devices_for", [])
+        self.dont_notify_new_devices_for = frozenset(dont_notify_new_devices_for)
+
     def generate_config_section(
         self, generate_secrets: bool = False, **kwargs: Any
     ) -> str:


### PR DESCRIPTION
List of users not to send out device list updates for when they register new devices. This is useful to handle bot accounts.

This is undocumented as its mostly a hack to test on matrix.org.

Note: This will still send out device list updates if the device is later updated, e.g. end to end keys are added.