### PR TITLE
Fix request path for `federation_whitelist_endpoint_enabled` option in documentation

### DIFF
--- a/changelog.d/17199.feature
+++ b/changelog.d/17199.feature
@@ -1,0 +1,1 @@
+Add a feature that allows clients to query the configured federation whitelist. Disabled by default.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1236,7 +1236,7 @@ federation_domain_whitelist:
 
 Enables an endpoint for fetching the federation whitelist config.
 
-The request method and path is `GET /_synapse/client/config/federation_whitelist`, and the
+The request method and path is `GET /_synapse/client/v1/config/federation_whitelist`, and the
 response format is:
 
 ```json


### PR DESCRIPTION
This commit fixes the request path in the `federation_whitelist_endpoint_enabled` config option.

The path was changed towards the tail end of development in https://github.com/element-hq/synapse/pull/16848. Thus updating it in the documentation was missed.