### PR TITLE
Removed `request_key` from the `SyncConfig` (moved outside as its own function parameter)

### DIFF
--- a/changelog.d/17200.misc
+++ b/changelog.d/17200.misc
@@ -1,0 +1,1 @@
+Prepare sync handler to be able to return different sync responses (`SyncVersion`).

--- a/changelog.d/17201.misc
+++ b/changelog.d/17201.misc
@@ -1,0 +1,1 @@
+Organize the sync cache key parameter outside of the sync config (separate concerns).

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -135,7 +135,6 @@ class SyncConfig:
     user: UserID
     filter_collection: FilterCollection
     is_guest: bool
-    request_key: SyncRequestKey
     device_id: Optional[str]
 
 
@@ -328,6 +327,7 @@ class SyncHandler:
         requester: Requester,
         sync_config: SyncConfig,
         sync_version: SyncVersion,
+        request_key: SyncRequestKey,
         since_token: Optional[StreamToken] = None,
         timeout: int = 0,
         full_state: bool = False,
@@ -340,10 +340,10 @@ class SyncHandler:
             requester: The user requesting the sync response.
             sync_config: Config/info necessary to process the sync request.
             sync_version: Determines what kind of sync response to generate.
+            request_key: The key to use for caching the response.
             since_token: The point in the stream to sync from.
             timeout: How long to wait for new data to arrive before giving up.
             full_state: Whether to return the full state for each room.
-
         Returns:
             When `SyncVersion.SYNC_V2`, returns a full `SyncResult`.
         """
@@ -354,7 +354,7 @@ class SyncHandler:
         await self.auth_blocking.check_auth_blocking(requester=requester)
 
         res = await self.response_cache.wrap(
-            sync_config.request_key,
+            request_key,
             self._wait_for_sync_for_user,
             sync_config,
             sync_version,

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -335,6 +335,17 @@ class SyncHandler:
         """Get the sync for a client if we have new data for it now. Otherwise
         wait for new data to arrive on the server. If the timeout expires, then
         return an empty sync result.
