### PR TITLE
Note preset behaviour in `autocreate_auto_join_room_preset` docs

### DIFF
--- a/changelog.d/17150.doc
+++ b/changelog.d/17150.doc
@@ -1,0 +1,1 @@
+Clarify the state of the created room when using the `autocreate_auto_join_room_preset` config option.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -2591,6 +2591,11 @@ Possible values for this option are:
 * "trusted_private_chat": an invitation is required to join this room and the invitee is
   assigned a power level of 100 upon joining the room.
 
+Each preset will set up a room in the same manner as if it were provided as the `preset` parameter when
+calling the
+[`POST /_matrix/client/v3/createRoom`](https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3createroom)
+Client-Server API endpoint.
+
 If a value of "private_chat" or "trusted_private_chat" is used then
 `auto_join_mxid_localpart` must also be configured.
 


### PR DESCRIPTION
Link to the `/createRoom` preset docs and note how they behave in the same manner when providing the preset name to the `autocreate_auto_join_room_preset` config option.

Off the back of an internal conversation asking for clarity around this behaviour.