### PR TITLE
Refund unused rate limit on downloads

### DIFF
--- a/changelog.d/17417.bugfix
+++ b/changelog.d/17417.bugfix
@@ -1,0 +1,1 @@
+Relax rate limiting behaviour on federated media downloads of unknown size.

--- a/tests/media/test_media_storage.py
+++ b/tests/media/test_media_storage.py
@@ -1086,10 +1086,29 @@ class RemoteDownloadLimiterTestCase(unittest.HomeserverTestCase):
             )
             assert channel2.code == 200
 
-        # eleventh will hit ratelimit
-        channel3 = self.make_request(
-            "GET",
-            "/_matrix/media/v3/download/remote.org/abcdefghijklmnopqrstuvwxyx",
-            shorthand=False,
-        )
-        assert channel3.code == 429
+        # If the refund code is working correctly, there should be ~200MB of free space
+        # in the limit. This is because we're assuming each file is 50MB, but are only
+        # consuming 30MB files (per the @patch on this test). We should be able to get
+        # 6 more requests through now, before rate limiting on the 7th or 8th (we can
+        # expect that 6.667 requests will make it at 200MB / 30MB, which may be just
+        # enough for a slow test run to get an additional request through).
+        for i in range(6):
+            channel3 = self.make_request(
+                "GET",
+                f"/_matrix/media/v3/download/remote.org/abcd{i}",
+                shorthand=False,
+            )
+            assert channel3.code == 200
+
+        # Try the rate limit again, testing the eighth request fails. We discard the
+        # seventh request because it may or may not be rate limited (see above). The
+        # eighth request would *definitely* be rate limited though, so we test that.
+        for i in range(2):
+            channel4 = self.make_request(
+                "GET",
+                f"/_matrix/media/v3/download/remote.org/abcde{i}",
+                shorthand=False,
+            )
+            if i == 1:  # test for second request (which will be #8)
+                assert channel4.code == 429
+            # else, discard 7th request because it's unhelpful


### PR DESCRIPTION
Fixes https://github.com/element-hq/synapse/issues/17394 (I think/hope)

A more complete fix likely involves the use of a `Linearizer` over the download endpoint, limiting the number of concurrent requests to ~6 from any one client. We would then only count against the requester's bucket once we know the size for sure instead of decrementing by `max_size`. Instead, this PR tries to refund the difference back to the rate limit, allowing the user to request more media at the cost of being rate limited if they have several (assumed) large concurrent requests on the go. The hope is this is uncommon, and that downloads complete quick enough to refund the bucket. 

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