+
+        Args:
+            requester: The user requesting the sync response.
+            sync_config: Config/info necessary to process the sync request.
+            sync_version: Determines what kind of sync response to generate.
+            since_token: The point in the stream to sync from.
+            timeout: How long to wait for new data to arrive before giving up.
+            full_state: Whether to return the full state for each room.
+
+        Returns:
+            When `SyncVersion.SYNC_V2`, returns a full `SyncResult`.
         """
         # If the user is not part of the mau group, then check that limits have
         # not been exceeded (if not part of the group by this point, almost certain
@@ -457,6 +468,7 @@ class SyncHandler:
         This is a wrapper around `generate_sync_result` which starts an open tracing
         span to track the sync. See `generate_sync_result` for the next part of your
         indoctrination.
+
         Args:
             sync_config: Config/info necessary to process the sync request.
             sync_version: Determines what kind of sync response to generate.

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -210,7 +210,6 @@ class SyncRestServlet(RestServlet):
             user=user,
             filter_collection=filter_collection,
             is_guest=requester.is_guest,
-            request_key=request_key,
             device_id=device_id,
         )
 
@@ -234,6 +233,7 @@ class SyncRestServlet(RestServlet):
                 requester,
                 sync_config,
                 SyncVersion.SYNC_V2,
+                request_key,
                 since_token=since_token,
                 timeout=timeout,
                 full_state=full_state,

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -40,6 +40,7 @@ from synapse.handlers.sync import (
     KnockedSyncResult,
     SyncConfig,
     SyncResult,
+    SyncVersion,
 )
 from synapse.http.server import HttpServer
 from synapse.http.servlet import RestServlet, parse_boolean, parse_integer, parse_string
@@ -232,6 +233,7 @@ class SyncRestServlet(RestServlet):
             sync_result = await self.sync_handler.wait_for_sync_for_user(
                 requester,
                 sync_config,
+                SyncVersion.SYNC_V2,
                 since_token=since_token,
                 timeout=timeout,
                 full_state=full_state,

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -36,7 +36,7 @@ from synapse.server import HomeServer
 from synapse.types import JsonDict, StreamToken, create_requester
 from synapse.util import Clock
 
-from tests.handlers.test_sync import generate_sync_config
+from tests.handlers.test_sync import SyncVersion, generate_sync_config
 from tests.unittest import (
     FederatingHomeserverTestCase,
     HomeserverTestCase,
@@ -521,7 +521,7 @@ def sync_presence(
     sync_config = generate_sync_config(requester.user.to_string())
     sync_result = testcase.get_success(
         testcase.hs.get_sync_handler().wait_for_sync_for_user(
-            requester, sync_config, since_token
+            requester, sync_config, SyncVersion.SYNC_V2, since_token
         )
     )
 

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -36,7 +36,7 @@ from synapse.server import HomeServer
 from synapse.types import JsonDict, StreamToken, create_requester
 from synapse.util import Clock
 
-from tests.handlers.test_sync import SyncVersion, generate_sync_config
+from tests.handlers.test_sync import SyncRequestKey, SyncVersion, generate_sync_config
 from tests.unittest import (
     FederatingHomeserverTestCase,
     HomeserverTestCase,
@@ -498,6 +498,15 @@ def send_presence_update(
     return channel.json_body
 
 
+_request_key = 0
+
+
+def generate_request_key() -> SyncRequestKey:
+    global _request_key
+    _request_key += 1
+    return ("request_key", _request_key)
+
+
 def sync_presence(
     testcase: HomeserverTestCase,
     user_id: str,
@@ -521,7 +530,11 @@ def sync_presence(
     sync_config = generate_sync_config(requester.user.to_string())
     sync_result = testcase.get_success(
         testcase.hs.get_sync_handler().wait_for_sync_for_user(
-            requester, sync_config, SyncVersion.SYNC_V2, since_token
+            requester,
+            sync_config,
+            SyncVersion.SYNC_V2,
+            generate_request_key(),
+            since_token,
         )
     )
 

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -24,7 +24,7 @@ from parameterized import parameterized
 
 from twisted.test.proto_helpers import MemoryReactor
 
-from synapse.api.constants import EventTypes, JoinRules
+from synapse.api.constants import AccountDataTypes, EventTypes, JoinRules
 from synapse.api.errors import Codes, ResourceLimitError
 from synapse.api.filtering import FilterCollection, Filtering
 from synapse.api.room_versions import RoomVersion, RoomVersions
@@ -928,7 +928,33 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
             priv_event_ids.append(event.event_id)
 
         self.assertIn(private_call_event.event_id, priv_event_ids)
+   
+    def test_push_rules_with_bad_account_data(self) -> None:
+        """Some old accounts have managed to set a `m.push_rules` account data,
+        which we should ignore in /sync response.
+        """
 
+        user = self.register_user("alice", "password")
+
+        # Insert the bad account data.
+        self.get_success(
+            self.store.add_account_data_for_user(user, AccountDataTypes.PUSH_RULES, {})
+        )
+
+        sync_result: SyncResult = self.get_success(
+            self.sync_handler.wait_for_sync_for_user(
+                create_requester(user), generate_sync_config(user)
+            )
+        )
+
+        for account_dict in sync_result.account_data:
+            if account_dict["type"] == AccountDataTypes.PUSH_RULES:
+                # We should have lots of push rules here, rather than the bad
+                # empty data.
+                self.assertNotEqual(account_dict["content"], {})
+                return
+
+        self.fail("No push rules found")
 
 def generate_sync_config(
     user_id: str,

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -928,7 +928,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
             priv_event_ids.append(event.event_id)
 
         self.assertIn(private_call_event.event_id, priv_event_ids)
-   
+
     def test_push_rules_with_bad_account_data(self) -> None:
         """Some old accounts have managed to set a `m.push_rules` account data,
         which we should ignore in /sync response.
