### PR TITLE
Improve perf of looking up device lists changes in /sync

### DIFF
--- a/changelog.d/17205.misc
+++ b/changelog.d/17205.misc
@@ -1,0 +1,1 @@
+Improve performance of calculating device lists changes in `/sync`.

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -112,6 +112,13 @@ class ReplicationDataHandler:
             token: stream token for this batch of rows
             rows: a list of Stream.ROW_TYPE objects as returned by Stream.parse_row.
         """
+        all_room_ids: Set[str] = set()
+        if stream_name == DeviceListsStream.NAME:
+            prev_token = self.store.get_device_stream_token()
+            all_room_ids = await self.store.get_all_device_list_changes(
+                prev_token, token
+            )
+
         self.store.process_replication_rows(stream_name, instance_name, token, rows)
         # NOTE: this must be called after process_replication_rows to ensure any
         # cache invalidations are first handled before any stream ID advances.
@@ -146,12 +153,6 @@ class ReplicationDataHandler:
                     StreamKeyType.TO_DEVICE, token, users=entities
                 )
         elif stream_name == DeviceListsStream.NAME:
-            all_room_ids: Set[str] = set()
-            for row in rows:
-                if row.entity.startswith("@") and not row.is_signature:
-                    room_ids = await self.store.get_rooms_for_user(row.entity)
-                    all_room_ids.update(room_ids)
-
             # `all_room_ids` can be large, so let's wake up those streams in batches
             for batched_room_ids in batch_iter(all_room_ids, 100):
                 self.notifier.on_new_event(


### PR DESCRIPTION
Based on #17197

This code path was changed in #17191

The idea here is to add a `StreamChangeCache` for the `device_lists_changes_in_rooms` table. Usually this is done by adding or updating a replication stream, but sending a new row for every room ID feels a lot and we just pull it out of the DB anyway.