### PR TITLE
Fixes to the table of contents in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,8 @@ deployment. It includes advanced identity management, auditing,
 moderation and data retention options as well as Long Term Support and
 SLAs. ESS can be used to support any Matrix-based frontend client.
 
+.. contents::
+
 🛠️ Installing and configuration
 ===============================
 

--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,6 @@ deployment. It includes advanced identity management, auditing,
 moderation and data retention options as well as Long Term Support and
 SLAs. ESS can be used to support any Matrix-based frontend client.
 
-.. contents::
-
 🛠️ Installing and configuration
 ===============================
 

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 .. image:: https://github.com/element-hq/product/assets/87339233/7abf477a-5277-47f3-be44-ea44917d8ed7
    :height: 60px
 
-===========================================================================================================
-Element Synapse - Matrix homeserver implementation |support| |development| |documentation| |license| |pypi| |python|
-===========================================================================================================
+**Element Synapse - Matrix homeserver implementation**
+
+|support| |development| |documentation| |license| |pypi| |python|
 
 Synapse is an open source `Matrix <https://matrix.org>`_ homeserver
 implementation, written and maintained by `Element <https://element.io>`_.
@@ -14,7 +14,7 @@ license. There is no support provided from Element unless you have a
 subscription.
 
 Subscription alternative
-------------------------
+========================
 
 Alternatively, for those that need an enterprise-ready solution, Element
 Server Suite (ESS) is `available as a subscription <https://element.io/pricing>`_.

--- a/changelog.d/17329.doc
+++ b/changelog.d/17329.doc
@@ -1,0 +1,1 @@
+Remove the auto-generated table of contents from the README.

--- a/changelog.d/17329.doc
+++ b/changelog.d/17329.doc
@@ -1,1 +1,1 @@
-Remove the auto-generated table of contents from the README.
+Update header in the README to visually fix the the auto-generated table of contents.


### PR DESCRIPTION
With the top-level header, the auto-generated TOC is pretty ugly.

![image](https://github.com/element-hq/synapse/assets/1342360/1013a599-f958-4316-9603-645c87ff21b0)

We could manually write a TOC, but we'd need to keep it up to date.

GitHub generates a TOC already - just hit the Outline button:

![image](https://github.com/element-hq/synapse/assets/1342360/076ca7de-79a9-47b1-9eba-beb344cca052)

~~I propose to just remove it.~~ Let's fix it: https://github.com/element-hq/synapse/pull/17329#issuecomment-2182617839

(Note that this is probably the only thing holding us back from converting the README to markdown - but that would be a separate PR.)