### PR TITLE
Don't try and resync devices for down hosts

### DIFF
--- a/changelog.d/17273.misc
+++ b/changelog.d/17273.misc
@@ -1,0 +1,1 @@
+Don't try and resync devices for remote users whose servers are marked as down.


### PR DESCRIPTION
It's just a waste of time if we won't even query the remote host as its marked as down.