### PR TITLE
Add `spaces` filtering to Sliding Sync `/sync`

### DIFF
--- a/changelog.d/17248.feature
+++ b/changelog.d/17248.feature
@@ -1,0 +1,1 @@
+Add `spaces` filtering to experimental [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575) Sliding Sync `/sync` endpoint.

--- a/tests/handlers/test_sliding_sync.py
+++ b/tests/handlers/test_sliding_sync.py
@@ -18,11 +18,19 @@
 #
 #
 import logging
+from typing import List, Optional
 from unittest.mock import patch
 
 from twisted.test.proto_helpers import MemoryReactor
 
-from synapse.api.constants import AccountDataTypes, EventTypes, JoinRules, Membership
+from synapse.api.constants import (
+    AccountDataTypes,
+    EventContentFields,
+    EventTypes,
+    JoinRules,
+    Membership,
+    RoomTypes,
+)
 from synapse.api.room_versions import RoomVersions
 from synapse.rest import admin
 from synapse.rest.client import knock, login, room
@@ -1189,6 +1197,32 @@ class FilterRoomsTestCase(HomeserverTestCase):
 
         return room_id
 
+    def _add_space_child(
+        self,
+        space_id: str,
+        room_id: str,
+        token: str,
+        order: Optional[str] = None,
+        via: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Helper to add a child room to a space.
+        """
+
+        if via is None:
+            via = [self.hs.hostname]
+
+        content: JsonDict = {"via": via}
+        if order is not None:
+            content["order"] = order
+        self.helper.send_state(
+            space_id,
+            event_type=EventTypes.SpaceChild,
+            body=content,
+            tok=token,
+            state_key=room_id,
+        )
+
     def test_filter_dm_rooms(self) -> None:
         """
         Test filter for DM rooms
@@ -1270,3 +1304,176 @@ class FilterRoomsTestCase(HomeserverTestCase):
         )
 
         self.assertEqual(filtered_room_ids, {room_id})
+
+    def test_filter_space_rooms(self) -> None:
+        """
+        Test `filter.spaces` for rooms in spaces
+        """
+        user1_id = self.register_user("user1", "pass")
+        user1_tok = self.login(user1_id, "pass")
+
+        space_a = self.helper.create_room_as(
+            user1_id,
+            tok=user1_tok,
+            extra_content={
+                "creation_content": {EventContentFields.ROOM_TYPE: RoomTypes.SPACE}
+            },
+        )
+        space_b = self.helper.create_room_as(
+            user1_id,
+            tok=user1_tok,
+            extra_content={
+                "creation_content": {EventContentFields.ROOM_TYPE: RoomTypes.SPACE}
+            },
+        )
+        space_c = self.helper.create_room_as(
+            user1_id,
+            tok=user1_tok,
+            extra_content={
+                "creation_content": {EventContentFields.ROOM_TYPE: RoomTypes.SPACE}
+            },
+        )
+
+        room_id1 = self.helper.create_room_as(
+            user1_id,
+            is_public=False,
+            tok=user1_tok,
+        )
+        # Add to space_a
+        self._add_space_child(space_a, room_id1, user1_tok)
+
+        room_id2 = self.helper.create_room_as(
+            user1_id,
+            is_public=False,
+            tok=user1_tok,
+        )
+        # Add to space_a and space_b
+        self._add_space_child(space_a, room_id2, user1_tok)
+        self._add_space_child(space_c, room_id2, user1_tok)
+
+        room_id3 = self.helper.create_room_as(
+            user1_id,
+            is_public=False,
+            tok=user1_tok,
+        )
+        # Add to all spaces
+        self._add_space_child(space_a, room_id3, user1_tok)
+        self._add_space_child(space_b, room_id3, user1_tok)
+        self._add_space_child(space_c, room_id3, user1_tok)
+
+        room_id4 = self.helper.create_room_as(
+            user1_id,
+            is_public=False,
+            tok=user1_tok,
+        )
+        # Add to space_c
+        self._add_space_child(space_c, room_id3, user1_tok)
+
+        room_not_in_space1 = self.helper.create_room_as(
+            user1_id,
+            is_public=False,
+            tok=user1_tok,
+        )
+
+        # TODO: Better way to avoid the circular import? (see
+        # https://github.com/element-hq/synapse/pull/17187#discussion_r1619492779)
+        from synapse.handlers.sliding_sync import SlidingSyncConfig
+
+        filters = SlidingSyncConfig.SlidingSyncList.Filters(
+            spaces=[
+                space_a,
+                space_b,
+            ],
+        )
+
+        # Try filtering the rooms
+        filtered_room_ids = self.get_success(
+            self.sliding_sync_handler.filter_rooms(
+                UserID.from_string(user1_id),
+                {
+                    # a
+                    room_id1,
+                    # a, c
+                    room_id2,
+                    # a, b, c
+                    room_id3,
+                    # c
+                    room_id4,
+                    # not in any space
+                    room_not_in_space1,
+                },
+                filters,
+            )
+        )
+
+        self.assertEqual(filtered_room_ids, {room_id1, room_id2, room_id3})
+
+    def test_filter_only_joined_spaces(self) -> None:
+        """
+        Test `filter.spaces` to make sure the filter only takes into account spaces we
+        are joined to.
+        """
+        user1_id = self.register_user("user1", "pass")
+        user1_tok = self.login(user1_id, "pass")
+        user2_id = self.register_user("user2", "pass")
+        user2_tok = self.login(user2_id, "pass")
+
+        # space_a created by user1
+        space_a = self.helper.create_room_as(
+            user1_id,
+            tok=user1_tok,
+            extra_content={
+                "creation_content": {EventContentFields.ROOM_TYPE: RoomTypes.SPACE}
+            },
+        )
+        # space_b created by user2
+        space_b = self.helper.create_room_as(
+            user2_id,
+            tok=user2_tok,
+            extra_content={
+                "creation_content": {EventContentFields.ROOM_TYPE: RoomTypes.SPACE}
+            },
+        )
+
+        room_id1 = self.helper.create_room_as(
+            user1_id,
+            is_public=False,
+            tok=user1_tok,
+        )
+        # Add to space_a
+        self._add_space_child(space_a, room_id1, user1_tok)
+
+        room_id2 = self.helper.create_room_as(
+            user1_id,
+            is_public=False,
+            tok=user1_tok,
+        )
+        # Add to space_b
+        self._add_space_child(space_b, room_id2, user2_tok)
+
+        # TODO: Better way to avoid the circular import? (see
+        # https://github.com/element-hq/synapse/pull/17187#discussion_r1619492779)
+        from synapse.handlers.sliding_sync import SlidingSyncConfig
+
+        filters = SlidingSyncConfig.SlidingSyncList.Filters(
+            spaces=[
+                space_a,
+                space_b,
+            ],
+        )
+
+        # Try filtering the rooms
+        filtered_room_ids = self.get_success(
+            self.sliding_sync_handler.filter_rooms(
+                UserID.from_string(user1_id),
+                {
+                    # a
+                    room_id1,
+                    # b (but user1 isn't in space_b)
+                    room_id2,
+                },
+                filters,
+            )
+        )
+
+        self.assertEqual(filtered_room_ids, {room_id1})


### PR DESCRIPTION
Add `spaces` filtering to Sliding Sync `/sync`

Based on [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575): Sliding Sync

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
