### PR TITLE
Log exceptions when failing to auto-join new user according to the `auto_join_rooms` option.

### DIFF
--- a/changelog.d/17176.misc
+++ b/changelog.d/17176.misc
@@ -1,0 +1,1 @@
+Log exceptions when failing to auto-join new user according to the `auto_join_rooms` option.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -590,7 +590,7 @@ class RegistrationHandler:
                 # moving away from bare excepts is a good thing to do.
                 logger.error("Failed to join new user to %r: %r", r, e)
             except Exception as e:
-                logger.error("Failed to join new user to %r: %r", r, e)
+                logger.error("Failed to join new user to %r: %r", r, e, exc_info=True)
 
     async def _auto_join_rooms(self, user_id: str) -> None:
         """Automatically joins users to auto join rooms - creating the room in the first place


### PR DESCRIPTION
Would have been useful for tracking down #16878.

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Add exception logging when failing to auto-join new user 

</li>
</ol>
