### PR TITLE
MSC4108: Add a Content-Type header on the PUT response

### DIFF
--- a/changelog.d/17253.misc
+++ b/changelog.d/17253.misc
@@ -1,0 +1,1 @@
+[MSC4108](https://github.com/matrix-org/matrix-spec-proposals/pull/4108): Add a `Content-Type` header on the `PUT` response to work around a faulty behavior in some caching reverse proxies.

--- a/rust/src/rendezvous/mod.rs
+++ b/rust/src/rendezvous/mod.rs
@@ -288,6 +288,12 @@ impl RendezvousHandler {
         let mut response = Response::new(Bytes::new());
         *response.status_mut() = StatusCode::ACCEPTED;
         prepare_headers(response.headers_mut(), session);
+
+        // Even though this isn't mandated by the MSC, we set a Content-Type on the response. It
+        // doesn't do any harm as the body is empty, but this helps escape a bug in some reverse
+        // proxy/cache setup which strips the ETag header if there is no Content-Type set.
+        response.headers_mut().typed_insert(ContentType::text());
+
         http_response_to_twisted(twisted_request, response)?;
 
         Ok(())

--- a/rust/src/rendezvous/mod.rs
+++ b/rust/src/rendezvous/mod.rs
@@ -292,6 +292,7 @@ impl RendezvousHandler {
         // Even though this isn't mandated by the MSC, we set a Content-Type on the response. It
         // doesn't do any harm as the body is empty, but this helps escape a bug in some reverse
         // proxy/cache setup which strips the ETag header if there is no Content-Type set.
+        // Specifically, we noticed this behaviour when placing Synapse behind Cloudflare.
         response.headers_mut().typed_insert(ContentType::text());
 
         http_response_to_twisted(twisted_request, response)?;


### PR DESCRIPTION
This is a workaround for some proxy setup, where the ETag header gets stripped from the response headers unless there is a Content-Type header set.

In particular, we saw this bug when putting Cloudflare in front of Synapse.
I'm pretty sure this is a Cloudflare bug, as this behaviour isn't documented anywhere, and doesn't make sense whatsoever.
