### PR TITLE
Added presence update on change of profile information and config flags for selective presence tracking

### DIFF
--- a/changelog.d/16992.feature
+++ b/changelog.d/16992.feature
@@ -1,0 +1,1 @@
+Added presence update on change of profile information and config flags for selective presence tracking. Contributed by @Michael-Hollister.

--- a/synapse/api/presence.py
+++ b/synapse/api/presence.py
@@ -83,6 +83,8 @@ class UserPresenceState:
     last_user_sync_ts: int
     status_msg: Optional[str]
     currently_active: bool
+    displayname: Optional[str]
+    avatar_url: Optional[str]
 
     def as_dict(self) -> JsonDict:
         return attr.asdict(self)
@@ -101,4 +103,6 @@ class UserPresenceState:
             last_user_sync_ts=0,
             status_msg=None,
             currently_active=False,
+            displayname=None,
+            avatar_url=None,
         )

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -384,6 +384,16 @@ class ServerConfig(Config):
         # Whether to internally track presence, requires that presence is enabled,
         self.track_presence = self.presence_enabled and presence_enabled != "untracked"
 
+        # Disabling server-side presence tracking
+        self.sync_presence_tracking = presence_config.get(
+            "sync_presence_tracking", True
+        )
+
+        # Disabling federation presence tracking
+        self.federation_presence_tracking = presence_config.get(
+            "federation_presence_tracking", True
+        )
+
         # Custom presence router module
         # This is the legacy way of configuring it (the config should now be put in the modules section)
         self.presence_router_module_class = None

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -1410,6 +1410,17 @@ class FederationHandlerRegistry:
         if not self.config.server.track_presence and edu_type == EduTypes.PRESENCE:
             return
 
+        if (
+            not self.config.server.federation_presence_tracking
+            and edu_type == EduTypes.PRESENCE
+        ):
+            filtered_edus = []
+            for e in content["push"]:
+                # Process only profile presence updates to reduce resource impact
+                if "status_msg" in e or "displayname" in e or "avatar_url" in e:
+                    filtered_edus.append(e)
+            content["push"] = filtered_edus
+
         # Check if we have a handler on this instance
         handler = self.edu_handlers.get(edu_type)
         if handler:

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -200,6 +200,19 @@ class ProfileHandler:
         if propagate:
             await self._update_join_states(requester, target_user)
 
+        if self.hs.config.server.track_presence:
+            presence_handler = self.hs.get_presence_handler()
+            current_presence_state = await presence_handler.get_state(target_user)
+
+            state = {
+                "presence": current_presence_state.state,
+                "status_message": current_presence_state.status_msg,
+                "displayname": new_displayname,
+                "avatar_url": current_presence_state.avatar_url,
+            }
+
+            await presence_handler.set_state(target_user, requester.device_id, state)
+
     async def get_avatar_url(self, target_user: UserID) -> Optional[str]:
         if self.hs.is_mine(target_user):
             try:
@@ -292,6 +305,19 @@ class ProfileHandler:
 
         if propagate:
             await self._update_join_states(requester, target_user)
+
+        if self.hs.config.server.track_presence:
+            presence_handler = self.hs.get_presence_handler()
+            current_presence_state = await presence_handler.get_state(target_user)
+
+            state = {
+                "presence": current_presence_state.state,
+                "status_message": current_presence_state.status_msg,
+                "displayname": current_presence_state.displayname,
+                "avatar_url": new_avatar_url,
+            }
+
+            await presence_handler.set_state(target_user, requester.device_id, state)
 
     @cached()
     async def check_avatar_size_and_mime_type(self, mxc: str) -> bool:

--- a/synapse/replication/tcp/streams/_base.py
+++ b/synapse/replication/tcp/streams/_base.py
@@ -330,6 +330,8 @@ class PresenceStream(_StreamFromIdGen):
         last_user_sync_ts: int
         status_msg: str
         currently_active: bool
+        displayname: str
+        avatar_url: str
 
     NAME = "presence"
     ROW_TYPE = PresenceStreamRow

--- a/synapse/storage/databases/main/presence.py
+++ b/synapse/storage/databases/main/presence.py
@@ -181,6 +181,8 @@ class PresenceStore(PresenceBackgroundUpdateStore, CacheInvalidationWorkerStore)
                 "last_user_sync_ts",
                 "status_msg",
                 "currently_active",
+                "displayname",
+                "avatar_url",
                 "instance_name",
             ),
             values=[
@@ -193,6 +195,8 @@ class PresenceStore(PresenceBackgroundUpdateStore, CacheInvalidationWorkerStore)
                     state.last_user_sync_ts,
                     state.status_msg,
                     state.currently_active,
+                    state.displayname,
+                    state.avatar_url,
                     self._instance_name,
                 )
                 for stream_id, state in zip(stream_orderings, presence_states)
