### PR TITLE
Optional whitespace support in Authorization (#1350)

### DIFF
--- a/changelog.d/17145.bugfix
+++ b/changelog.d/17145.bugfix
@@ -1,1 +1,1 @@
-Add support for optional whitespace around Authorization param commas
+Add support for optional whitespace around the Federation API's `Authorization` header's parameter commas.

--- a/changelog.d/17145.bugfix
+++ b/changelog.d/17145.bugfix
@@ -1,0 +1,1 @@
+Add support for optional whitespace around Authorization param commas

--- a/synapse/federation/transport/server/_base.py
+++ b/synapse/federation/transport/server/_base.py
@@ -180,7 +180,11 @@ def _parse_auth_header(header_bytes: bytes) -> Tuple[str, str, str, Optional[str
     """
     try:
         header_str = header_bytes.decode("utf-8")
-        params = re.split(" +", header_str)[1].split(",")
+        space_or_tab = "[ \t]"
+        params = re.split(
+            rf"{space_or_tab}*,{space_or_tab}*",
+            re.split(r"^X-Matrix +", header_str, maxsplit=1)[1],
+        )
         param_dict: Dict[str, str] = {
             k.lower(): v for k, v in [param.split("=", maxsplit=1) for param in params]
         }

--- a/tests/federation/transport/server/test__base.py
+++ b/tests/federation/transport/server/test__base.py
@@ -147,3 +147,10 @@ class BaseFederationAuthorizationTests(unittest.TestCase):
             ),
             ("foo", "ed25519:1", "sig", "bar"),
         )
+        # test that "optional whitespace(s)" (space and tabulation) are allowed between comma-separated auth-param components
+        self.assertEqual(
+            _parse_auth_header(
+                b'X-Matrix origin=foo , key="ed25519:1",  sig="sig",	destination="bar",		extra_field=ignored'
+            ),
+            ("foo", "ed25519:1", "sig", "bar"),
+        )


### PR DESCRIPTION
Fix #1350 by adding support for optional whitespace around `,`.
 
Additionally, 
- used `\s` which is more lax than the spec since `OWS` is defined as `*( SP / HTAB )`
 - Added the `X-Matrix` part to the regex ` ^X-Matrix\s+`  to make more clear what it's doing. Added it as insensitive to lower probability of issues, but since it was not checking the `X-Matrix` part before it could create issues. 
 - On the whitespace handling of this part replaced ` +` with `\s+` since the parsing appear to be more lax than the spec (which if I understand correctly mandate only one space, cf `1*SP`)

Will of course remove it if you believe it should not be included.