### PR TITLE
Fix OIDC login regression

### DIFF
--- a/changelog.d/17031.feature
+++ b/changelog.d/17031.feature
@@ -1,0 +1,1 @@
+OIDC: try to JWT decode userinfo response if JSON parsing failed.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -390,6 +390,13 @@ class BaseHttpClient:
                         cooperator=self._cooperator,
                     )
 
+                # Always make sure we add a user agent to the request
+                if headers is None:
+                    headers = Headers()
+
+                if not headers.hasHeader("User-Agent"):
+                    headers.addRawHeader("User-Agent", self.user_agent)
+
                 request_deferred: defer.Deferred = treq.request(
                     method,
                     uri,


### PR DESCRIPTION
Requests may require a User-Agent header, and the change in #16972 accidentally removed it, resulting in requests getting rejected causing login to fail.