### PR TITLE
Fix sentry default tags

### DIFF
--- a/changelog.d/17251.bugfix
+++ b/changelog.d/17251.bugfix
@@ -1,0 +1,1 @@
+Fix reporting of default tags to Sentry, such as worker name. Broke in v1.108.0.

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -681,17 +681,17 @@ def setup_sentry(hs: "HomeServer") -> None:
     )
 
     # We set some default tags that give some context to this instance
-    with sentry_sdk.configure_scope() as scope:
-        scope.set_tag("matrix_server_name", hs.config.server.server_name)
+    global_scope = sentry_sdk.Scope.get_global_scope()
+    global_scope.set_tag("matrix_server_name", hs.config.server.server_name)
 
-        app = (
-            hs.config.worker.worker_app
-            if hs.config.worker.worker_app
-            else "synapse.app.homeserver"
-        )
-        name = hs.get_instance_name()
-        scope.set_tag("worker_app", app)
-        scope.set_tag("worker_name", name)
+    app = (
+        hs.config.worker.worker_app
+        if hs.config.worker.worker_app
+        else "synapse.app.homeserver"
+    )
+    name = hs.get_instance_name()
+    global_scope.set_tag("worker_app", app)
+    global_scope.set_tag("worker_name", name)
 
 
 def setup_sdnotify(hs: "HomeServer") -> None:


### PR DESCRIPTION
This was broken by the sentry 2.0 upgrade

Broke in v1.108.0
