### PR TITLE
Fix building debian packages on non-clean checkouts

### DIFF
--- a/changelog.d/17390.misc
+++ b/changelog.d/17390.misc
@@ -1,0 +1,1 @@
+Fix building debian packages on non-clean checkouts.

--- a/docker/build_debian.sh
+++ b/docker/build_debian.sh
@@ -12,7 +12,7 @@ cp -aT /synapse/source /synapse/build
 cd /synapse/build
 
 # Delete any existing `.so` files to ensure a clean build.
-rm /synapse/build/synapse/*.so
+rm -f /synapse/build/synapse/*.so
 
 # if this is a prerelease, set the Section accordingly.
 #

--- a/docker/build_debian.sh
+++ b/docker/build_debian.sh
@@ -11,6 +11,9 @@ DIST=$(cut -d ':' -f2 <<< "${distro:?}")
 cp -aT /synapse/source /synapse/build
 cd /synapse/build
 
+# Delete any existing `.so` files to ensure a clean build.
+rm /synapse/build/synapse/*.so
+
 # if this is a prerelease, set the Section accordingly.
 #
 # When the package is later added to the package repo, reprepro will use the


### PR DESCRIPTION
If we leave the `.so` in place it causes the tests to fail, as it gets picked up (instead of the newly built .so) and so fails with mismatched GLIBC errors.