### PR TITLE
Ensure we delete media if we reject due to spam check

### DIFF
--- a/changelog.d/17246.misc
+++ b/changelog.d/17246.misc
@@ -1,0 +1,1 @@
+Fix errors in logs about closing incorrect logging contexts when media gets rejected by a module.

--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -1049,6 +1049,11 @@ class MediaRepository:
                     finally:
                         t_byte_source.close()
 
+                    # We flush and close the file to ensure that the bytes have
+                    # been written before getting the size.
+                    f.flush()
+                    f.close()
+
                     t_len = os.path.getsize(fname)
 
                     # Write to database


### PR DESCRIPTION
Fixes up #17239

We need to keep the spam check within the `try/except` block. Also makes it so that we don't enter the top span twice.

Also also ensures that we get the right thumbnail length.