### PR TITLE
Add missing index to `access_tokens` table

### DIFF
--- a/changelog.d/17045.misc
+++ b/changelog.d/17045.misc
@@ -1,0 +1,1 @@
+Improve database performance by adding a missing index to `access_tokens.refresh_token_id`.

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -2266,6 +2266,13 @@ class RegistrationStore(StatsStore, RegistrationBackgroundUpdateStore):
     ):
         super().__init__(database, db_conn, hs)
 
+        self.db_pool.updates.register_background_index_update(
+            update_name="access_tokens_refresh_token_id_idx",
+            index_name="access_tokens_refresh_token_id_idx",
+            table="access_tokens",
+            columns=("refresh_token_id",),
+        )
+
         self._ignore_unknown_session_error = (
             hs.config.server.request_token_inhibit_3pid_errors
         )


### PR DESCRIPTION
This was causing sequential scans when using refresh tokens.