### PR TITLE
Upon deactivation, forget all of the user's rooms

### DIFF
--- a/changelog.d/17400.feature
+++ b/changelog.d/17400.feature
@@ -1,0 +1,1 @@
+Forget all of a user's rooms upon deactivation, enabling future purges.

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -283,6 +283,10 @@ class DeactivateAccountHandler:
                     ratelimit=False,
                     require_consent=False,
                 )
+
+                # Mark the room forgotten too, because they won't be able to do this
+                # for us. This may lead to the room being purged eventually.
+                await self._room_member_handler.forget(user, room_id)
             except Exception:
                 logger.exception(
                     "Failed to part user %r from room %r: ignoring and continuing",

--- a/tests/handlers/test_deactivate_account.py
+++ b/tests/handlers/test_deactivate_account.py
@@ -461,3 +461,25 @@ class DeactivateAccountTestCase(HomeserverTestCase):
         # Validate that there is no displayname in any of the events
         for event in events:
             self.assertTrue("displayname" not in event.content)
+
+    def test_rooms_forgotten_upon_deactivation(self) -> None:
+        """
+        Tests that the user 'forgets' the rooms they left upon deactivation.
+        """
+        # Create a room
+        room_id = self.helper.create_room_as(
+            self.user,
+            is_public=True,
+            tok=self.token,
+        )
+
+        # Deactivate the account
+        self._deactivate_my_account()
+
+        # Get all of the user's forgotten rooms
+        forgotten_rooms = self.get_success(
+            self._store.get_forgotten_rooms_for_user(self.user)
+        )
+
+        # Validate that the created room is forgotten
+        self.assertTrue(room_id in forgotten_rooms)


### PR DESCRIPTION
This can help ensure that the rooms are eventually purged if the other local users also forget them. Synapse already clears some of the room information as part of the `_background_remove_left_rooms` background task, but this doesn't catch `events`, `event_json`, etc.
