### PR TITLE
Fix PR #16677, a parameter was missing in a function call

### DIFF
--- a/changelog.d/17033.bugfix
+++ b/changelog.d/17033.bugfix
@@ -1,1 +1,1 @@
-Fix PR #16677, a parameter was missing in a function call.
+Fix server notice rooms not always being created as unencrypted rooms, even when `encryption_enabled_by_default_for_room_type` is in use (server notices are always unencrypted).

--- a/changelog.d/17033.bugfix
+++ b/changelog.d/17033.bugfix
@@ -1,0 +1,1 @@
+Fix PR #16677, a parameter was missing in a function call.

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -956,6 +956,7 @@ class RoomCreationHandler:
             room_alias=room_alias,
             power_level_content_override=power_level_content_override,
             creator_join_profile=creator_join_profile,
+            ignore_forced_encryption=ignore_forced_encryption,
         )
 
         # we avoid dropping the lock between invites, as otherwise joins can


### PR DESCRIPTION
I made a silly mistake in https://github.com/matrix-org/synapse/pull/16677.

Sorry for that :facepalm: 

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
