### PR TITLE
Fix mypy on latest Twisted release

### DIFF
--- a/synapse/http/proxy.py
+++ b/synapse/http/proxy.py
@@ -262,7 +262,8 @@ class _ProxyResponseBody(protocol.Protocol):
             self._request.finish()
         else:
             # Abort the underlying request since our remote request also failed.
-            self._request.transport.abortConnection()
+            if self._request.channel:
+                self._request.channel.forceAbortClient()
 
 
 class ProxySite(Site):

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -153,9 +153,9 @@ def return_json_error(
     # Only respond with an error response if we haven't already started writing,
     # otherwise lets just kill the connection
     if request.startedWriting:
-        if request.transport:
+        if request.channel:
             try:
-                request.transport.abortConnection()
+                request.channel.forceAbortClient()
             except Exception:
                 # abortConnection throws if the connection is already closed
                 pass

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -150,7 +150,8 @@ class SynapseRequest(Request):
                 self.get_method(),
                 self.get_redacted_uri(),
             )
-            self.transport.abortConnection()
+            if self.channel:
+                self.channel.forceAbortClient()
             return
         super().handleContentChunk(data)
 


### PR DESCRIPTION
`ITransport.abortConnection` isn't a thing, but `HTTPChannel.forceAbortClient` calls it, so lets just use that 