### PR TITLE
Fix bug where typing replication breaks

### DIFF
--- a/changelog.d/17252.bugfix
+++ b/changelog.d/17252.bugfix
@@ -1,0 +1,1 @@
+Fix bug where typing updates would not be sent when using workers after a restart.

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -477,9 +477,9 @@ class TypingWriterHandler(FollowerTypingHandler):
 
         rows = []
         for room_id in changed_rooms:
-            serial = self._room_serials[room_id]
-            if last_id < serial <= current_id:
-                typing = self._room_typing[room_id]
+            serial = self._room_serials.get(room_id)
+            if serial and last_id < serial <= current_id:
+                typing = self._room_typing.get(room_id, set())
                 rows.append((serial, [room_id, list(typing)]))
         rows.sort()
 


### PR DESCRIPTION
This can happen on restarts of the service, due to old rooms being pruned.