### PR TITLE
bugfix: always prefer unthreaded receipt when >1 exist (MSC4102)

### DIFF
--- a/changelog.d/16927.bugfix
+++ b/changelog.d/16927.bugfix
@@ -1,1 +1,1 @@
-Always prefer unthreaded receipt when >1 exist (MSC4102).
+Always prefer unthreaded receipt when >1 exist ([MSC4102](https://github.com/matrix-org/matrix-spec-proposals/pull/4102)).

--- a/changelog.d/16927.bugfix
+++ b/changelog.d/16927.bugfix
@@ -1,0 +1,1 @@
+Always prefer unthreaded receipt when >1 exist (MSC4102).

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -480,11 +480,13 @@ class ReceiptsWorkerStore(SQLBaseStore):
             # This means we will drop some receipts, but MSC4102 is designed to drop semantically
             # meaningless receipts, so this is okay. Previously, we would drop meaningful data!
             receipt_data = db_to_json(data)
-            if user_id in receipt_type_dict: # existing receipt
+            if user_id in receipt_type_dict:  # existing receipt
                 # is the existing receipt threaded and we are currently processing an unthreaded one?
                 if "thread_id" in receipt_type_dict[user_id] and not thread_id:
-                    receipt_type_dict[user_id] = receipt_data # replace with unthreaded one
-            else: # receipt does not exist, just set it
+                    receipt_type_dict[
+                        user_id
+                    ] = receipt_data  # replace with unthreaded one
+            else:  # receipt does not exist, just set it
                 receipt_type_dict[user_id] = receipt_data
                 if thread_id:
                     receipt_type_dict[user_id]["thread_id"] = thread_id

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -472,9 +472,22 @@ class ReceiptsWorkerStore(SQLBaseStore):
             event_entry = room_event["content"].setdefault(event_id, {})
             receipt_type_dict = event_entry.setdefault(receipt_type, {})
 
-            receipt_type_dict[user_id] = db_to_json(data)
-            if thread_id:
-                receipt_type_dict[user_id]["thread_id"] = thread_id
+            # MSC4102: always replace threaded receipts with unthreaded ones if there is a clash.
+            # Specifically:
+            # - if there is no existing receipt, great, set the data.
+            # - if there is an existing receipt, is it threaded (thread_id present)?
+            #    YES: replace if this receipt has no thread id. NO: do not replace.
+            # This means we will drop some receipts, but MSC4102 is designed to drop semantically
+            # meaningless receipts, so this is okay. Previously, we would drop meaningful data!
+            receipt_data = db_to_json(data)
+            if user_id in receipt_type_dict: # existing receipt
+                # is the existing receipt threaded and we are currently processing an unthreaded one?
+                if "thread_id" in receipt_type_dict[user_id] and not thread_id:
+                    receipt_type_dict[user_id] = receipt_data # replace with unthreaded one
+            else: # receipt does not exist, just set it
+                receipt_type_dict[user_id] = receipt_data
+                if thread_id:
+                    receipt_type_dict[user_id]["thread_id"] = thread_id
 
         results = {
             room_id: [results[room_id]] if room_id in results else []


### PR DESCRIPTION
### Pull Request Checklist

MSC: https://github.com/matrix-org/matrix-spec-proposals/pull/4102
Tests: https://github.com/matrix-org/complement/pull/709

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
