### PR TITLE
Do not refuse to set read_marker if previous event_id is in wrong room

### DIFF
--- a/changelog.d/16990.bugfix
+++ b/changelog.d/16990.bugfix
@@ -1,0 +1,1 @@
+Fix case in which `m.fully_read` marker would not get updated. Contributed by @SpiritCroc.

--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -55,12 +55,12 @@ class ReadMarkerHandler:
 
             should_update = True
             # Get event ordering, this also ensures we know about the event
-            event_ordering = await self.store.get_event_ordering(event_id)
+            event_ordering = await self.store.get_event_ordering(event_id, room_id)
 
             if existing_read_marker:
                 try:
                     old_event_ordering = await self.store.get_event_ordering(
-                        existing_read_marker["event_id"]
+                        existing_read_marker["event_id"], room_id
                     )
                 except SynapseError:
                     # Old event no longer exists, assume new is ahead. This may

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -1997,16 +1997,18 @@ class EventsWorkerStore(SQLBaseStore):
         return rows, to_token, True
 
     @cached(max_entries=5000)
-    async def get_event_ordering(self, event_id: str) -> Tuple[int, int]:
+    async def get_event_ordering(self, event_id: str, room_id: str) -> Tuple[int, int]:
         res = await self.db_pool.simple_select_one(
             table="events",
             retcols=["topological_ordering", "stream_ordering"],
-            keyvalues={"event_id": event_id},
+            keyvalues={"event_id": event_id, "room_id": room_id},
             allow_none=True,
         )
 
         if not res:
-            raise SynapseError(404, "Could not find event %s" % (event_id,))
+            raise SynapseError(
+                404, "Could not find event %s in room %s" % (event_id, room_id)
+            )
 
         return int(res[0]), int(res[1])
 

--- a/tests/rest/client/test_read_marker.py
+++ b/tests/rest/client/test_read_marker.py
@@ -78,7 +78,7 @@ class ReadMarkerTestCase(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "POST",
-            "/rooms/!abc:beep/read_markers",
+            f"/rooms/{room_id}/read_markers",
             content={
                 "m.fully_read": event_id_1,
             },
@@ -90,7 +90,7 @@ class ReadMarkerTestCase(unittest.HomeserverTestCase):
         event_id_2 = send_message()
         channel = self.make_request(
             "POST",
-            "/rooms/!abc:beep/read_markers",
+            f"/rooms/{room_id}/read_markers",
             content={
                 "m.fully_read": event_id_2,
             },
@@ -123,7 +123,7 @@ class ReadMarkerTestCase(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "POST",
-            "/rooms/!abc:beep/read_markers",
+            f"/rooms/{room_id}/read_markers",
             content={
                 "m.fully_read": event_id_1,
             },
@@ -142,7 +142,7 @@ class ReadMarkerTestCase(unittest.HomeserverTestCase):
         event_id_2 = send_message()
         channel = self.make_request(
             "POST",
-            "/rooms/!abc:beep/read_markers",
+            f"/rooms/{room_id}/read_markers",
             content={
                 "m.fully_read": event_id_2,
             },


### PR DESCRIPTION
I was having some room in which the `m.fully_read` would never update, despite synapse returning 200 whenever a client tried to do so. Upon checking the `event_id` that was being persisted in account data, and looking it up in my database, it appeared to be in a different room than the room I was trying to set the read marker for.

Accordingly, it should be a good idea to ensure the room_id is appropriate when comparing event ordering before setting the fully_read marker, to avoid having events in different rooms preventing us from setting an appropriate marker.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
