### PR TITLE
Fixed presence results not returning offline users on initial sync

### DIFF
--- a/changelog.d/17231.bugfix
+++ b/changelog.d/17231.bugfix
@@ -1,1 +1,1 @@
-Fixed presence results not returning offline users on initial sync. Contributed by @Michael-Hollister.
+Added configurable option to always include offline users in presence sync results. Contributed by @Michael-Hollister.

--- a/changelog.d/17231.bugfix
+++ b/changelog.d/17231.bugfix
@@ -1,0 +1,1 @@
+Fixed presence results not returning offline users on initial sync. Contributed by @Michael-Hollister.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -246,6 +246,7 @@ Example configuration:
 ```yaml
 presence:
   enabled: false
+  include_offline_users_on_sync: false
 ```
 
 `enabled` can also be set to a special value of "untracked" which ignores updates
@@ -253,6 +254,10 @@ received via clients and federation, while still accepting updates from the
 [module API](../../modules/index.md).
 
 *The "untracked" option was added in Synapse 1.96.0.*
+
+When clients perform an initial or `full_state` sync, presence results for offline users are
+not included by default. Setting `include_offline_users_on_sync` to `true` will always include
+offline users in the results. Defaults to false.
 
 ---
 ### `require_auth_for_profile_requests`

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -384,6 +384,11 @@ class ServerConfig(Config):
         # Whether to internally track presence, requires that presence is enabled,
         self.track_presence = self.presence_enabled and presence_enabled != "untracked"
 
+        # Determines if presence results for offline users are included on initial/full sync
+        self.presence_include_offline_users_on_sync = presence_config.get(
+            "include_offline_users_on_sync", False
+        )
+
         # Custom presence router module
         # This is the legacy way of configuring it (the config should now be put in the modules section)
         self.presence_router_module_class = None

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -2281,13 +2281,20 @@ class SyncHandler:
 
         since_token = sync_result_builder.since_token
         presence_key = None
+        include_offline = False
         if since_token and not sync_result_builder.full_state:
             presence_key = since_token.presence_key
+            include_offline = True
 
         presence, presence_key = await presence_source.get_new_events(
             user=user,
             from_key=presence_key,
             is_guest=sync_config.is_guest,
+            include_offline=(
+                True
+                if self.hs_config.server.presence_include_offline_users_on_sync
+                else include_offline
+            ),
         )
         assert presence_key
         sync_result_builder.now_token = now_token.copy_and_replace(

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -2281,16 +2281,13 @@ class SyncHandler:
 
         since_token = sync_result_builder.since_token
         presence_key = None
-        include_offline = False
         if since_token and not sync_result_builder.full_state:
             presence_key = since_token.presence_key
-            include_offline = True
 
         presence, presence_key = await presence_source.get_new_events(
             user=user,
             from_key=presence_key,
             is_guest=sync_config.is_guest,
-            include_offline=include_offline,
         )
         assert presence_key
         sync_result_builder.now_token = now_token.copy_and_replace(

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -916,7 +916,7 @@ def _test_sending_local_online_presence_to_local_user(
     presence_updates, sync_token = sync_presence(
         test_case, test_case.presence_receiver_id
     )
-    test_case.assertEqual(len(presence_updates), 1)
+    test_case.assertEqual(len(presence_updates), 2)
 
     presence_update: UserPresenceState = presence_updates[0]
     test_case.assertEqual(presence_update.user_id, test_case.presence_sender_id)

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -916,7 +916,7 @@ def _test_sending_local_online_presence_to_local_user(
     presence_updates, sync_token = sync_presence(
         test_case, test_case.presence_receiver_id
     )
-    test_case.assertEqual(len(presence_updates), 2)
+    test_case.assertEqual(len(presence_updates), 1)
 
     presence_update: UserPresenceState = presence_updates[0]
     test_case.assertEqual(presence_update.user_id, test_case.presence_sender_id)


### PR DESCRIPTION
This is to address an issue in which `m.presence` results on initial sync are not returning entries of users who are currently offline. I believe this was intended behavior as stated in https://github.com/element-hq/synapse/issues/1535, but since this was 8+ years ago, I wanted to check if that is still the case. If this is still desired behavior, then feel free to close the PR.

However, I think this change is useful for applications that use the presence system for tracking user profile information/updates (e.g. https://github.com/element-hq/synapse/pull/16992 or for profile status messages). 

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
