### PR TITLE
Reduce pauses on large device list changes

### DIFF
--- a/changelog.d/17192.misc
+++ b/changelog.d/17192.misc
@@ -1,0 +1,1 @@
+Improve performance by fixing a reactor pause.


### PR DESCRIPTION
For large accounts waking up all the relevant notifier streams can cause pauses of the reactor.