### PR TITLE
Fix bug with creating public rooms on workers

### DIFF
--- a/changelog.d/17177.bugfix
+++ b/changelog.d/17177.bugfix
@@ -1,0 +1,1 @@
+Fix bug where disabling room publication prevented public rooms being created on workers.

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -21,13 +21,11 @@
 #
 
 import logging
-from abc import abstractmethod
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Any,
-    Awaitable,
     Collection,
     Dict,
     List,


### PR DESCRIPTION
If room publication is disabled then creating public rooms on workers would not work.

Introduced in #16811.

Stack trace:

```
AttributeError: 'GenericWorkerStore' object has no attribute 'set_room_is_public'
  File "synapse/http/server.py", line 332, in _async_render_wrapper
    callback_return = await self._async_render(request)
  File "synapse/http/server.py", line 544, in _async_render
    callback_return = await raw_callback_return
  File "synapse/rest/client/room.py", line 171, in on_POST
    return await self._do(request, requester)
  File "synapse/rest/client/room.py", line 176, in _do
    room_id, _, _ = await self._room_creation_handler.create_room(
  File "synapse/handlers/room.py", line 921, in create_room
    await self.store.set_room_is_public(room_id, False)
```