### PR TITLE
Enable complement tests for MSC4115 support

### DIFF
--- a/changelog.d/17137.feature
+++ b/changelog.d/17137.feature
@@ -1,0 +1,1 @@
+Add support for MSC4115 (membership metadata on events).

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -214,7 +214,16 @@ fi
 
 extra_test_args=()
 
-test_packages="./tests/csapi ./tests ./tests/msc3874 ./tests/msc3890 ./tests/msc3391 ./tests/msc3930 ./tests/msc3902 ./tests/msc3967"
+test_packages=(
+    ./tests/csapi
+    ./tests
+    ./tests/msc3874
+    ./tests/msc3890
+    ./tests/msc3391
+    ./tests/msc3930
+    ./tests/msc3902
+    ./tests/msc3967
+)
 
 # Enable dirty runs, so tests will reuse the same container where possible.
 # This significantly speeds up tests, but increases the possibility of test pollution.
@@ -278,7 +287,7 @@ fi
 export PASS_SYNAPSE_LOG_TESTING=1
 
 # Run the tests!
-echo "Images built; running complement with ${extra_test_args[@]} $@ $test_packages"
+echo "Images built; running complement with ${extra_test_args[@]} $@ ${test_packages[@]}"
 cd "$COMPLEMENT_DIR"
 
-go test -v -tags "synapse_blacklist" -count=1 "${extra_test_args[@]}" "$@" $test_packages
+go test -v -tags "synapse_blacklist" -count=1 "${extra_test_args[@]}" "$@" "${test_packages[@]}"

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -223,6 +223,7 @@ test_packages=(
     ./tests/msc3930
     ./tests/msc3902
     ./tests/msc3967
+    ./tests/msc4115
 )
 
 # Enable dirty runs, so tests will reuse the same container where possible.


### PR DESCRIPTION
Follow-up to #17137 and https://github.com/matrix-org/complement/pull/722