@@ -232,7 +236,8 @@ class PresenceStore(PresenceBackgroundUpdateStore, CacheInvalidationWorkerStore)
             sql = """
                 SELECT stream_id, user_id, state, last_active_ts,
                     last_federation_update_ts, last_user_sync_ts,
-                    status_msg, currently_active
+                    status_msg, currently_active, displayname,
+                    avatar_url
                 FROM presence_stream
                 WHERE ? < stream_id AND stream_id <= ?
                 ORDER BY stream_id ASC
@@ -285,6 +290,8 @@ class PresenceStore(PresenceBackgroundUpdateStore, CacheInvalidationWorkerStore)
                     "last_user_sync_ts",
                     "status_msg",
                     "currently_active",
+                    "displayname",
+                    "avatar_url",
                 ),
                 desc="get_presence_for_users",
             ),
@@ -299,8 +306,10 @@ class PresenceStore(PresenceBackgroundUpdateStore, CacheInvalidationWorkerStore)
                 last_user_sync_ts=last_user_sync_ts,
                 status_msg=status_msg,
                 currently_active=bool(currently_active),
+                displayname=displayname,
+                avatar_url=avatar_url,
             )
-            for user_id, state, last_active_ts, last_federation_update_ts, last_user_sync_ts, status_msg, currently_active in rows
+            for user_id, state, last_active_ts, last_federation_update_ts, last_user_sync_ts, status_msg, currently_active, displayname, avatar_url, in rows
         }
 
     async def should_user_receive_full_presence_with_token(
@@ -427,6 +436,8 @@ class PresenceStore(PresenceBackgroundUpdateStore, CacheInvalidationWorkerStore)
                         "last_user_sync_ts",
                         "status_msg",
                         "currently_active",
+                        "displayname",
+                        "avatar_url",
                     ),
                     order_direction="ASC",
                 ),
@@ -440,6 +451,8 @@ class PresenceStore(PresenceBackgroundUpdateStore, CacheInvalidationWorkerStore)
                 last_user_sync_ts,
                 status_msg,
                 currently_active,
+                displayname,
+                avatar_url,
             ) in rows:
                 users_to_state[user_id] = UserPresenceState(
                     user_id=user_id,
@@ -449,6 +462,8 @@ class PresenceStore(PresenceBackgroundUpdateStore, CacheInvalidationWorkerStore)
                     last_user_sync_ts=last_user_sync_ts,
                     status_msg=status_msg,
                     currently_active=bool(currently_active),
+                    displayname=displayname,
+                    avatar_url=avatar_url,
                 )
 
             # We've run out of updates to query
@@ -471,7 +486,8 @@ class PresenceStore(PresenceBackgroundUpdateStore, CacheInvalidationWorkerStore)
         # query.
         sql = (
             "SELECT user_id, state, last_active_ts, last_federation_update_ts,"
-            " last_user_sync_ts, status_msg, currently_active FROM presence_stream"
+            " last_user_sync_ts, status_msg, currently_active, displayname, avatar_url "
+            " FROM presence_stream"
             " WHERE state != ?"
         )
 
@@ -489,8 +505,10 @@ class PresenceStore(PresenceBackgroundUpdateStore, CacheInvalidationWorkerStore)
                 last_user_sync_ts=last_user_sync_ts,
                 status_msg=status_msg,
                 currently_active=bool(currently_active),
+                displayname=displayname,
+                avatar_url=avatar_url,
             )
-            for user_id, state, last_active_ts, last_federation_update_ts, last_user_sync_ts, status_msg, currently_active in rows
+            for user_id, state, last_active_ts, last_federation_update_ts, last_user_sync_ts, status_msg, currently_active, displayname, avatar_url, in rows
         ]
 
     def take_presence_startup_info(self) -> List[UserPresenceState]:

--- a/synapse/storage/schema/__init__.py
+++ b/synapse/storage/schema/__init__.py
@@ -19,7 +19,7 @@
 #
 #
 
-SCHEMA_VERSION = 84  # remember to update the list below when updating
+SCHEMA_VERSION = 85  # remember to update the list below when updating
 """Represents the expectations made by the codebase about the database schema
 
 This should be incremented whenever the codebase changes its requirements on the
@@ -132,12 +132,15 @@ Changes in SCHEMA_VERSION = 82
 
 Changes in SCHEMA_VERSION = 83
     - The event_txn_id is no longer used.
