### PR TITLE
Fix `joined_rooms`/`joined_room_ids` usage

### DIFF
--- a/changelog.d/17208.misc
+++ b/changelog.d/17208.misc
@@ -1,0 +1,1 @@
+Rename to be obvious: `joined_rooms` -> `joined_room_ids`.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1875,7 +1875,7 @@ class SyncHandler:
                 # or if the changed user is the syncing user (as we always
                 # want to include device list updates of their own devices).
                 if user_id == changed_user_id or any(
-                    rid in joined_rooms for rid in entries
+                    rid in joined_room_ids for rid in entries
                 ):
                     users_that_have_changed.add(changed_user_id)
         else:


### PR DESCRIPTION
Fix `joined_rooms`/`joined_room_ids` usage

This change was introduced in https://github.com/element-hq/synapse/pull/17203

But then https://github.com/element-hq/synapse/pull/17207 was reverted which brought back usage of `joined_rooms` that needed to be updated. Wasn't caught because `develop` wasn't up to date before merging.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
