### PR TITLE
Stabliize support for MSC3981: recurse /relations

### DIFF
--- a/changelog.d/17023.feature
+++ b/changelog.d/17023.feature
@@ -1,0 +1,1 @@
+Stabilize support for [MSC3981](https://github.com/matrix-org/matrix-spec-proposals/pull/3981): `/relations` recursion.

--- a/changelog.d/17023.feature
+++ b/changelog.d/17023.feature
@@ -1,1 +1,1 @@
-Stabilize support for [MSC3981](https://github.com/matrix-org/matrix-spec-proposals/pull/3981): `/relations` recursion.
+Stabilize support for [MSC3981](https://github.com/matrix-org/matrix-spec-proposals/pull/3981): `/relations` recursion. Contributed by @clokep.

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -393,11 +393,6 @@ class ExperimentalConfig(Config):
         # MSC3967: Do not require UIA when first uploading cross signing keys
         self.msc3967_enabled = experimental.get("msc3967_enabled", False)
 
-        # MSC3981: Recurse relations
-        self.msc3981_recurse_relations = experimental.get(
-            "msc3981_recurse_relations", False
-        )
-
         # MSC3861: Matrix architecture change to delegate authentication via OIDC
         try:
             self.msc3861 = MSC3861(**experimental.get("msc3861", {}))

--- a/synapse/rest/client/relations.py
+++ b/synapse/rest/client/relations.py
@@ -70,12 +70,9 @@ class RelationPaginationServlet(RestServlet):
         pagination_config = await PaginationConfig.from_request(
             self._store, request, default_limit=5, default_dir=Direction.BACKWARDS
         )
-        if self._support_recurse:
-            recurse = parse_boolean(request, "recurse", default=False) or parse_boolean(
-                request, "org.matrix.msc3981.recurse", default=False
-            )
-        else:
-            recurse = False
+        recurse = parse_boolean(request, "recurse", default=False) or parse_boolean(
+            request, "org.matrix.msc3981.recurse", default=False
+        )
 
         # The unstable version of this API returns an extra field for client
         # compatibility, see https://github.com/matrix-org/synapse/issues/12930.

--- a/synapse/rest/client/relations.py
+++ b/synapse/rest/client/relations.py
@@ -55,7 +55,6 @@ class RelationPaginationServlet(RestServlet):
         self.auth = hs.get_auth()
         self._store = hs.get_datastores().main
         self._relations_handler = hs.get_relations_handler()
-        self._support_recurse = hs.config.experimental.msc3981_recurse_relations
 
     async def on_GET(
         self,

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -132,7 +132,8 @@ class VersionsRestServlet(RestServlet):
                     # Adds support for relation-based redactions as per MSC3912.
                     "org.matrix.msc3912": self.config.experimental.msc3912_enabled,
                     # Whether recursively provide relations is supported.
-                    "org.matrix.msc3981": self.config.experimental.msc3981_recurse_relations,
+                    # TODO This is no longer needed once unstable MSC3981 does not need to be supported.
+                    "org.matrix.msc3981": True,
                     # Adds support for deleting account data.
                     "org.matrix.msc3391": self.config.experimental.msc3391_enabled,
                     # Allows clients to inhibit profile update propagation.

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -35,7 +35,6 @@ from synapse.util import Clock
 from tests import unittest
 from tests.server import FakeChannel
 from tests.test_utils.event_injection import inject_event
-from tests.unittest import override_config
 
 
 class BaseRelationsTestCase(unittest.HomeserverTestCase):

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -957,7 +957,6 @@ class RelationPaginationTestCase(BaseRelationsTestCase):
 
 
 class RecursiveRelationTestCase(BaseRelationsTestCase):
-    @override_config({"experimental_features": {"msc3981_recurse_relations": True}})
     def test_recursive_relations(self) -> None:
         """Generate a complex, multi-level relationship tree and query it."""
         # Create a thread with a few messages in it.
@@ -1003,7 +1002,7 @@ class RecursiveRelationTestCase(BaseRelationsTestCase):
         channel = self.make_request(
             "GET",
             f"/_matrix/client/v1/rooms/{self.room}/relations/{self.parent_id}"
-            "?dir=f&limit=20&org.matrix.msc3981.recurse=true",
+            "?dir=f&limit=20&recurse=true",
             access_token=self.user_token,
         )
         self.assertEqual(200, channel.code, channel.json_body)
@@ -1024,7 +1023,6 @@ class RecursiveRelationTestCase(BaseRelationsTestCase):
             ],
         )
 
-    @override_config({"experimental_features": {"msc3981_recurse_relations": True}})
     def test_recursive_relations_with_filter(self) -> None:
         """The event_type and rel_type still apply."""
         # Create a thread with a few messages in it.
@@ -1052,7 +1050,7 @@ class RecursiveRelationTestCase(BaseRelationsTestCase):
         channel = self.make_request(
             "GET",
             f"/_matrix/client/v1/rooms/{self.room}/relations/{self.parent_id}/{RelationTypes.ANNOTATION}"
-            "?dir=f&limit=20&org.matrix.msc3981.recurse=true",
+            "?dir=f&limit=20&recurse=true",
             access_token=self.user_token,
         )
         self.assertEqual(200, channel.code, channel.json_body)
@@ -1065,7 +1063,7 @@ class RecursiveRelationTestCase(BaseRelationsTestCase):
         channel = self.make_request(
             "GET",
             f"/_matrix/client/v1/rooms/{self.room}/relations/{self.parent_id}/{RelationTypes.ANNOTATION}/m.reaction"
-            "?dir=f&limit=20&org.matrix.msc3981.recurse=true",
+            "?dir=f&limit=20&recurse=true",
             access_token=self.user_token,
         )
         self.assertEqual(200, channel.code, channel.json_body)


### PR DESCRIPTION
See [MSC3981](https://github.com/matrix-org/matrix-spec-proposals/pull/3981), this pretty much just removes flags though.

Part of #17021