### PR TITLE
Prevent `start_for_complement.sh` from setting `START_POSTGRES` to `false` when it's already set

### DIFF
--- a/changelog.d/16985.misc
+++ b/changelog.d/16985.misc
@@ -1,0 +1,1 @@
+Allow containers building on top of Synapse's Complement container is use the included PostgreSQL cluster.

--- a/docker/complement/conf/postgres.supervisord.conf
+++ b/docker/complement/conf/postgres.supervisord.conf
@@ -1,7 +1,7 @@
 [program:postgres]
 command=/usr/local/bin/prefix-log gosu postgres postgres
 
-# Only start if START_POSTGRES=1
+# Only start if START_POSTGRES=true
 autostart=%(ENV_START_POSTGRES)s
 
 # Lower priority number = starts first

--- a/docker/complement/conf/start_for_complement.sh
+++ b/docker/complement/conf/start_for_complement.sh
@@ -32,8 +32,13 @@ case "$SYNAPSE_COMPLEMENT_DATABASE" in
     ;;
 
   sqlite|"")
-    # Configure supervisord not to start Postgres, as we don't need it
-    export START_POSTGRES=false
+    # Check that START_POSTGRES hasn't already been set
+    # (i.e. by another container image inheriting our own).
+    # If not, then set it here.
+    if [ -z "$START_POSTGRES" ]; then
+      # Configure supervisord not to start Postgres.
+      export START_POSTGRES=false
+    fi
     ;;
 
   *)

--- a/docker/complement/conf/start_for_complement.sh
+++ b/docker/complement/conf/start_for_complement.sh
@@ -32,13 +32,9 @@ case "$SYNAPSE_COMPLEMENT_DATABASE" in
     ;;
 
   sqlite|"")
-    # Check that START_POSTGRES hasn't already been set
+    # Set START_POSTGRES to false unless it has already been set
     # (i.e. by another container image inheriting our own).
-    # If not, then set it here.
-    if [ -z "$START_POSTGRES" ]; then
-      # Configure supervisord not to start Postgres.
-      export START_POSTGRES=false
-    fi
+    export START_POSTGRES=${START_POSTGRES:-false}
     ;;
 
   *)


### PR DESCRIPTION
I have a use case where I'd like the Synapse image to start up a postgres instance that I can use, but don't want to force Synapse to use postgres as well.

This commit prevents postgres from being started when it has already been explicitly enabled elsewhere.