### PR TITLE
Ignore attempts to send to-device messages to bad users

### DIFF
--- a/changelog.d/17240.bugfix
+++ b/changelog.d/17240.bugfix
@@ -1,0 +1,1 @@
+Ignore attempts to send to-device messages to bad users, to avoid log spam when we try to connect to the bad server.

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -236,6 +236,13 @@ class DeviceMessageHandler:
         local_messages = {}
         remote_messages: Dict[str, Dict[str, Dict[str, JsonDict]]] = {}
         for user_id, by_device in messages.items():
+            if not UserID.is_valid(user_id):
+                logger.warning(
+                    "Ignoring attempt to send device message to invalid user: %r",
+                    user_id,
+                )
+                continue
+
             # add an opentracing log entry for each message
             for device_id, message_content in by_device.items():
                 log_kv(


### PR DESCRIPTION
Currently sending a to-device message to a user ID with a dodgy destination is accepted, but then ends up spamming the logs when we try and send to the destination.

An alternative would be to reject the request, but I'm slightly nervous that could break things.