@@ -943,7 +943,10 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
 
         sync_result: SyncResult = self.get_success(
             self.sync_handler.wait_for_sync_for_user(
-                create_requester(user), generate_sync_config(user)
+                create_requester(user),
+                generate_sync_config(user),
+                sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
 
@@ -955,6 +958,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 return
 
         self.fail("No push rules found")
+
 
 def generate_sync_config(
     user_id: str,

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -31,7 +31,7 @@ from synapse.api.room_versions import RoomVersion, RoomVersions
 from synapse.events import EventBase
 from synapse.events.snapshot import EventContext
 from synapse.federation.federation_base import event_from_pdu_json
-from synapse.handlers.sync import SyncConfig, SyncResult, SyncVersion
+from synapse.handlers.sync import SyncConfig, SyncRequestKey, SyncResult, SyncVersion
 from synapse.rest import admin
 from synapse.rest.client import knock, login, room
 from synapse.server import HomeServer
@@ -40,6 +40,14 @@ from synapse.util import Clock
 
 import tests.unittest
 import tests.utils
+
+_request_key = 0
+
+
+def generate_request_key() -> SyncRequestKey:
+    global _request_key
+    _request_key += 1
+    return ("request_key", _request_key)
 
 
 class SyncTestCase(tests.unittest.HomeserverTestCase):
@@ -77,6 +85,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 requester,
                 sync_config,
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
 
@@ -87,6 +96,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 requester,
                 sync_config,
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             ),
             ResourceLimitError,
         )
@@ -102,6 +112,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 requester,
                 sync_config,
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             ),
             ResourceLimitError,
         )
@@ -124,6 +135,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 requester,
                 sync_config=generate_sync_config(user, device_id="dev"),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
 
@@ -157,6 +169,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 requester,
                 sync_config=generate_sync_config(user),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
         self.assertIn(joined_room, [r.room_id for r in result.joined])
@@ -169,6 +182,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 requester,
                 sync_config=generate_sync_config(user, device_id="dev"),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
                 since_token=initial_result.next_batch,
             )
         )
@@ -200,6 +214,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 requester,
                 sync_config=generate_sync_config(user),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
         self.assertNotIn(joined_room, [r.room_id for r in result.joined])
@@ -212,6 +227,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 requester,
                 sync_config=generate_sync_config(user, device_id="dev"),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
                 since_token=initial_result.next_batch,
             )
         )
@@ -254,6 +270,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 create_requester(owner),
                 generate_sync_config(owner),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
         self.assertEqual(len(alice_sync_result.joined), 1)
@@ -277,6 +294,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 eve_requester,
                 eve_sync_config,
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
 
@@ -295,6 +313,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 eve_requester,
                 eve_sync_config,
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
                 since_token=eve_sync_after_ban.next_batch,
             )
         )
@@ -307,6 +326,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 eve_requester,
                 eve_sync_config,
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
                 since_token=None,
             )
         )
@@ -341,6 +361,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 alice_requester,
                 generate_sync_config(alice),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
         last_room_creation_event_id = (
@@ -369,6 +390,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                     ),
                 ),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
                 since_token=initial_sync_result.next_batch,
             )
         )
@@ -414,6 +436,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 alice_requester,
                 generate_sync_config(alice),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
         last_room_creation_event_id = (
@@ -452,6 +475,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                     ),
                 ),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
                 since_token=initial_sync_result.next_batch,
             )
         )
@@ -498,6 +522,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 alice_requester,
                 generate_sync_config(alice),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
         last_room_creation_event_id = (
@@ -523,6 +548,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                     ),
                 ),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
                 since_token=initial_sync_result.next_batch,
             )
         )
@@ -553,6 +579,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                     ),
                 ),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
                 since_token=incremental_sync.next_batch,
             )
         )
