### PR TITLE
Fix outdated Security Disclosure Policy references

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,4 +2,4 @@
 (using a matrix.org account if necessary). We do not use GitHub issues for
 support.
 
-**If you want to report a security issue** please see https://matrix.org/security-disclosure-policy/
+**If you want to report a security issue** please see https://element.io/security/security-disclosure-policy

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -7,7 +7,7 @@ body:
         **THIS IS NOT A SUPPORT CHANNEL!**
         **IF YOU HAVE SUPPORT QUESTIONS ABOUT RUNNING OR CONFIGURING YOUR OWN HOME SERVER**, please ask in **[#synapse:matrix.org](https://matrix.to/#/#synapse:matrix.org)** (using a matrix.org account if necessary).
 
-        If you want to report a security issue, please see https://matrix.org/security-disclosure-policy/
+        If you want to report a security issue, please see https://element.io/security/security-disclosure-policy
 
         This is a bug report form. By following the instructions below and completing the sections with your information, you will help the us to get all the necessary data to fix your issue.
 

--- a/changelog.d/17341.doc
+++ b/changelog.d/17341.doc
@@ -1,0 +1,1 @@
+Fix stale references to the Foundation's Security Disclosure Policy.

--- a/docs/welcome_and_overview.md
+++ b/docs/welcome_and_overview.md
@@ -62,6 +62,6 @@ following documentation:
 
 ## Reporting a security vulnerability
 
-If you've found a security issue in Synapse or any other Matrix.org Foundation
-project, please report it to us in accordance with our [Security Disclosure
-Policy](https://www.matrix.org/security-disclosure-policy/). Thank you!
+If you've found a security issue in Synapse or any other Element project,
+please report it to us in accordance with our [Security Disclosure
+Policy](https://element.io/security/security-disclosure-policy). Thank you!


### PR DESCRIPTION
Removes stale references to Matrix.org's SDP and replace it with Element's.