### PR TITLE
Specify IP subnet literals in canonical form

### DIFF
--- a/changelog.d/16953.misc
+++ b/changelog.d/16953.misc
@@ -1,0 +1,1 @@
+Specify IP subnets in canonical form.

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -128,7 +128,7 @@ class AuthTestCase(unittest.HomeserverTestCase):
             token="foobar",
             url="a_url",
             sender=self.test_user,
-            ip_range_whitelist=IPSet(["192.168/16"]),
+            ip_range_whitelist=IPSet(["192.168.0.0/16"]),
         )
         self.store.get_app_service_by_token = Mock(return_value=app_service)
         self.store.get_user_by_access_token = AsyncMock(return_value=None)
@@ -147,7 +147,7 @@ class AuthTestCase(unittest.HomeserverTestCase):
             token="foobar",
             url="a_url",
             sender=self.test_user,
-            ip_range_whitelist=IPSet(["192.168/16"]),
+            ip_range_whitelist=IPSet(["192.168.0.0/16"]),
         )
         self.store.get_app_service_by_token = Mock(return_value=app_service)
         self.store.get_user_by_access_token = AsyncMock(return_value=None)


### PR DESCRIPTION
This is needed, because the netaddr package removed support for the implicit prefix form in version 1.0.0:
https://github.com/netaddr/netaddr/pull/360

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