@@ -615,6 +642,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 alice_requester,
                 generate_sync_config(alice),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
         last_room_creation_event_id = (
@@ -639,6 +667,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                     ),
                 ),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
         room_sync = initial_sync_result.joined[0]
@@ -660,6 +689,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 alice_requester,
                 generate_sync_config(alice),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
                 since_token=initial_sync_result.next_batch,
             )
         )
@@ -713,6 +743,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 bob_requester,
                 generate_sync_config(bob),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
 
@@ -744,6 +775,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                     bob, filter_collection=FilterCollection(self.hs, filter_dict)
                 ),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
                 since_token=None if initial_sync else initial_sync_result.next_batch,
             )
         ).archived[0]
@@ -839,6 +871,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 create_requester(user),
                 generate_sync_config(user),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
         event_ids = []
@@ -887,6 +920,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 create_requester(user2),
                 generate_sync_config(user2),
                 sync_version=SyncVersion.SYNC_V2,
+                request_key=generate_request_key(),
             )
         )
         priv_event_ids = []
@@ -894,9 +928,6 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
             priv_event_ids.append(event.event_id)
 
         self.assertIn(private_call_event.event_id, priv_event_ids)
-
-
-_request_key = 0
 
 
 def generate_sync_config(
@@ -915,12 +946,9 @@ def generate_sync_config(
     if filter_collection is None:
         filter_collection = Filtering(Mock()).DEFAULT_FILTER_COLLECTION
 
-    global _request_key
-    _request_key += 1
     return SyncConfig(
         user=UserID.from_string(user_id),
         filter_collection=filter_collection,
         is_guest=False,
-        request_key=("request_key", _request_key),
         device_id=device_id,
     )

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -31,7 +31,7 @@ from synapse.api.room_versions import RoomVersion, RoomVersions
 from synapse.events import EventBase
 from synapse.events.snapshot import EventContext
 from synapse.federation.federation_base import event_from_pdu_json
-from synapse.handlers.sync import SyncConfig, SyncResult
+from synapse.handlers.sync import SyncConfig, SyncResult, SyncVersion
 from synapse.rest import admin
 from synapse.rest.client import knock, login, room
 from synapse.server import HomeServer
@@ -73,13 +73,21 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         # Check that the happy case does not throw errors
         self.get_success(self.store.upsert_monthly_active_user(user_id1))
         self.get_success(
-            self.sync_handler.wait_for_sync_for_user(requester, sync_config)
+            self.sync_handler.wait_for_sync_for_user(
+                requester,
+                sync_config,
+                sync_version=SyncVersion.SYNC_V2,
+            )
         )
 
         # Test that global lock works
         self.auth_blocking._hs_disabled = True
         e = self.get_failure(
-            self.sync_handler.wait_for_sync_for_user(requester, sync_config),
+            self.sync_handler.wait_for_sync_for_user(
+                requester,
+                sync_config,
+                sync_version=SyncVersion.SYNC_V2,
+            ),
             ResourceLimitError,
         )
         self.assertEqual(e.value.errcode, Codes.RESOURCE_LIMIT_EXCEEDED)
@@ -90,7 +98,11 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         requester = create_requester(user_id2)
 
         e = self.get_failure(
-            self.sync_handler.wait_for_sync_for_user(requester, sync_config),
+            self.sync_handler.wait_for_sync_for_user(
+                requester,
+                sync_config,
+                sync_version=SyncVersion.SYNC_V2,
+            ),
             ResourceLimitError,
         )
         self.assertEqual(e.value.errcode, Codes.RESOURCE_LIMIT_EXCEEDED)
@@ -109,7 +121,9 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         requester = create_requester(user)
         initial_result = self.get_success(
             self.sync_handler.wait_for_sync_for_user(
-                requester, sync_config=generate_sync_config(user, device_id="dev")
+                requester,
+                sync_config=generate_sync_config(user, device_id="dev"),
+                sync_version=SyncVersion.SYNC_V2,
             )
         )
 
@@ -140,7 +154,9 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         # The rooms should appear in the sync response.
         result = self.get_success(
             self.sync_handler.wait_for_sync_for_user(
-                requester, sync_config=generate_sync_config(user)
+                requester,
+                sync_config=generate_sync_config(user),
+                sync_version=SyncVersion.SYNC_V2,
             )
         )
         self.assertIn(joined_room, [r.room_id for r in result.joined])
@@ -152,6 +168,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
             self.sync_handler.wait_for_sync_for_user(
                 requester,
                 sync_config=generate_sync_config(user, device_id="dev"),
+                sync_version=SyncVersion.SYNC_V2,
                 since_token=initial_result.next_batch,
             )
         )
@@ -180,7 +197,9 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         # Get a new request key.
         result = self.get_success(
             self.sync_handler.wait_for_sync_for_user(
-                requester, sync_config=generate_sync_config(user)
+                requester,
+                sync_config=generate_sync_config(user),
+                sync_version=SyncVersion.SYNC_V2,
             )
         )
         self.assertNotIn(joined_room, [r.room_id for r in result.joined])
@@ -192,6 +211,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
             self.sync_handler.wait_for_sync_for_user(
                 requester,
                 sync_config=generate_sync_config(user, device_id="dev"),
+                sync_version=SyncVersion.SYNC_V2,
                 since_token=initial_result.next_batch,
             )
         )
