### PR TITLE
Revert "Ignore notification counts from rooms you've left"

### DIFF
--- a/changelog.d/16954.bugfix
+++ b/changelog.d/16954.bugfix
@@ -1,1 +1,0 @@
-Fix a bug introduced in v1.100.0 where notifications from rooms you've left would continue to be counted.

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -404,11 +404,7 @@ class EventPushActionsWorkerStore(ReceiptsWorkerStore, StreamWorkerStore, SQLBas
                 SELECT e.room_id, notif_count, e.stream_ordering, e.thread_id, last_receipt_stream_ordering,
                     ev.stream_ordering AS receipt_stream_ordering
                 FROM event_push_summary AS e
-                INNER JOIN local_current_membership AS lcm ON (
-                    e.user_id = lcm.user_id
-                    AND e.room_id = lcm.room_id
-                    AND lcm.membership = 'join'
-                )
+                INNER JOIN local_current_membership USING (user_id, room_id)
                 LEFT JOIN receipts_linearized AS r ON (
                     e.user_id = r.user_id
                     AND e.room_id = r.room_id
@@ -476,11 +472,7 @@ class EventPushActionsWorkerStore(ReceiptsWorkerStore, StreamWorkerStore, SQLBas
                 SELECT e.room_id, e.stream_ordering, e.thread_id,
                     ev.stream_ordering AS receipt_stream_ordering
                 FROM event_push_actions AS e
-                INNER JOIN local_current_membership AS lcm ON (
-                    e.user_id = lcm.user_id
-                    AND e.room_id = lcm.room_id
-                    AND lcm.membership = 'join'
-                )
+                INNER JOIN local_current_membership USING (user_id, room_id)
                 LEFT JOIN receipts_linearized AS r ON (
                     e.user_id = r.user_id
                     AND e.room_id = r.room_id
@@ -522,11 +514,7 @@ class EventPushActionsWorkerStore(ReceiptsWorkerStore, StreamWorkerStore, SQLBas
                     SELECT e.room_id, e.stream_ordering, e.thread_id,
                         ev.stream_ordering AS receipt_stream_ordering
                     FROM event_push_actions AS e
-                    INNER JOIN local_current_membership AS lcm ON (
-                        e.user_id = lcm.user_id
-                        AND e.room_id = lcm.room_id
-                        AND lcm.membership = 'join'
-                    )
+                    INNER JOIN local_current_membership USING (user_id, room_id)
                     LEFT JOIN receipts_linearized AS r ON (
                         e.user_id = r.user_id
                         AND e.room_id = r.room_id


### PR DESCRIPTION
Reverts element-hq/synapse#16954. This was a partial fix for https://github.com/element-hq/synapse/pull/16756, which we've now reverted in https://github.com/element-hq/synapse/issues/16979.

Thus, the partial fix can be reverted as well.

This PR does not require a changelog, and deletes the changelog of https://github.com/element-hq/synapse/issues/16979.