### PR TITLE
Add type annotation to `visited_chains`

### DIFF
--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -2454,7 +2454,7 @@ class _LinkMap:
             return target_seq <= src_seq
 
         # We have to graph traverse the links to check for indirect paths.
-        visited_chains = collections.Counter()
+        visited_chains: Dict[int, int] = collections.Counter()
         search = [(src_chain, src_seq)]
         while search:
             chain, seq = search.pop()


### PR DESCRIPTION
This should fix CI on `develop`. Broke in https://github.com/element-hq/synapse/commit/0fe9e1f7dafa80f3e02762f7ae75cefee5b3316c, presumably due to a `mypy` dependency upgrade.