### PR TITLE
Fix bug where `StreamChangeCache` would not respect cache factors

### DIFF
--- a/changelog.d/17152.bugfix
+++ b/changelog.d/17152.bugfix
@@ -1,0 +1,1 @@
+Fix bug where `StreamChangeCache` would not respect configured cache factors.

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -115,7 +115,7 @@ class StreamChangeCache:
         """
         new_size = math.floor(self._original_max_size * factor)
         if new_size != self._max_size:
-            self.max_size = new_size
+            self._max_size = new_size
             self._evict()
             return True
         return False


### PR DESCRIPTION
Annoyingly mypy didn't pick up this typo.