### PR TITLE
Multi-worker-docker-container: disable log buffering

### DIFF
--- a/changelog.d/16919.misc
+++ b/changelog.d/16919.misc
@@ -1,0 +1,1 @@
+Multi-worker-docker-container: disable log buffering.

--- a/docker/prefix-log
+++ b/docker/prefix-log
@@ -7,6 +7,9 @@
 #   prefix-log command [args...]
 #
 
-exec 1> >(awk '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0}' >&1)
-exec 2> >(awk '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0}' >&2)
+# '-W interactive' is a `mawk` extension which disables buffering on stdout and sets line-buffered reads on
+# stdin. The effect is that the output is flushed after each line, rather than being batched, which helps reduce
+# confusion due to to interleaving of the different processes.
+exec 1> >(awk -W interactive '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0 }' >&1)
+exec 2> >(awk -W interactive '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0 }' >&2)
 exec "$@"


### PR DESCRIPTION
Background: we have a `matrixdotorg/synapse-workers` docker image, which is intended for running multiple workers within the same container. That image includes a `prefix-log` script which, for each line printed to stdout or stderr by one of the processes, prepends the name of the process.

This commit disables buffering in that script, so that lines are logged quickly after they are printed. This makes it much easier to understand the output, since they then come out in a natural order.