### PR TITLE
Make the release script create a release branch for Complement as well

### DIFF
--- a/changelog.d/17318.misc
+++ b/changelog.d/17318.misc
@@ -1,0 +1,1 @@
+Make the release script create a release branch for Complement as well.


### PR DESCRIPTION
We got bitten a bit during the v1.109 release, where even though our CI would pick up any release-vXXX branch on complement, we don't automatically create them in the complement repo.
This adds this logic to the release script.
