### PR TITLE
Fixups to #17064

### DIFF
--- a/changelog.d/17065.bugfix
+++ b/changelog.d/17065.bugfix
@@ -1,0 +1,1 @@
+Fix various long-standing bugs which could cause incorrect state to be returned from `/sync` in certain situations.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1272,8 +1272,11 @@ class SyncHandler:
             for e in batch.events[1:]:
                 if e.prev_event_ids() != [prev_event_id]:
                     break
+                prev_event_id = e.event_id
             else:
                 is_linear_timeline = True
+        else:
+            is_linear_timeline = True
 
         if is_linear_timeline and not batch.limited:
             state_ids: StateMap[str] = {}


### PR DESCRIPTION
Forget a line, and an empty batch is trivially linear.

c.f. #17064