### PR TITLE
Route auth'd fed media requests to media repo in Complement tests

### DIFF
--- a/changelog.d/17422.misc
+++ b/changelog.d/17422.misc
@@ -1,0 +1,1 @@
+Route authenticated federation media requests to media repository workers in Complement tests.

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -126,6 +126,7 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
             "^/_synapse/admin/v1/media/.*$",
             "^/_synapse/admin/v1/quarantine_media/.*$",
             "^/_matrix/client/v1/media/.*$",
+            "^/_matrix/federation/v1/media/.*$",
         ],
         # The first configured media worker will run the media background jobs
         "shared_extra_conf": {


### PR DESCRIPTION
Missed in https://github.com/element-hq/synapse/pull/17350.