### PR TITLE
Prevent locking up while processing batched_auth_events

### DIFF
--- a/changelog.d/16968.bugfix
+++ b/changelog.d/16968.bugfix
@@ -1,0 +1,1 @@
+Fix a potential deadlock when checking state independent auth rules by creating a deepcopy of authentication events. Contributed by @ggogel.

--- a/changelog.d/16968.bugfix
+++ b/changelog.d/16968.bugfix
@@ -1,1 +1,1 @@
-Fix a potential deadlock when checking state independent auth rules by creating a deepcopy of authentication events. Contributed by @ggogel.
+Do not create a shallow copy of batched_auth_events to prevent a potential deadlock. Contributed by @ggogel.

--- a/changelog.d/16968.bugfix
+++ b/changelog.d/16968.bugfix
@@ -1,1 +1,1 @@
-Do not create a shallow copy of batched_auth_events to prevent a potential deadlock. Contributed by @ggogel.
+Prevent locking up when checking auth rules that are independent of room state for batched auth events. Contributed by @ggogel.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -186,8 +186,9 @@ async def check_state_independent_auth_rules(
         return
 
     # 2. Reject if event has auth_events that: ...
-    auth_events: MutableMapping[str, "EventBase"] = {}
+    auth_events: MutableMapping[str, "EventBase"]
     if batched_auth_events:
+        auth_events = batched_auth_events
         needed_auth_event_ids = [
             event_id
             for event_id in event.auth_event_ids()
@@ -200,7 +201,6 @@ async def check_state_independent_auth_rules(
                 allow_rejected=True,
             )
             auth_events.update(needed_auth_events)
-        auth_events.update(batched_auth_events)
     else:
         auth_events = await store.get_events(
             event.auth_event_ids(),

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -21,6 +21,7 @@
 #
 
 import collections.abc
+import copy
 import logging
 import typing
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
@@ -177,7 +178,7 @@ async def check_state_independent_auth_rules(
     # 2. Reject if event has auth_events that: ...
     if batched_auth_events:
         # Copy the batched auth events to avoid mutating them.
-        auth_events = dict(batched_auth_events)
+        auth_events = copy.deepcopy(batched_auth_events)
         needed_auth_event_ids = set(event.auth_event_ids()) - batched_auth_events.keys()
         if needed_auth_event_ids:
             auth_events.update(

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -30,7 +30,6 @@ from signedjson.key import decode_verify_key_bytes
 from signedjson.sign import SignatureVerifyException, verify_signed_json
 from typing_extensions import Protocol
 from unpaddedbase64 import decode_base64
-from synapse.events import make_event_from_dict
 
 from synapse.api.constants import (
     MAX_PDU_SIZE,

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -188,7 +188,7 @@ async def check_state_independent_auth_rules(
     # 2. Reject if event has auth_events that: ...
     auth_events: MutableMapping[str, "EventBase"]
     if batched_auth_events:
-        auth_events = dict(batched_auth_events)
+        auth_events = batched_auth_events
         needed_auth_event_ids = [
             event_id
             for event_id in event.auth_event_ids()

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -21,6 +21,7 @@
 #
 
 import collections.abc
+import copy
 import logging
 import typing
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
@@ -181,7 +182,7 @@ async def check_state_independent_auth_rules(
         auth_events = {}
         for key, value in batched_auth_events.items():
             auth_events[key] = make_event_from_dict(
-                event_dict=value.get_dict(),
+                event_dict=copy.deepcopy(value.get_dict()),
                 room_version=value.room_version,
                 rejected_reason=value.rejected_reason
             )

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -34,6 +34,7 @@ from typing import (
     Set,
     Tuple,
     Union,
+    cast,
 )
 
 from canonicaljson import encode_canonical_json
@@ -186,6 +187,7 @@ async def check_state_independent_auth_rules(
         return
 
     # 2. Reject if event has auth_events that: ...
+    auth_events: MutableMapping[str, "EventBase"] = {}
     if batched_auth_events:
         needed_auth_event_ids = [
             event_id
@@ -202,7 +204,8 @@ async def check_state_independent_auth_rules(
                 allow_rejected=True,
             )
         
-        auth_events: Mapping[str, "EventBase"] = {**batched_auth_events, **needed_auth_events} 
+        auth_events = cast(MutableMapping[str, "EventBase"], batched_auth_events)
+        auth_events.update(needed_auth_events)
     else:
         auth_events = await store.get_events(
             event.auth_event_ids(),

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -25,6 +25,7 @@ import logging
 import typing
 from typing import (
     Any,
+    ChainMap,
     Dict,
     Iterable,
     List,
@@ -35,7 +36,6 @@ from typing import (
     Tuple,
     Union,
     cast,
-    ChainMap,
 )
 
 from canonicaljson import encode_canonical_json

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -23,7 +23,7 @@
 import collections.abc
 import logging
 import typing
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Set, Tuple, Union
 
 from canonicaljson import encode_canonical_json
 from signedjson.key import decode_verify_key_bytes
@@ -175,6 +175,7 @@ async def check_state_independent_auth_rules(
         return
 
     # 2. Reject if event has auth_events that: ...
+    auth_events: MutableMapping[str, "EventBase"]
     if batched_auth_events:
         auth_events = batched_auth_events
         needed_auth_event_ids = [

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -177,7 +177,7 @@ async def check_state_independent_auth_rules(
     # 2. Reject if event has auth_events that: ...
     auth_events: MutableMapping[str, "EventBase"]
     if batched_auth_events:
-        auth_events = batched_auth_events
+        auth_events = dict(batched_auth_events)
         needed_auth_event_ids = [
             event_id
             for event_id in event.auth_event_ids()

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -177,7 +177,7 @@ async def check_state_independent_auth_rules(
     # 2. Reject if event has auth_events that: ...
     if batched_auth_events:
         auth_events = batched_auth_events
-        needed_auth_event_ids = set(event.auth_event_ids()) - set(batched_auth_events)
+        needed_auth_event_ids = [event_id for event_id in event.auth_event_ids() if event_id not in batched_auth_events]
         if needed_auth_event_ids:
             needed_auth_events = await store.get_events(
                 needed_auth_event_ids,

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -190,6 +190,10 @@ async def check_state_independent_auth_rules(
     # 2. Reject if event has auth_events that: ...
     auth_events: ChainMap[str, EventBase] = ChainMap()
     if batched_auth_events:
+        # batched_auth_events can become very large. To avoid repeatedly copying it, which
+        # would significantly impact performance, we use a ChainMap.
+        # batched_auth_events must be cast to MutableMapping because .new_child() requires
+        # this type. This casting is safe as the mapping is never mutated.
         auth_events = auth_events.new_child(cast(MutableMapping[str, "EventBase"], batched_auth_events))
         needed_auth_event_ids = [
             event_id

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -179,13 +179,12 @@ async def check_state_independent_auth_rules(
         auth_events = batched_auth_events
         needed_auth_event_ids = set(event.auth_event_ids()) - set(batched_auth_events)
         if needed_auth_event_ids:
-            auth_events.update(
-                await store.get_events(
-                    needed_auth_event_ids,
-                    redact_behaviour=EventRedactBehaviour.as_is,
-                    allow_rejected=True,
-                )
+            needed_auth_events = await store.get_events(
+                needed_auth_event_ids,
+                redact_behaviour=EventRedactBehaviour.as_is,
+                allow_rejected=True
             )
+            auth_events.update(needed_auth_events)
     else:
         auth_events = await store.get_events(
             event.auth_event_ids(),

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -175,13 +175,23 @@ async def check_state_independent_auth_rules(
         return
 
     # 2. Reject if event has auth_events that: ...
-    auth_events = await store.get_events(
-        event.auth_event_ids(),
-        redact_behaviour=EventRedactBehaviour.as_is,
-        allow_rejected=True,
-    )
     if batched_auth_events:
-        auth_events.update(batched_auth_events)
+        auth_events = batched_auth_events
+        needed_auth_event_ids = set(event.auth_event_ids()) - set(batched_auth_events)
+        if needed_auth_event_ids:
+            auth_events.update(
+                await store.get_events(
+                    needed_auth_event_ids,
+                    redact_behaviour=EventRedactBehaviour.as_is,
+                    allow_rejected=True,
+                )
+            )
+    else:
+        auth_events = await store.get_events(
+            event.auth_event_ids(),
+            redact_behaviour=EventRedactBehaviour.as_is,
+            allow_rejected=True
+        )
 
     room_id = event.room_id
     auth_dict: MutableStateMap[str] = {}

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -186,14 +186,18 @@ async def check_state_independent_auth_rules(
         return
 
     # 2. Reject if event has auth_events that: ...
-    auth_events: MutableMapping[str, "EventBase"]
+    auth_events: MutableMapping[str, "EventBase"] = {}
     if batched_auth_events:
-        auth_events = batched_auth_events
+        # Add items individually to prevent locking the whole mapping
+        for key, value in batched_auth_events.items():
+            auth_events[key] = value
+        
         needed_auth_event_ids = [
             event_id
             for event_id in event.auth_event_ids()
             if event_id not in batched_auth_events
         ]
+
         if needed_auth_event_ids:
             needed_auth_events = await store.get_events(
                 needed_auth_event_ids,

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -189,23 +189,20 @@ async def check_state_independent_auth_rules(
     # 2. Reject if event has auth_events that: ...
     auth_events: MutableMapping[str, "EventBase"] = {}
     if batched_auth_events:
+        auth_events = cast(MutableMapping[str, "EventBase"], batched_auth_events)
         needed_auth_event_ids = [
             event_id
             for event_id in event.auth_event_ids()
             if event_id not in batched_auth_events
         ]
-
-        needed_auth_events: MutableMapping[str, "EventBase"] = {}
-
         if needed_auth_event_ids:
-            needed_auth_events = await store.get_events(
-                needed_auth_event_ids,
-                redact_behaviour=EventRedactBehaviour.as_is,
-                allow_rejected=True,
+            auth_events.update(
+                await store.get_events(
+                    needed_auth_event_ids,
+                    redact_behaviour=EventRedactBehaviour.as_is,
+                    allow_rejected=True,
+                )
             )
-        
-        auth_events = cast(MutableMapping[str, "EventBase"], batched_auth_events)
-        auth_events.update(needed_auth_events)
     else:
         auth_events = await store.get_events(
             event.auth_event_ids(),

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -177,19 +177,23 @@ async def check_state_independent_auth_rules(
     # 2. Reject if event has auth_events that: ...
     if batched_auth_events:
         auth_events = batched_auth_events
-        needed_auth_event_ids = [event_id for event_id in event.auth_event_ids() if event_id not in batched_auth_events]
+        needed_auth_event_ids = [
+            event_id
+            for event_id in event.auth_event_ids()
+            if event_id not in batched_auth_events
+        ]
         if needed_auth_event_ids:
             needed_auth_events = await store.get_events(
                 needed_auth_event_ids,
                 redact_behaviour=EventRedactBehaviour.as_is,
-                allow_rejected=True
+                allow_rejected=True,
             )
             auth_events.update(needed_auth_events)
     else:
         auth_events = await store.get_events(
             event.auth_event_ids(),
             redact_behaviour=EventRedactBehaviour.as_is,
-            allow_rejected=True
+            allow_rejected=True,
         )
 
     room_id = event.room_id

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -194,7 +194,9 @@ async def check_state_independent_auth_rules(
         # would significantly impact performance, we use a ChainMap.
         # batched_auth_events must be cast to MutableMapping because .new_child() requires
         # this type. This casting is safe as the mapping is never mutated.
-        auth_events = auth_events.new_child(cast(MutableMapping[str, "EventBase"], batched_auth_events))
+        auth_events = auth_events.new_child(
+            cast(MutableMapping[str, "EventBase"], batched_auth_events)
+        )
         needed_auth_event_ids = [
             event_id
             for event_id in event.auth_event_ids()

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -23,7 +23,18 @@
 import collections.abc
 import logging
 import typing
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Set, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 from canonicaljson import encode_canonical_json
 from signedjson.key import decode_verify_key_bytes

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -177,13 +177,23 @@ async def check_state_independent_auth_rules(
         return
 
     # 2. Reject if event has auth_events that: ...
-    auth_events = await store.get_events(
-        event.auth_event_ids(),
-        redact_behaviour=EventRedactBehaviour.as_is,
-        allow_rejected=True,
-    )
     if batched_auth_events:
-        auth_events.update(batched_auth_events)
+        auth_events = batched_auth_events
+        needed_auth_event_ids = set(event.auth_event_ids()) - set(batched_auth_events)
+        if needed_auth_event_ids:
+            auth_events.update(
+                await store.get_events(
+                    needed_auth_event_ids,
+                    redact_behaviour=EventRedactBehaviour.as_is,
+                    allow_rejected=True,
+                )
+            )
+    else:
+        auth_events = await store.get_events(
+            event.auth_event_ids(),
+            redact_behaviour=EventRedactBehaviour.as_is,
+            allow_rejected=True
+        )
 
     room_id = event.room_id
     auth_dict: MutableStateMap[str] = {}

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -186,17 +186,14 @@ async def check_state_independent_auth_rules(
         return
 
     # 2. Reject if event has auth_events that: ...
-    auth_events: MutableMapping[str, "EventBase"] = {}
     if batched_auth_events:
-        # Add items individually to prevent locking the whole mapping
-        for key, value in batched_auth_events.items():
-            auth_events[key] = value
-        
         needed_auth_event_ids = [
             event_id
             for event_id in event.auth_event_ids()
             if event_id not in batched_auth_events
         ]
+
+        needed_auth_events: MutableMapping[str, "EventBase"] = {}
 
         if needed_auth_event_ids:
             needed_auth_events = await store.get_events(
@@ -204,7 +201,8 @@ async def check_state_independent_auth_rules(
                 redact_behaviour=EventRedactBehaviour.as_is,
                 allow_rejected=True,
             )
-            auth_events.update(needed_auth_events)
+        
+        auth_events: Mapping[str, "EventBase"] = {**batched_auth_events, **needed_auth_events} 
     else:
         auth_events = await store.get_events(
             event.auth_event_ids(),

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -21,7 +21,6 @@
 #
 
 import collections.abc
-import copy
 import logging
 import typing
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -182,7 +182,11 @@ async def check_state_independent_auth_rules(
         auth_events = {}
         for key, value in batched_auth_events.items():
             auth_events[key] = make_event_from_dict(
-                event_dict=copy.deepcopy(value.get_dict()),
+                event_dict={
+                    "type": value.get("type"),
+                    "state_key": value.get_state_key(),
+                    "room_id": value.get("room_id")
+                },
                 room_version=value.room_version,
                 rejected_reason=value.rejected_reason
             )

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -186,9 +186,8 @@ async def check_state_independent_auth_rules(
         return
 
     # 2. Reject if event has auth_events that: ...
-    auth_events: MutableMapping[str, "EventBase"]
+    auth_events: MutableMapping[str, "EventBase"] = {}
     if batched_auth_events:
-        auth_events = batched_auth_events
         needed_auth_event_ids = [
             event_id
             for event_id in event.auth_event_ids()
@@ -201,6 +200,7 @@ async def check_state_independent_auth_rules(
                 allow_rejected=True,
             )
             auth_events.update(needed_auth_events)
+        auth_events.update(batched_auth_events)
     else:
         auth_events = await store.get_events(
             event.auth_event_ids(),

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -175,23 +175,13 @@ async def check_state_independent_auth_rules(
         return
 
     # 2. Reject if event has auth_events that: ...
+    auth_events = await store.get_events(
+        event.auth_event_ids(),
+        redact_behaviour=EventRedactBehaviour.as_is,
+        allow_rejected=True,
+    )
     if batched_auth_events:
-        auth_events = batched_auth_events
-        needed_auth_event_ids = set(event.auth_event_ids()) - set(batched_auth_events)
-        if needed_auth_event_ids:
-            auth_events.update(
-                await store.get_events(
-                    needed_auth_event_ids,
-                    redact_behaviour=EventRedactBehaviour.as_is,
-                    allow_rejected=True,
-                )
-            )
-    else:
-        auth_events = await store.get_events(
-            event.auth_event_ids(),
-            redact_behaviour=EventRedactBehaviour.as_is,
-            allow_rejected=True
-        )
+        auth_events.update(batched_auth_events)
 
     room_id = event.room_id
     auth_dict: MutableStateMap[str] = {}


### PR DESCRIPTION
This PR aims to fix #16895, caused by a regression in #7 and not fixed by #16903. The PR #16903 only fixes a starvation issue, where the CPU isn't released. There is a second issue, where the execution is blocked. This theory is supported by the flame graphs provided in #16895 and the fact that I see the CPU usage reducing and far below the limit.

Since the changes in #7, the method `check_state_independent_auth_rules` is called with the additional parameter `batched_auth_events`:

https://github.com/element-hq/synapse/blob/6fa13b4f927c10b5f4e9495be746ec28849f5cb6/synapse/handlers/federation_event.py#L1741-L1743


It makes the execution enter this if clause, introduced with #15195

https://github.com/element-hq/synapse/blob/6fa13b4f927c10b5f4e9495be746ec28849f5cb6/synapse/event_auth.py#L178-L189

There are two issues in the above code snippet.

First, there is the blocking issue. I'm not entirely sure if this is a deadlock, starvation, or something different. In the beginning, I thought the copy operation was responsible. It wasn't. Then I investigated the nested `store.get_events` inside the function `update`. This was also not causing the blocking issue. Only when I replaced the set difference operation (`-` ) with a list comprehension, the blocking was resolved. Creating and comparing sets with a very large amount of events seems to be problematic.

This is how the flamegraph looks now while persisting outliers. As you can see, the execution no longer locks up in the above function.
![output_2024-02-28_13-59-40](https://github.com/element-hq/synapse/assets/13143850/6db9c9ac-484f-47d0-bdde-70abfbd773ec)

Second, the copying here doesn't serve any purpose, because only a shallow copy is created. This means the same objects from the original dict are referenced. This fails the intention of protecting these objects from mutation. The review of the original PR https://github.com/matrix-org/synapse/pull/15195 had an extensive discussion about this matter.

Various approaches to copying the auth_events were attempted:
1) Implementing a deepcopy caused issues due to builtins.EventInternalMetadata not being pickleable.
2) Creating a dict with new objects akin to a deepcopy.
3) Creating a dict with new objects containing only necessary attributes.

Concluding, there is no easy way to create an actual copy of the objects. Opting for a deepcopy can significantly strain memory and CPU resources, making it an inefficient choice. I don't see why the copy is necessary in the first place. Therefore I'm proposing to remove it altogether.

After these changes, I was able to successfully join these rooms, without the main worker locking up:
- #synapse:matrix.org
- #element-android:matrix.org
- #element-web:matrix.org
- #ecips:matrix.org
- #ipfs-chatter:ipfs.io
- #python:matrix.org
- #matrix:matrix.org