### PR TITLE
Redact membership events if the user requested erasure upon deactivating

### DIFF
--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -22,14 +22,12 @@ import itertools
 import logging
 from typing import TYPE_CHECKING, Optional
 
-from synapse.api.constants import Membership, EventTypes, Direction
+from synapse.api.constants import Membership, EventTypes
 from synapse.api.errors import SynapseError
 from synapse.handlers.device import DeviceHandler
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.types import Codes, Requester, UserID, create_requester
-from synapse.api.filtering import Filter
-from immutabledict import immutabledict
-from synapse.streams.config import PaginationConfig
+from synapse.events import EventBase
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
@@ -51,8 +49,6 @@ class DeactivateAccountHandler:
         self.user_directory_handler = hs.get_user_directory_handler()
         self._server_name = hs.hostname
         self._third_party_rules = hs.get_module_api_callbacks().third_party_event_rules
-        # Used to get
-        self._pagination_handler = hs.get_pagination_handler()
         self._event_creation_handler = hs.get_event_creation_handler()
 
         # Flag that indicates whether the process to part users from rooms is running
@@ -266,45 +262,35 @@ class DeactivateAccountHandler:
         """Causes the given user_id to leave all the rooms they're joined to"""
         user = UserID.from_string(user_id)
 
-        # Get all membership events for this user
         rooms_for_user = await self.store.get_rooms_for_user(user_id)
-
-        filter = Filter(self.hs, {})
-        filter.senders = [user_id]
-        filter.types = [EventTypes.Member]
-        filter.limit = 1000
-
-        pagination = PaginationConfig(direction=Direction.FORWARDS, limit=1000, from_token=None, to_token=None)
-
-        logger.info("EventFilter: %r", filter)
-        requester = create_requester(user_id)
+        requester = create_requester(user, authenticated_entity=self._server_name)
+        should_erase = await self.store.is_user_erased(user_id)
 
         for room_id in rooms_for_user:
-            logger.info("User parter parting %r from %r", user_id, room_id)
-
-            filter.rooms = [room_id]
-            # TODO: Use something else to get the membership events
-            events = await self._pagination_handler.get_messages(requester=requester, room_id=room_id, event_filter=filter, use_admin_priviledge=False, pagin_config=pagination)
-
-            # TODO: Check if there are more events
-            for event in events["chunk"]:
-                has_profile = "displayname" in event["content"] or "avatar_url" in event["content"]
-                if has_profile and "redacted_because" not in event["unsigned"]:
-                    event_dict = {
-                        "type": EventTypes.Redaction,
-                        "content": {
-                            "redacts": event["event_id"], # room version 11
-                        },
-                        "redacts": event["event_id"], # earlier room version
-                        "room_id": event["room_id"],
-                        "sender": requester.user.to_string(),
-                    }
-                    logger.info("sending redaction event")
-                    await self._event_creation_handler.create_event(requester, event_dict)
-
             try:
+                # Before parting the user, redact all membership events if requested
+                if should_erase:
+                    event_ids = await self.store.get_membership_event_ids_for_user(
+                        user_id, room_id)
+                    events: list[EventBase] = await self.store.get_events_as_list(
+                        event_ids)
+                    for event in events:
+                        has_profile = "displayname" in event.content or "avatar_url" in event.content
+                        if has_profile and "redacted_because" not in event.unsigned:
+                            event_dict = {
+                                "type": EventTypes.Redaction,
+                                "room_id": event["room_id"],
+                                "sender": requester.user.to_string(),
+                            }
+                            if event.room_version.updated_redaction_rules:
+                                event_dict["content"]["redacts"] = event.event_id
+                            else:
+                                event_dict["redacts"] = event.event_id
+                            await self._event_creation_handler.create_and_send_nonmember_event(
+                                requester, event_dict, ratelimit=False)
+
                 await self._room_member_handler.update_membership(
-                    create_requester(user, authenticated_entity=self._server_name),
+                    requester,
                     user,
                     room_id,
                     "leave",

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -22,12 +22,12 @@ import itertools
 import logging
 from typing import TYPE_CHECKING, Optional
 
-from synapse.api.constants import Membership, EventTypes
+from synapse.api.constants import EventTypes, Membership
 from synapse.api.errors import SynapseError
+from synapse.events import EventBase
 from synapse.handlers.device import DeviceHandler
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.types import Codes, Requester, UserID, create_requester
-from synapse.events import EventBase
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
@@ -271,11 +271,16 @@ class DeactivateAccountHandler:
                 # Before parting the user, redact all membership events if requested
                 if should_erase:
                     event_ids = await self.store.get_membership_event_ids_for_user(
-                        user_id, room_id)
+                        user_id, room_id
+                    )
                     events: list[EventBase] = await self.store.get_events_as_list(
-                        event_ids)
+                        event_ids
+                    )
                     for event in events:
-                        has_profile = "displayname" in event.content or "avatar_url" in event.content
+                        has_profile = (
+                            "displayname" in event.content
+                            or "avatar_url" in event.content
+                        )
                         if has_profile and "redacted_because" not in event.unsigned:
                             event_dict = {
                                 "type": EventTypes.Redaction,
@@ -286,8 +291,9 @@ class DeactivateAccountHandler:
                                 event_dict["content"]["redacts"] = event.event_id
                             else:
                                 event_dict["redacts"] = event.event_id
-                            await self._event_creation_handler.create_and_send_nonmember_event(
-                                requester, event_dict, ratelimit=False)
+                            await self._event_creation_handler.create_event(
+                                requester, event_dict, ratelimit=False
+                            )
 
                 await self._room_member_handler.update_membership(
                     requester,

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -1234,6 +1234,26 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
 
         return set(room_ids)
 
+    async def get_membership_event_ids_for_user(self, user_id: str, room_id: str) -> Set[str]:
+        """Get all event_ids for the given user and room.
+
+        Args:
+            user_id: The user ID to get the event IDs for.
+            room_id: The room ID to look up events for.
+
+        Returns:
+            Set of event IDs
+        """
+
+        event_ids = await self.db_pool.simple_select_onecol(
+            table="room_memberships",
+            keyvalues={"user_id": user_id, "room_id": room_id},
+            retcol="event_id",
+            desc="get_membership_event_ids_for_user"
+        )
+
+        return set(event_ids)
+
     @cached(max_entries=5000)
     async def _get_membership_from_event_id(
         self, member_event_id: str

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -1234,7 +1234,9 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
 
         return set(room_ids)
 
-    async def get_membership_event_ids_for_user(self, user_id: str, room_id: str) -> Set[str]:
+    async def get_membership_event_ids_for_user(
+        self, user_id: str, room_id: str
+    ) -> Set[str]:
         """Get all event_ids for the given user and room.
 
         Args:
@@ -1249,7 +1251,7 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
             table="room_memberships",
             keyvalues={"user_id": user_id, "room_id": room_id},
             retcol="event_id",
-            desc="get_membership_event_ids_for_user"
+            desc="get_membership_event_ids_for_user",
         )
 
         return set(event_ids)


### PR DESCRIPTION
Fixes #15355 by redacting all membership events before leaving rooms.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
