### PR TITLE
Fix room `type` typo in mailer

### DIFF
--- a/changelog.d/17336.bugfix
+++ b/changelog.d/17336.bugfix
@@ -1,0 +1,1 @@
+Fix email notification subject when invited to a space.

--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -716,7 +716,7 @@ class Mailer:
                 )
                 if (
                     create_event
-                    and create_event.content.get("room_type") == RoomTypes.SPACE
+                    and create_event.content.get(EventContentFields.ROOM_TYPE) == RoomTypes.SPACE
                 ):
                     return self.email_subjects.invite_from_person_to_space % {
                         "person": inviter_name,

--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -28,7 +28,7 @@ import jinja2
 from markupsafe import Markup
 from prometheus_client import Counter
 
-from synapse.api.constants import EventTypes, Membership, RoomTypes
+from synapse.api.constants import EventContentFields, EventTypes, Membership, RoomTypes
 from synapse.api.errors import StoreError
 from synapse.config.emailconfig import EmailSubjectConfig
 from synapse.events import EventBase
@@ -716,7 +716,8 @@ class Mailer:
                 )
                 if (
                     create_event
-                    and create_event.content.get(EventContentFields.ROOM_TYPE) == RoomTypes.SPACE
+                    and create_event.content.get(EventContentFields.ROOM_TYPE)
+                    == RoomTypes.SPACE
                 ):
                     return self.email_subjects.invite_from_person_to_space % {
                         "person": inviter_name,


### PR DESCRIPTION
Fix room `type` typo in mailer

Correct event content field is `EventContentFields.ROOM_TYPE` (`type`) :white_check_mark: , not `room_type` :x:

Spec: https://spec.matrix.org/v1.10/client-server-api/#mroomcreate

> ### `m.room.create`
> 
> Name | Type | Description
> --- | --- | ---
> `creator` | `string` | The `user_id` of the room creator. Required for, and only present in, room versions 1 - 10. Starting with room version 11 the event `sender` should be used instead.
> `m.federate` | `boolean` | Whether users on other servers can join this room. Defaults to `true` if key does not exist.
> `predecessor` | `Previous Room` | A reference to the room this room replaces, if the previous room was upgraded.
> `room_version` | `string` | The version of the room. Defaults to "1" if the key does not exist.
> `type` | `string` | Optional [room type](https://spec.matrix.org/v1.10/client-server-api/#types) to denote a room’s intended function outside of traditional conversation. Unspecified room types are possible using [Namespaced Identifiers](https://spec.matrix.org/v1.10/appendices/#common-namespaced-identifier-grammar).

---

Bug introduced in https://github.com/matrix-org/synapse/pull/10426



### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
