### PR TITLE
Change allow_unsafe_locale to also apply on new databases

### DIFF
--- a/changelog.d/17238.misc
+++ b/changelog.d/17238.misc
@@ -1,0 +1,1 @@
+Change the `allow_unsafe_locale` config option to also apply when setting up new databases.

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -242,7 +242,7 @@ host    all         all             ::1/128     ident
 
 ### Fixing incorrect `COLLATE` or `CTYPE`
 
-Synapse will also refuse to start when using a database with incorrect values of
+Synapse will refuse to start when using a database with incorrect values of
 `COLLATE` and `CTYPE` unless the config flag `allow_unsafe_locale`, found in the
 `database` section of the config, is set to true. Using different locales can
 cause issues if the locale library is updated from underneath the database, or

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -242,12 +242,11 @@ host    all         all             ::1/128     ident
 
 ### Fixing incorrect `COLLATE` or `CTYPE`
 
-Synapse will refuse to set up a new database if it has the wrong values of
-`COLLATE` and `CTYPE` set. Synapse will also refuse to start an existing database with incorrect values
-of `COLLATE` and `CTYPE` unless the config flag `allow_unsafe_locale`, found in the 
-`database` section of the config, is set to true. Using different locales can cause issues if the locale library is updated from
-underneath the database, or if a different version of the locale is used on any
-replicas.
+Synapse will also refuse to start when using a database with incorrect values of
+`COLLATE` and `CTYPE` unless the config flag `allow_unsafe_locale`, found in the
+`database` section of the config, is set to true. Using different locales can
+cause issues if the locale library is updated from underneath the database, or
+if a different version of the locale is used on any replicas.
 
 If you have a database with an unsafe locale, the safest way to fix the issue is to dump the database and recreate it with
 the correct locale parameter (as shown above). It is also possible to change the

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -142,6 +142,10 @@ class PostgresEngine(
         apply stricter checks on new databases versus existing database.
         """
 
+        allow_unsafe_locale = self.config.get("allow_unsafe_locale", False)
+        if allow_unsafe_locale:
+            return
+
         collation, ctype = self.get_db_locale(txn)
 
         errors = []
@@ -154,8 +158,10 @@ class PostgresEngine(
 
         if errors:
             raise IncorrectDatabaseSetup(
-                "Database is incorrectly configured:\n\n%s\n\n"
-                "See docs/postgres.md for more information." % ("\n".join(errors))
+                "Database has incorrect ctype of %r. Should be 'C'\n"
+                "See docs/postgres.md for more information. You can override this check by"
+                "setting 'allow_unsafe_locale' to true in the database config.",
+                ctype,
             )
 
     def convert_param_style(self, sql: str) -> str:

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -158,10 +158,10 @@ class PostgresEngine(
 
         if errors:
             raise IncorrectDatabaseSetup(
-                "Database has incorrect ctype of %r. Should be 'C'\n"
+                "Database is incorrectly configured:\n\n%s\n\n"
                 "See docs/postgres.md for more information. You can override this check by"
                 "setting 'allow_unsafe_locale' to true in the database config.",
-                ctype,
+                "\n".join(errors),
             )
 
     def convert_param_style(self, sql: str) -> str:


### PR DESCRIPTION
We relax this as there are use cases where this is safe, though it is still highly recommended that people avoid using it.