### PR TITLE
Switch to macOS 12 runners to fix building of wheels for macOS

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -130,7 +130,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.19.1
 
       - name: Set up QEMU to emulate aarch64
         if: matrix.arch == 'aarch64'

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -102,7 +102,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-20.04, macos-12]
         arch: [x86_64, aarch64]
         # is_pr is a flag used to exclude certain jobs from the matrix on PRs.
         # It is not read by the rest of the workflow.
@@ -112,9 +112,9 @@ jobs:
         exclude:
           # Don't build macos wheels on PR CI.
           - is_pr: true
-            os: "macos-11"
+            os: "macos-12"
           # Don't build aarch64 wheels on mac.
-          - os: "macos-11"
+          - os: "macos-12"
             arch: aarch64
           # Don't build aarch64 wheels on PR CI.
           - is_pr: true

--- a/changelog.d/17319.misc
+++ b/changelog.d/17319.misc
@@ -1,0 +1,1 @@
+Switch to macOS 12 runners to fix building of wheels for macOS.


### PR DESCRIPTION
This changes the release artefacts workflow to use `macos-12` runners instead of `macos-11`, as the latter will be fully deprecated in a few days.

I also had to update `cibuildwheel` to a newer version, as it would not 'repair' the macOS wheels correctly

The difference is that now instead of outputting a macOS 11+ compatible wheel, we output a macOS 12+ compatible one. This is fine, as macOS 11 is considered EOL since September 2023.

We can also expect that macOS 12 will be considered EOL in September 2024, as Apple usually supports the last 3 macOS version, and macOS 15 is scheduled to be released around that time.

The last commit on that PR should be removed before merging, as it is there only to have all wheels built like a release on a PR.