### PR TITLE
Add `is_encrypted` filtering to Sliding Sync `/sync`

### DIFF
--- a/changelog.d/17249.feature
+++ b/changelog.d/17249.feature
@@ -1,0 +1,1 @@
+Add `is_encrypted` filtering to experimental [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575) Sliding Sync `/sync` endpoint.

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -271,6 +271,8 @@ class SlidingSyncHandler:
                 # Apply filters
                 filtered_room_ids = room_id_set
                 if list_config.filters is not None:
+                    # TODO: To be absolutely correct, this could also take into account
+                    # from/to tokens
                     filtered_room_ids = await self.filter_rooms(
                         sync_config.user, room_id_set, list_config.filters
                     )

--- a/tests/handlers/test_sliding_sync.py
+++ b/tests/handlers/test_sliding_sync.py
@@ -668,59 +668,35 @@ class FilterRoomsTestCase(HomeserverTestCase):
         # https://github.com/element-hq/synapse/pull/17187#discussion_r1619492779)
         from synapse.handlers.sliding_sync import SlidingSyncConfig
 
-        filters = SlidingSyncConfig.SlidingSyncList.Filters(
+        # Try with `is_dm=True`
+        # -----------------------------
+        truthy_filters = SlidingSyncConfig.SlidingSyncList.Filters(
             is_dm=True,
         )
 
         # Try filtering the rooms
-        filtered_room_ids = self.get_success(
+        truthy_filtered_room_ids = self.get_success(
             self.sliding_sync_handler.filter_rooms(
-                UserID.from_string(user1_id), {room_id, dm_room_id}, filters
+                UserID.from_string(user1_id), {room_id, dm_room_id}, truthy_filters
             )
         )
 
-        self.assertEqual(filtered_room_ids, {dm_room_id})
+        self.assertEqual(truthy_filtered_room_ids, {dm_room_id})
 
-    def test_filter_non_dm_rooms(self) -> None:
-        """
-        Test `filter.is_dm` for non-DM rooms
-        """
-        user1_id = self.register_user("user1", "pass")
-        user1_tok = self.login(user1_id, "pass")
-        user2_id = self.register_user("user2", "pass")
-        user2_tok = self.login(user2_id, "pass")
-
-        # Create a normal room
-        room_id = self.helper.create_room_as(
-            user1_id,
-            is_public=False,
-            tok=user1_tok,
-        )
-
-        # Create a DM room
-        dm_room_id = self._create_dm_room(
-            inviter_user_id=user1_id,
-            inviter_tok=user1_tok,
-            invitee_user_id=user2_id,
-            invitee_tok=user2_tok,
-        )
-
-        # TODO: Better way to avoid the circular import? (see
-        # https://github.com/element-hq/synapse/pull/17187#discussion_r1619492779)
-        from synapse.handlers.sliding_sync import SlidingSyncConfig
-
-        filters = SlidingSyncConfig.SlidingSyncList.Filters(
+        # Try with `is_dm=True`
+        # -----------------------------
+        falsy_filters = SlidingSyncConfig.SlidingSyncList.Filters(
             is_dm=False,
         )
 
         # Try filtering the rooms
-        filtered_room_ids = self.get_success(
+        falsy_filtered_room_ids = self.get_success(
             self.sliding_sync_handler.filter_rooms(
-                UserID.from_string(user1_id), {room_id, dm_room_id}, filters
+                UserID.from_string(user1_id), {room_id, dm_room_id}, falsy_filters
             )
         )
 
-        self.assertEqual(filtered_room_ids, {room_id})
+        self.assertEqual(falsy_filtered_room_ids, {room_id})
 
     def test_filter_space_rooms(self) -> None:
         """
@@ -894,3 +870,68 @@ class FilterRoomsTestCase(HomeserverTestCase):
         )
 
         self.assertEqual(filtered_room_ids, {room_id1})
+
+    def test_filter_encrypted_rooms(self) -> None:
+        """
+        Test `filter.is_encrypted` for encrypted rooms
+        """
+        user1_id = self.register_user("user1", "pass")
+        user1_tok = self.login(user1_id, "pass")
+
+        # Create a normal room
+        room_id = self.helper.create_room_as(
+            user1_id,
+            is_public=False,
+            tok=user1_tok,
+        )
+
+        # Create an encrypted room
+        encrypted_room_id = self.helper.create_room_as(
+            user1_id,
+            is_public=False,
+            tok=user1_tok,
+        )
+        self.helper.send_state(
+            encrypted_room_id,
+            EventTypes.RoomEncryption,
+            {"algorithm": "m.megolm.v1.aes-sha2"},
+            tok=user1_tok,
+        )
+
+        # TODO: Better way to avoid the circular import? (see
+        # https://github.com/element-hq/synapse/pull/17187#discussion_r1619492779)
+        from synapse.handlers.sliding_sync import SlidingSyncConfig
+
+        # Try with `is_encrypted=True`
+        # -----------------------------
+        truthy_filters = SlidingSyncConfig.SlidingSyncList.Filters(
+            is_encrypted=True,
+        )
+
+        # Try filtering the rooms
+        truthy_filtered_room_ids = self.get_success(
+            self.sliding_sync_handler.filter_rooms(
+                UserID.from_string(user1_id),
+                {room_id, encrypted_room_id},
+                truthy_filters,
+            )
+        )
+
+        self.assertEqual(truthy_filtered_room_ids, {encrypted_room_id})
+
+        # Try with `is_encrypted=False`
+        # -----------------------------
+        falsy_filters = SlidingSyncConfig.SlidingSyncList.Filters(
+            is_encrypted=False,
+        )
+
+        # Try filtering the rooms
+        falsy_filtered_room_ids = self.get_success(
+            self.sliding_sync_handler.filter_rooms(
+                UserID.from_string(user1_id),
+                {room_id, encrypted_room_id},
+                falsy_filters,
+            )
+        )
+
+        self.assertEqual(falsy_filtered_room_ids, {room_id})


### PR DESCRIPTION
Add `is_encrypted` filtering to Sliding Sync `/sync`

Based on [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575): Sliding Sync

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
