### PR TITLE
Clarify that MSC4151 is enabled on matrix.org

### DIFF
--- a/changelog.d/17296.feature
+++ b/changelog.d/17296.feature
@@ -1,0 +1,1 @@
+Add support for the unstable [MSC4151](https://github.com/matrix-org/matrix-spec-proposals/pull/4151) report room API.

--- a/synapse/rest/client/reporting.py
+++ b/synapse/rest/client/reporting.py
@@ -107,7 +107,15 @@ class ReportEventRestServlet(RestServlet):
 
 
 class ReportRoomRestServlet(RestServlet):
-    # https://github.com/matrix-org/matrix-spec-proposals/pull/4151
+    """This endpoint lets clients report a room for abuse.
+
+    Whilst MSC4151 is not yet merged, this unstable endpoint is enabled on matrix.org
+    for content moderation purposes, and therefore backwards compatibility should be
+    carefully considered when changing anything on this endpoint.
+
+    More details on the MSC: https://github.com/matrix-org/matrix-spec-proposals/pull/4151
+    """
+
     PATTERNS = client_patterns(
         "/org.matrix.msc4151/rooms/(?P<room_id>[^/]*)/report$",
         releases=[],


### PR DESCRIPTION
This clarifies in the comments that the MSC is being used in matrix.org

See #17270 