### PR TITLE
Reduce DB usage when backpaginating

### DIFF
--- a/changelog.d/17055.misc
+++ b/changelog.d/17055.misc
@@ -1,0 +1,1 @@
+Reduce database usage when backpaginating.


### PR DESCRIPTION
In certain cases going from a stream token to a topological token can be expensive (as it all rows in the room above the stream ordering), so we refactor things so we do that calculation less.