### PR TITLE
Add note about external_ids for User Admin API in documentation

### DIFF
--- a/changelog.d/17139.doc
+++ b/changelog.d/17139.doc
@@ -1,1 +1,1 @@
-Update User Admin API with note about prefixing OIDC external_id providers
+Update User Admin API with note about prefixing OIDC external_id providers.

--- a/changelog.d/17139.doc
+++ b/changelog.d/17139.doc
@@ -1,0 +1,1 @@
+Update User Admin API with note about prefixing OIDC external_id providers

--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -141,8 +141,8 @@ Body parameters:
   provider for SSO (Single sign-on). More details are in the configuration manual under the
   sections [sso](../usage/configuration/config_documentation.md#sso) and [oidc_providers](../usage/configuration/config_documentation.md#oidc_providers).
   - `auth_provider` - **string**, required. The unique, internal ID of the external identity provider.
-    The same as `idp_id` from the homeserver configuration. Note that no error is raised if the
-    provided value is not in the homeserver configuration.
+    The same as `idp_id` from the homeserver configuration. If using OIDC, this value should be prefixed
+    with `oidc-`. Note that no error is raised if the provided value is not in the homeserver configuration.
   - `external_id` - **string**, required. An identifier for the user in the external identity provider.
     When the user logs in to the identity provider, this must be the unique ID that they map to.
 - `admin` - **bool**, optional, defaults to `false`. Whether the user is a homeserver administrator,


### PR DESCRIPTION
If the login method is OIDC then the external id provider must be prefixed with 'oidc-', which was not mentioned before.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
