### PR TITLE
Note the new federated media worker endpoints in the worker docs & upgrade notes

### DIFF
--- a/changelog.d/17421.doc
+++ b/changelog.d/17421.doc
@@ -1,0 +1,1 @@
+Document the new federation media worker endpoints in the [upgrade notes](https://element-hq.github.io/synapse/v1.111/upgrade.html) and [worker docs](https://element-hq.github.io/synapse/v1.111/workers.html).

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -119,13 +119,14 @@ stacking them up. You can monitor the currently running background updates with
 
 # Upgrading to v1.111.0
 
-## New worker endpoints for authenticated client media
+## New worker endpoints for authenticated client and federation media
 
 [Media repository workers](./workers.md#synapseappmedia_repository) handling
-Media APIs can now handle the following endpoint pattern:
+Media APIs can now handle the following endpoint patterns:
 
 ```
 ^/_matrix/client/v1/media/.*$
+^/_matrix/federation/v1/media/.*$
 ```
 
 Please update your reverse proxy configuration.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -740,6 +740,7 @@ Handles the media repository. It can handle all endpoints starting with:
 
     /_matrix/media/
     /_matrix/client/v1/media/
+    /_matrix/federation/v1/media/
 
 ... and the following regular expressions matching media-specific administration APIs:
 


### PR DESCRIPTION
Media workers can handle the new auth'd media federation endpoints as well.

The new endpoints are:

* [`GET /_matrix/federation/v1/media/download/{mediaId}`](https://spec.matrix.org/v1.11/server-server-api/#get_matrixfederationv1mediadownloadmediaid)
* [`GET /_matrix/federation/v1/media/thumbnail/{mediaId}`](https://spec.matrix.org/v1.11/server-server-api/#get_matrixfederationv1mediathumbnailmediaid)