@@ -231,7 +251,9 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         # Do a sync as Alice to get the latest event in the room.
         alice_sync_result: SyncResult = self.get_success(
             self.sync_handler.wait_for_sync_for_user(
-                create_requester(owner), generate_sync_config(owner)
+                create_requester(owner),
+                generate_sync_config(owner),
+                sync_version=SyncVersion.SYNC_V2,
             )
         )
         self.assertEqual(len(alice_sync_result.joined), 1)
@@ -251,7 +273,11 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         eve_requester = create_requester(eve)
         eve_sync_config = generate_sync_config(eve)
         eve_sync_after_ban: SyncResult = self.get_success(
-            self.sync_handler.wait_for_sync_for_user(eve_requester, eve_sync_config)
+            self.sync_handler.wait_for_sync_for_user(
+                eve_requester,
+                eve_sync_config,
+                sync_version=SyncVersion.SYNC_V2,
+            )
         )
 
         # Sanity check this sync result. We shouldn't be joined to the room.
@@ -268,6 +294,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
             self.sync_handler.wait_for_sync_for_user(
                 eve_requester,
                 eve_sync_config,
+                sync_version=SyncVersion.SYNC_V2,
                 since_token=eve_sync_after_ban.next_batch,
             )
         )
@@ -279,6 +306,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
             self.sync_handler.wait_for_sync_for_user(
                 eve_requester,
                 eve_sync_config,
+                sync_version=SyncVersion.SYNC_V2,
                 since_token=None,
             )
         )
@@ -310,7 +338,9 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         # Do an initial sync as Alice to get a known starting point.
         initial_sync_result = self.get_success(
             self.sync_handler.wait_for_sync_for_user(
-                alice_requester, generate_sync_config(alice)
+                alice_requester,
+                generate_sync_config(alice),
+                sync_version=SyncVersion.SYNC_V2,
             )
         )
         last_room_creation_event_id = (
@@ -338,6 +368,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                         self.hs, {"room": {"timeline": {"limit": 2}}}
                     ),
                 ),
+                sync_version=SyncVersion.SYNC_V2,
                 since_token=initial_sync_result.next_batch,
             )
         )
@@ -380,7 +411,9 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         # Do an initial sync as Alice to get a known starting point.
         initial_sync_result = self.get_success(
             self.sync_handler.wait_for_sync_for_user(
-                alice_requester, generate_sync_config(alice)
+                alice_requester,
+                generate_sync_config(alice),
+                sync_version=SyncVersion.SYNC_V2,
             )
         )
         last_room_creation_event_id = (
@@ -418,6 +451,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                         },
                     ),
                 ),
