### PR TITLE
Fix exception when failing to talk to remote server

### DIFF
--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -322,6 +322,7 @@ class PerDestinationQueue:
         )
 
     async def _transaction_transmission_loop(self) -> None:
+        pending_pdus: List[EventBase] = []
         try:
             self.transmission_loop_running = True
 
@@ -337,11 +338,12 @@ class PerDestinationQueue:
                     # not caught up yet
                     return
 
+            pending_pdus = []
             while True:
                 self._new_data_to_send = False
 
                 async with _TransactionQueueManager(self) as (
-                    pending_pdus,
+                    pending_pdus,  # noqa: F811
                     pending_edus,
                 ):
                     if not pending_pdus and not pending_edus:


### PR DESCRIPTION
Broke in #17381

Stack trace:

```
RequestSendFailed: Failed to send request: RuntimeError: No Content-Type header received from remote server
  File "synapse/federation/sender/per_destination_queue.py", line 335, in _transaction_transmission_loop
    await self._catch_up_transmission_loop()
  File "synapse/federation/sender/per_destination_queue.py", line 585, in _catch_up_transmission_loop
    await self._transaction_manager.send_new_transaction(
  File "synapse/util/metrics.py", line 120, in measured_func
    r = await func(self, *args, **kwargs)
  File "synapse/federation/sender/transaction_manager.py", line 169, in send_new_transaction
    response = await self._transport_layer.send_transaction(
  File "synapse/federation/transport/client.py", line 255, in send_transaction
    return await self.client.put_json(
  File "synapse/http/matrixfederationclient.py", line 1057, in put_json
    body = await _handle_response(
  File "synapse/http/matrixfederationclient.py", line 295, in _handle_response
    check_content_type_is(response.headers, parser.CONTENT_TYPE)
  File "synapse/http/matrixfederationclient.py", line 1774, in check_content_type_is
    raise RequestSendFailed(
UnboundLocalError: cannot access local variable 'pending_pdus' where it is not associated with a value
  File "synapse/metrics/background_process_metrics.py", line 251, in run
    return await func(*args, **kwargs)
  File "synapse/federation/sender/per_destination_queue.py", line 424, in _transaction_transmission_loop
    for p in pending_pdus:
```