### PR TITLE
synapse complement image: hardcode enabling msc3266

### DIFF
--- a/changelog.d/17105.misc
+++ b/changelog.d/17105.misc
@@ -1,0 +1,1 @@
+Enabled MSC3266 by default in the synapse complement image.

--- a/docker/complement/conf/workers-shared-extra.yaml.j2
+++ b/docker/complement/conf/workers-shared-extra.yaml.j2
@@ -102,6 +102,8 @@ experimental_features:
   msc3874_enabled: true
   # no UIA for x-signing upload for the first time
   msc3967_enabled: true
+  # Expose a room summary for public rooms
+  msc3266_enabled: true
 
   msc4115_membership_on_events: true
 


### PR DESCRIPTION
This is an alternative to https://github.com/matrix-org/matrix-rust-sdk/issues/3340 where we don't need to change our CI setup too much in the Rust SDK repository, and still can test MSC3266.