+                sync_version=SyncVersion.SYNC_V2,
                 since_token=initial_sync_result.next_batch,
             )
         )
@@ -461,7 +495,9 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         # Do an initial sync as Alice to get a known starting point.
         initial_sync_result = self.get_success(
             self.sync_handler.wait_for_sync_for_user(
-                alice_requester, generate_sync_config(alice)
+                alice_requester,
+                generate_sync_config(alice),
+                sync_version=SyncVersion.SYNC_V2,
             )
         )
         last_room_creation_event_id = (
@@ -486,6 +522,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                         self.hs, {"room": {"timeline": {"limit": 1}}}
                     ),
                 ),
+                sync_version=SyncVersion.SYNC_V2,
                 since_token=initial_sync_result.next_batch,
             )
         )
@@ -515,6 +552,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                         self.hs, {"room": {"timeline": {"limit": 1}}}
                     ),
                 ),
+                sync_version=SyncVersion.SYNC_V2,
                 since_token=incremental_sync.next_batch,
             )
         )
@@ -574,7 +612,9 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         # Do an initial sync to get a known starting point.
         initial_sync_result = self.get_success(
             self.sync_handler.wait_for_sync_for_user(
-                alice_requester, generate_sync_config(alice)
+                alice_requester,
+                generate_sync_config(alice),
+                sync_version=SyncVersion.SYNC_V2,
             )
         )
         last_room_creation_event_id = (
@@ -598,6 +638,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                         self.hs, {"room": {"timeline": {"limit": 1}}}
                     ),
                 ),
+                sync_version=SyncVersion.SYNC_V2,
             )
         )
         room_sync = initial_sync_result.joined[0]
@@ -618,6 +659,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
             self.sync_handler.wait_for_sync_for_user(
                 alice_requester,
                 generate_sync_config(alice),
+                sync_version=SyncVersion.SYNC_V2,
                 since_token=initial_sync_result.next_batch,
             )
         )
@@ -668,7 +710,9 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
 
         initial_sync_result = self.get_success(
             self.sync_handler.wait_for_sync_for_user(
-                bob_requester, generate_sync_config(bob)
+                bob_requester,
+                generate_sync_config(bob),
+                sync_version=SyncVersion.SYNC_V2,
             )
         )
 
@@ -699,6 +743,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
                 generate_sync_config(
                     bob, filter_collection=FilterCollection(self.hs, filter_dict)
                 ),
+                sync_version=SyncVersion.SYNC_V2,
                 since_token=None if initial_sync else initial_sync_result.next_batch,
             )
         ).archived[0]
@@ -791,7 +836,9 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         # but that it does not come down /sync in public room
         sync_result: SyncResult = self.get_success(
             self.sync_handler.wait_for_sync_for_user(
-                create_requester(user), generate_sync_config(user)
+                create_requester(user),
+                generate_sync_config(user),
+                sync_version=SyncVersion.SYNC_V2,
             )
         )
         event_ids = []
@@ -837,7 +884,9 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
 
         private_sync_result: SyncResult = self.get_success(
             self.sync_handler.wait_for_sync_for_user(
-                create_requester(user2), generate_sync_config(user2)
+                create_requester(user2),
+                generate_sync_config(user2),
+                sync_version=SyncVersion.SYNC_V2,
             )
         )
         priv_event_ids = []


### PR DESCRIPTION
Removed `request_key` from the `SyncConfig` (moved outside as its own function parameter) so it doesn't have to flow into `_generate_sync_entry_for_xxx` methods. This way we can separate the concerns of caching from generating the response and reuse the `_generate_sync_entry_for_xxx` functions as we see fit. Plus caching doesn't really have anything to do with the config of sync.

Split from https://github.com/element-hq/synapse/pull/17167

Spawning from https://github.com/element-hq/synapse/pull/17167#discussion_r1601497279



### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
   - Waiting on https://github.com/element-hq/synapse/pull/17200 to merge first
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
