### PR TITLE
Track complement release branch when releasing

### DIFF
--- a/changelog.d/17396.misc
+++ b/changelog.d/17396.misc
@@ -1,0 +1,1 @@
+Pin CI to complement release branch for releases.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -71,6 +71,8 @@ def cli() -> None:
 
       - A checkout of the sytest repository at ../sytest
 
+      - A checkout of the complement repository at ../complement
+
     Then to use:
 
         ./scripts-dev/release.py prepare
@@ -112,10 +114,12 @@ def _prepare() -> None:
     # Make sure we're in a git repo.
     synapse_repo = get_repo_and_check_clean_checkout()
     sytest_repo = get_repo_and_check_clean_checkout("../sytest", "sytest")
+    complement_repo = get_repo_and_check_clean_checkout("../complement", "complement")
 
-    click.secho("Updating Synapse and Sytest git repos...")
+    click.secho("Updating Synapse, Sytest and Complement git repos...")
     synapse_repo.remote().fetch()
     sytest_repo.remote().fetch()
+    complement_repo.remote().fetch()
 
     # Get the current version and AST from root Synapse module.
     current_version = get_package_version()
@@ -199,16 +203,28 @@ def _prepare() -> None:
         # release type.
         if current_version.is_prerelease:
             default = release_branch_name
+            complement_default = release_branch_name
         elif release_type == "minor":
             default = "develop"
+            complement_default = "main"
         else:
             default = "master"
+            complement_default = "main"
 
-        branch_name = click.prompt(
+        sy_branch_name = click.prompt(
             "Which branch should the release be based on?", default=default
         )
 
-        for repo_name, repo in {"synapse": synapse_repo, "sytest": sytest_repo}.items():
+        complement_branch = click.prompt(
+            "Which Complement branch should the release be based on?",
+            default=complement_default,
+        )
+
+        for repo_name, (repo, branch_name) in {
+            "synapse": (synapse_repo, sy_branch_name),
+            "sytest": (sytest_repo, sy_branch_name),
+            "complement": (complement_repo, complement_branch),
+        }.items():
             base_branch = find_ref(repo, branch_name)
             if not base_branch:
                 print(f"Could not find base branch {branch_name} for {repo_name}!")
@@ -230,6 +246,11 @@ def _prepare() -> None:
         # not on subsequent RCs or full releases).
         if click.confirm("Push new SyTest branch?", default=True):
             sytest_repo.git.push("-u", sytest_repo.remote().name, release_branch_name)
+        # The same special case rules apply to Complement.
+        if click.confirm("Push new Complement branch?", default=True):
+            complement_repo.git.push(
+                "-u", complement_repo.remote().name, release_branch_name
+            )
 
     # Switch to the release branch and ensure it's up to date.
     synapse_repo.git.checkout(release_branch_name)
@@ -630,6 +651,9 @@ def _merge_back() -> None:
     else:
         # Full release
         sytest_repo = get_repo_and_check_clean_checkout("../sytest", "sytest")
+        complement_repo = get_repo_and_check_clean_checkout(
+            "../complement", "complement"
+        )
 
         if click.confirm(f"Merge {branch_name} → master?", default=True):
             _merge_into(synapse_repo, branch_name, "master")
@@ -642,6 +666,9 @@ def _merge_back() -> None:
 
         if click.confirm("On SyTest, merge master → develop?", default=True):
             _merge_into(sytest_repo, "master", "develop")
+
+        if click.confirm(f"On Complement, merge {branch_name} → main?", default=True):
+            _merge_into(complement_repo, branch_name, "main")
 
 
 @cli.command()


### PR DESCRIPTION
I would like to test this out the next time I do a Synapse release before marking this PR as ready.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [X] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
