### PR TITLE
Support MSC3779: "Owned" state events

### DIFF
--- a/changelog.d/17332.feature
+++ b/changelog.d/17332.feature
@@ -1,0 +1,1 @@
+Add implementation of owned state events as proposed by [MSC3779](https://github.com/matrix-org/matrix-spec-proposals/pull/3779).

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -132,6 +132,23 @@ class EventTypes:
     CallInvite: Final = "m.call.invite"
 
 
+ZERO_LENGTH_STATE_KEY_EVENT_TYPES = {
+    EventTypes.CanonicalAlias,
+    EventTypes.Create,
+    EventTypes.JoinRules,
+    EventTypes.PowerLevels,
+    EventTypes.Name,
+    EventTypes.Topic,
+    EventTypes.RoomAvatar,
+    EventTypes.Pinned,
+    EventTypes.RoomEncryption,
+    EventTypes.RoomHistoryVisibility,
+    EventTypes.GuestAccess,
+    EventTypes.ServerACL,
+    EventTypes.Tombstone,
+}
+
+
 class ToDeviceEventTypes:
     RoomKeyRequest: Final = "m.room_key_request"
 

--- a/synapse/api/room_versions.py
+++ b/synapse/api/room_versions.py
@@ -320,6 +320,26 @@ class RoomVersions:
         enforce_int_power_levels=True,
         msc3931_push_features=(PushRuleRoomFlag.EXTENSIBLE_EVENTS,),
     )
+    MSC3779v10 = RoomVersion(
+        # MSC3779 ("Owned" state events) based on room version "10"
+        "org.matrix.msc3779.10",
+        RoomDisposition.UNSTABLE,
+        EventFormatVersions.ROOM_V4_PLUS,
+        StateResolutionVersions.V2,
+        enforce_key_validity=True,
+        special_case_aliases_auth=False,
+        strict_canonicaljson=True,
+        limit_notifications_power_levels=True,
+        implicit_room_creator=False,
+        updated_redaction_rules=False,
+        restricted_join_rule=True,
+        restricted_join_rule_fix=True,
+        knock_join_rule=True,
+        msc3389_relation_redactions=False,
+        knock_restricted_join_rule=True,
+        enforce_int_power_levels=True,
+        msc3931_push_features=(),
+    )
     V11 = RoomVersion(
         "11",
         RoomDisposition.STABLE,
@@ -355,6 +375,7 @@ KNOWN_ROOM_VERSIONS: Dict[str, RoomVersion] = {
         RoomVersions.V9,
         RoomVersions.V10,
         RoomVersions.V11,
+        RoomVersions.MSC3779v10,
     )
 }
 

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -808,11 +808,12 @@ def get_send_level(
 def _can_send_event(event: "EventBase", auth_events: StateMap["EventBase"]) -> bool:
     power_levels_event = get_power_level_event(auth_events)
 
+    uses_owned_state_events = event.room_version is RoomVersions.MSC3779v10
     send_level = get_send_level(
         event.type,
         event.get("state_key"),
         power_levels_event,
-        event.user_id if event.room_version is RoomVersions.MSC3779v10 else None,
+        event.user_id if uses_owned_state_events else None,
     )
     user_level = get_user_power_level(event.user_id, auth_events)
 
@@ -826,7 +827,7 @@ def _can_send_event(event: "EventBase", auth_events: StateMap["EventBase"]) -> b
 
     # Check state_key
     if hasattr(event, "state_key"):
-        if event.state_key.startswith("@"):
+        if not uses_owned_state_events and event.state_key.startswith("@"):
             if event.state_key != event.user_id:
                 raise AuthError(403, "You are not allowed to set others state")
 

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -46,6 +46,7 @@ from unpaddedbase64 import decode_base64
 
 from synapse.api.constants import (
     MAX_PDU_SIZE,
+    ZERO_LENGTH_STATE_KEY_EVENT_TYPES,
     EventContentFields,
     EventTypes,
     JoinRules,
@@ -794,6 +795,7 @@ def get_send_level(
                 state_key == msc_3779_sender
                 or state_key.startswith(msc_3779_sender + "_")
             )
+            and etype not in ZERO_LENGTH_STATE_KEY_EVENT_TYPES
         )
         if state_key is not None and not is_owned_state_event:
             send_level = power_levels_content.get("state_default", 50)

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -829,8 +829,7 @@ def _can_send_event(event: "EventBase", auth_events: StateMap["EventBase"]) -> b
     if hasattr(event, "state_key"):
         if event.state_key.startswith("@"):
             if event.state_key != event.user_id and (
-                not use_msc3779
-                or not event.state_key.startswith(event.user_id + "_")
+                not use_msc3779 or not event.state_key.startswith(event.user_id + "_")
             ):
                 raise AuthError(403, "You are not allowed to set others state")
 

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -828,8 +828,8 @@ def _can_send_event(event: "EventBase", auth_events: StateMap["EventBase"]) -> b
     # Check state_key
     if hasattr(event, "state_key"):
         if event.state_key.startswith("@"):
-            if event.state_key != event.user_id and (
-                not use_msc3779 or not event.state_key.startswith(event.user_id + "_")
+            if event.state_key != event.user_id and not (
+                use_msc3779 and event.state_key.startswith(event.user_id + "_")
             ):
                 raise AuthError(403, "You are not allowed to set others state")
 


### PR DESCRIPTION
See: [MSC3779](https://github.com/matrix-org/matrix-spec-proposals/pull/3779)

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
