### PR TITLE
Remove `stream_positions` table

### DIFF
--- a/changelog.d/17047.misc
+++ b/changelog.d/17047.misc
@@ -1,0 +1,2 @@
+Remove need for `stream_positions` table.
+

--- a/synapse/storage/databases/main/account_data.py
+++ b/synapse/storage/databases/main/account_data.py
@@ -80,7 +80,6 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
                 db_conn=db_conn,
                 db=database,
                 notifier=hs.get_replication_notifier(),
-                stream_name="account_data",
                 instance_name=self._instance_name,
                 tables=[
                     ("room_account_data", "instance_name", "stream_id"),

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -107,7 +107,6 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
                 db_conn,
                 database,
                 notifier=hs.get_replication_notifier(),
-                stream_name="caches",
                 instance_name=hs.get_instance_name(),
                 tables=[
                     (

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -99,7 +99,6 @@ class DeviceInboxWorkerStore(SQLBaseStore):
                     db_conn=db_conn,
                     db=database,
                     notifier=hs.get_replication_notifier(),
-                    stream_name="to_device",
                     instance_name=self._instance_name,
                     tables=[
                         ("device_inbox", "instance_name", "stream_id"),

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -202,7 +202,6 @@ class EventsWorkerStore(SQLBaseStore):
                 db_conn=db_conn,
                 db=database,
                 notifier=hs.get_replication_notifier(),
-                stream_name="events",
                 instance_name=hs.get_instance_name(),
                 tables=[("events", "instance_name", "stream_ordering")],
                 sequence_name="events_stream_seq",
@@ -212,7 +211,6 @@ class EventsWorkerStore(SQLBaseStore):
                 db_conn=db_conn,
                 db=database,
                 notifier=hs.get_replication_notifier(),
-                stream_name="backfill",
                 instance_name=hs.get_instance_name(),
                 tables=[("events", "instance_name", "stream_ordering")],
                 sequence_name="events_backfill_stream_seq",
@@ -314,7 +312,6 @@ class EventsWorkerStore(SQLBaseStore):
                 db_conn=db_conn,
                 db=database,
                 notifier=hs.get_replication_notifier(),
-                stream_name="un_partial_stated_event_stream",
                 instance_name=hs.get_instance_name(),
                 tables=[
                     ("un_partial_stated_event_stream", "instance_name", "stream_id")

--- a/synapse/storage/databases/main/presence.py
+++ b/synapse/storage/databases/main/presence.py
@@ -96,7 +96,6 @@ class PresenceStore(PresenceBackgroundUpdateStore, CacheInvalidationWorkerStore)
                 db_conn=db_conn,
                 db=database,
                 notifier=hs.get_replication_notifier(),
-                stream_name="presence_stream",
                 instance_name=self._instance_name,
                 tables=[("presence_stream", "instance_name", "stream_id")],
                 sequence_name="presence_stream_sequence",

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -89,7 +89,6 @@ class ReceiptsWorkerStore(SQLBaseStore):
                 db_conn=db_conn,
                 db=database,
                 notifier=hs.get_replication_notifier(),
-                stream_name="receipts",
                 instance_name=self._instance_name,
                 tables=[("receipts_linearized", "instance_name", "stream_id")],
                 sequence_name="receipts_sequence",

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -162,7 +162,6 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
                 db_conn=db_conn,
                 db=database,
                 notifier=hs.get_replication_notifier(),
-                stream_name="un_partial_stated_room_stream",
                 instance_name=self._instance_name,
                 tables=[
                     ("un_partial_stated_room_stream", "instance_name", "stream_id")

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -414,9 +414,7 @@ class MultiWriterIdGenerator(AbstractStreamIdGenerator):
         # We start at 1 here as a) the first generated stream ID will be 2, and
         # b) other parts of the code assume that stream IDs are strictly greater
         # than 0.
-        self._persisted_upto_position = (
-            min(self._current_positions.values()) if self._current_positions else 1
-        )
+        self._persisted_upto_position = 1
         self._known_persisted_positions: List[int] = []
 
         # The maximum stream ID that we have seen been allocated across any writer.

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -443,6 +443,7 @@ class MultiWriterIdGenerator(AbstractStreamIdGenerator):
             self._current_positions.values(), default=1
         )
 
+        # TODO: this needs updating or verifying
         # For the case where `stream_positions` is not up-to-date,
         # `_persisted_upto_position` may be higher.
         self._max_seen_allocated_stream_id = max(

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -407,7 +407,7 @@ class MultiWriterIdGenerator(AbstractStreamIdGenerator):
         # will be gapless; gaps can form when e.g. a transaction was rolled
         # back. This means that sometimes we won't be able to skip forward the
         # position even though everything has been persisted. However, since
-        # gaps should be relatively rare it's still worth doing the book keeping
+        # gaps should be relatively rare it's still worth doing the bookkeeping
         # that allows us to skip forwards when there are gapless runs of
         # positions.
         #
@@ -443,7 +443,7 @@ class MultiWriterIdGenerator(AbstractStreamIdGenerator):
             self._current_positions.values(), default=1
         )
 
-        # For the case where `stream_positions` is not up to date,
+        # For the case where `stream_positions` is not up-to-date,
         # `_persisted_upto_position` may be higher.
         self._max_seen_allocated_stream_id = max(
             self._max_seen_allocated_stream_id, self._persisted_upto_position
@@ -455,7 +455,7 @@ class MultiWriterIdGenerator(AbstractStreamIdGenerator):
 
         if not writers:
             # If there have been no explicit writers given then any instance can
-            # write to the stream. In which case, let's pre-seed our own
+            # write to the stream. In which case, lets pre-seed our own
             # position with the current minimum.
             self._current_positions[self._instance_name] = self._persisted_upto_position
 
@@ -548,7 +548,7 @@ class MultiWriterIdGenerator(AbstractStreamIdGenerator):
                 }
                 cur.execute(sql, (min_stream_id * self._return_factor,))
 
-                # Cast safety: this corresponds to the types returned by the query above.
+                # Cast safety: this corresponds to the types returned by the query above
                 rows.extend(cast(Iterable[Tuple[str, int]], cur))
 
             with self._lock:

--- a/tests/storage/test_id_generators.py
+++ b/tests/storage/test_id_generators.py
@@ -205,7 +205,6 @@ class MultiWriterIdGeneratorTestCase(HomeserverTestCase):
                 conn,
                 self.db_pool,
                 notifier=self.hs.get_replication_notifier(),
-                stream_name="test_stream",
                 instance_name=instance_name,
                 tables=[("foobar", "instance_name", "stream_id")],
                 sequence_name="foobar_seq",
@@ -752,7 +751,6 @@ class BackwardsMultiWriterIdGeneratorTestCase(HomeserverTestCase):
                 conn,
                 self.db_pool,
                 notifier=self.hs.get_replication_notifier(),
-                stream_name="test_stream",
                 instance_name=instance_name,
                 tables=[("foobar", "instance_name", "stream_id")],
                 sequence_name="foobar_seq",
@@ -889,7 +887,6 @@ class MultiTableMultiWriterIdGeneratorTestCase(HomeserverTestCase):
                 conn,
                 self.db_pool,
                 notifier=self.hs.get_replication_notifier(),
-                stream_name="test_stream",
                 instance_name=instance_name,
                 tables=[
                     ("foobar1", "instance_name", "stream_id"),

--- a/tests/storage/test_id_generators.py
+++ b/tests/storage/test_id_generators.py
@@ -623,14 +623,8 @@ class MultiWriterIdGeneratorTestCase(HomeserverTestCase):
         self.get_success(_get_next_async())
         self.assertEqual(id_gen_3.get_persisted_upto_position(), 6)
 
-        # If we add back the old "first" then we shouldn't see the persisted up
-        # to position revert back to 3.
-        # TODO: I postulate that it actually should be a 3 and not a 6, as "first"
-        #  hasn't actually written anything since it's initial 3 reflecting it's minimum
-        #  persisted value.
-        #  I assert that the first instance created in this test is proof, since it's
-        #  instance name is neither of the writers named and is therefore a 'reader' and
-        #  not a 'writer', just as this 5th instance is.
+        # If we add back the old "first" then we should see the persisted up
+        # to position revert back to 3, as this writer hasn't written anything since.
         id_gen_5 = self._create_id_generator("five", writers=["first", "third"])
         self.assertEqual(id_gen_5.get_persisted_upto_position(), 3)
         self.assertEqual(id_gen_5.get_current_token_for_writer("first"), 3)

--- a/tests/storage/test_id_generators.py
+++ b/tests/storage/test_id_generators.py
@@ -897,17 +897,14 @@ class MultiTableMultiWriterIdGeneratorTestCase(HomeserverTestCase):
         self.get_success(self.db_pool.runInteraction("_insert_rows", _insert))
 
     def test_load_existing_stream(self) -> None:
-        """Test creating ID gens with multiple tables that have rows from after
-        the position in `stream_positions` table.
-        """
+        """Test creating ID gens with multiple tables load positions correctly."""
         self._insert_rows("foobar1", "first", 3)
-        self._insert_rows("foobar2", "second", 3)
-        self._insert_rows("foobar2", "second", 1)
+        self._insert_rows("foobar2", "second", 4)
 
         first_id_gen = self._create_id_generator("first", writers=["first", "second"])
         second_id_gen = self._create_id_generator("second", writers=["first", "second"])
 
-        self.assertEqual(first_id_gen.get_positions(), {"first": 3, "second": 6})
+        self.assertEqual(first_id_gen.get_positions(), {"first": 3, "second": 7})
         self.assertEqual(first_id_gen.get_current_token_for_writer("first"), 7)
         self.assertEqual(first_id_gen.get_current_token_for_writer("second"), 7)
         self.assertEqual(first_id_gen.get_persisted_upto_position(), 7)


### PR DESCRIPTION
The `stream_positions` table is used to track what sequence number(as a stream id) has been last persisted into the database, and only for Postgres. Updating this table seems to be done often, but is only read from during startup. As all the data that is in that table can be discovered in each stream's actual `tables`, just use that at startup and don't bother with this extra table.

After start-up, this data is maintained in memory the same way it is today.

The motivator for this change:
```log
2024-02-22 16:24:01.454 CST [127] LOG:  duration: 1836.864 ms  plan:
        Query Text:
                    INSERT INTO stream_positions (stream_name, instance_name, stream_id)
                    VALUES ('presence_stream', 'presence1', (87199721))
                    ON CONFLICT (stream_name, instance_name)
                    DO UPDATE SET
                        stream_id = EXCLUDED.stream_id
                    WHERE stream_positions.stream_id < EXCLUDED.stream_id

        Insert on stream_positions  (cost=0.00..0.01 rows=0 width=0) (actual time=1836.861..1836.862 rows=0 loops=1)
          Conflict Resolution: UPDATE
          Conflict Arbiter Indexes: stream_positions_idx
          Conflict Filter: (stream_positions.stream_id < excluded.stream_id)
          Tuples Inserted: 0
          Conflicting Tuples: 1
          ->  Result  (cost=0.00..0.01 rows=1 width=72) (actual time=0.002..0.003 rows=1 loops=1)
2024-02-22 16:24:01.538 CST [148] LOG:  process 148 still waiting for ExclusiveLock on tuple (0,110) of relation 20495 of database 19796 after 1000.080 ms
2024-02-22 16:24:01.538 CST [148] DETAIL:  Process holding the lock: 149. Wait queue: 151, 97, 150, 148, 124.
2024-02-22 16:24:01.538 CST [148] STATEMENT:
                    INSERT INTO stream_positions (stream_name, instance_name, stream_id)
                    VALUES ('presence_stream', 'presence1', (87199723))
                    ON CONFLICT (stream_name, instance_name)
                    DO UPDATE SET
                        stream_id = EXCLUDED.stream_id
                    WHERE stream_positions.stream_id < EXCLUDED.stream_id

2024-02-22 16:24:01.883 CST [127] LOG:  duration: 2265.752 ms  statement:
                    INSERT INTO stream_positions (stream_name, instance_name, stream_id)
                    VALUES ('presence_stream', 'presence1', (87199721))
                    ON CONFLICT (stream_name, instance_name)
                    DO UPDATE SET
                        stream_id = EXCLUDED.stream_id
                    WHERE stream_positions.stream_id < EXCLUDED.stream_id
```
Let's just...not do this 🤷‍♂️ 

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
