### PR TITLE
Fix joining remote rooms when a `on_new_event` callback is registered

### DIFF
--- a/changelog.d/16973.bugfix
+++ b/changelog.d/16973.bugfix
@@ -1,0 +1,1 @@
+Fix joining remote rooms when a module uses the `on_new_event` callback. This callback may now pass partial state events instead of the full state for remote rooms.

--- a/docs/modules/third_party_rules_callbacks.md
+++ b/docs/modules/third_party_rules_callbacks.md
@@ -142,6 +142,10 @@ Called after sending an event into a room. The module is passed the event, as we
 as the state of the room _after_ the event. This means that if the event is a state event,
 it will be included in this state.
 
+The state map may not be complete if Synapse hasn't yet loaded the full state
+of the room. This can happen for events in rooms that were just joined from
+a remote server.
+
 Note that this callback is called when the event has already been processed and stored
 into the room, which means this callback cannot be used to deny persisting the event. To
 deny an incoming event, see [`check_event_for_spam`](spam_checker_callbacks.md#check_event_for_spam) instead.

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -562,10 +562,15 @@ class StateStorageController:
     @trace
     @tag_args
     async def get_current_state(
-        self, room_id: str, state_filter: Optional[StateFilter] = None
+        self,
+        room_id: str,
+        state_filter: Optional[StateFilter] = None,
+        await_full_state: bool = True,
     ) -> StateMap[EventBase]:
         """Same as `get_current_state_ids` but also fetches the events"""
-        state_map_ids = await self.get_current_state_ids(room_id, state_filter)
+        state_map_ids = await self.get_current_state_ids(
+            room_id, state_filter, await_full_state
+        )
 
         event_map = await self.stores.main.get_events(list(state_map_ids.values()))
 


### PR DESCRIPTION
Since Synapse 1.76.0, any module which registers a `on_new_event` callback would brick the ability to join remote rooms.
This is because this callback tried to get the full state of the room, which would end up in a deadlock.

Related: https://github.com/matrix-org/synapse-auto-accept-invite/issues/18

The following module would brick the ability to join remote rooms:

```python
from typing import Any, Dict, Literal, Union
import logging

from synapse.module_api import ModuleApi, EventBase

logger = logging.getLogger(__name__)

class MyModule:
    def __init__(self, config: None, api: ModuleApi):
        self._api = api
        self._config = config

        self._api.register_third_party_rules_callbacks(
            on_new_event=self.on_new_event,
        )

    async def on_new_event(self, event: EventBase, _state_map: Any) -> None:
        logger.info(f"Received new event: {event}")

    @staticmethod
    def parse_config(_config: Dict[str, Any]) -> None:
        return None
```

This is technically a breaking change, as we are now passing partial state on the `on_new_event` callback.
However, this callback was broken for federated rooms since 1.76.0, and local rooms have full state anyway, so it's unlikely that it would change anything.