+
+Changes in SCHEMA_VERSION = 85
+    - Added displayname and avatar_url columns to presence_stream
 """
 
 
 SCHEMA_COMPAT_VERSION = (
-    # The event_txn_id table and tables from MSC2716 no longer exist.
-    83
+    # Added displayname and avatar_url columns to presence_stream
+    85
 )
 """Limit on how far the synapse codebase can be rolled back without breaking db compat
 

--- a/synapse/storage/schema/main/delta/85/01presence_stream_updates.sql
+++ b/synapse/storage/schema/main/delta/85/01presence_stream_updates.sql
@@ -1,0 +1,20 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2023 New Vector, Ltd
+--
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2024 New Vector, Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+ALTER TABLE presence_stream ADD COLUMN displayname TEXT;
+ALTER TABLE presence_stream ADD COLUMN avatar_url TEXT;

--- a/tests/api/test_filtering.py
+++ b/tests/api/test_filtering.py
@@ -450,6 +450,8 @@ class FilteringTestCase(unittest.HomeserverTestCase):
                 last_user_sync_ts=0,
                 status_msg=None,
                 currently_active=False,
+                displayname=None,
+                avatar_url=None,
             ),
         ]
 
@@ -478,6 +480,8 @@ class FilteringTestCase(unittest.HomeserverTestCase):
                 last_user_sync_ts=0,
                 status_msg=None,
                 currently_active=False,
+                displayname=None,
+                avatar_url=None,
             ),
         ]
 

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -366,6 +366,8 @@ class PresenceUpdateTestCase(unittest.HomeserverTestCase):
                 last_user_sync_ts=1,
                 status_msg="I'm online!",
                 currently_active=True,
+                displayname=None,
+                avatar_url=None,
             )
             presence_states.append(presence_state)
 
@@ -718,6 +720,8 @@ class PresenceHandlerInitTestCase(unittest.HomeserverTestCase):
                         last_user_sync_ts=now,
                         status_msg=None,
                         currently_active=True,
+                        displayname=None,
+                        avatar_url=None,
                     )
                 ]
             )


### PR DESCRIPTION
This PR address two issues:
1. We now send an `m.presence` update on change of profile information (`displayname` and `avatar_url`) per stated in the spec: https://spec.matrix.org/v1.9/client-server-api/#events-on-change-of-profile-information
2. Since presence updates now has more utility beyond representing a user's online/offline status, I have added config flags to selectively enable/disable server-side tracking of users activity. The following config options have been added and take effect when `presence` is enabled:
    a. `sync_presence_tracking` (Default enabled): Determines if the server tracks a user's presence activity when syncing. If disabled, the server will not automatically update the user's presence activity when the sync endpoint is called.
    b. `federation_presence_tracking` (Default enabled): Determines if the server will accept presence EDUs that only contain presence activity updates. If disabled, the server will drop processing EDUs that do not contain updates to the `status_msg`, `displayname`, and `avatar_url` fields.

Note that if `sync_presence_tracking` and/or `federation_presence_tracking` is disabled, client applications an still call the `/presence/{userId}/status` endpoints to update the user's presence.

The motivation for adding the config options is to improve server performance when applications are using presence to track user profile updates, but not user activity status. Combining this along with [MSC4069](https://github.com/matrix-org/matrix-spec-proposals/pull/4069) for disabling profile `m.room.member` event propagation results in more efficient profile update process for client applications to use.

Below are some graphs from [loadtests](https://gitlab.futo.org/load-testing/matrix-locust) that show performance improvements when `sync_presence_tracking` and `federation_presence_tracking` are disabled. The setup is that of 500 users distributed among 2 federated servers in which users only call the `/sync` endpoint (no room updates or messages being sent during the test).

With current default behavior (`presence`, `sync_presence_tracking`, and `federation_presence_tracking` are enabled)

Server 1: (workers enabled, 1 master worker and 1 presence writer)
![image](https://github.com/element-hq/synapse/assets/6564365/18d1f541-c5c0-453c-b8ec-ede98697984f)

Server 2: (workers disabled)
![image](https://github.com/element-hq/synapse/assets/6564365/473cd631-a38e-4767-b4bd-b12f10b50673)

We see that there are CPU usage spikes of up to 50% when processing presence events. When disabling `sync_presence_tracking` and `federation_presence_tracking`, we eliminate CPU usage spikes when processing presence updates from user's sync activity:

Server 1: (workers enabled, 1 master worker and 1 presence writer)
![image](https://github.com/element-hq/synapse/assets/6564365/9b7ab954-e872-4288-a7a9-00f9c1ee2663)

Server 2: (workers disabled)
![image](https://github.com/element-hq/synapse/assets/6564365/cce4ae22-beab-402a-9aba-14b01fc1521c)


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
