### PR TITLE
Fix bug where sync could get stuck when using workers

### DIFF
--- a/changelog.d/17438.bugfix
+++ b/changelog.d/17438.bugfix
@@ -1,0 +1,1 @@
+Fix rare bug where the `/sync` would break for a user when using workers with multiple stream writers.

--- a/changelog.d/17438.bugfix
+++ b/changelog.d/17438.bugfix
@@ -1,1 +1,1 @@
-Fix rare bug where the `/sync` would break for a user when using workers with multiple stream writers.
+Fix rare bug where `/sync` would break for a user when using workers with multiple stream writers.

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -640,10 +640,17 @@ class SlidingSyncHandler:
                 instance_to_max_stream_ordering_map[instance_name] = stream_ordering
 
         # Then assemble the `RoomStreamToken`
+        min_stream_pos = min(instance_to_max_stream_ordering_map.values())
         membership_snapshot_token = RoomStreamToken(
             # Minimum position in the `instance_map`
-            stream=min(instance_to_max_stream_ordering_map.values()),
-            instance_map=immutabledict(instance_to_max_stream_ordering_map),
+            stream=min_stream_pos,
+            instance_map=immutabledict(
+                {
+                    instance_name: stream_pos
+                    for instance_name, stream_pos in instance_to_max_stream_ordering_map.items()
+                    if stream_pos > min_stream_pos
+                }
+            ),
         )
 
         # Since we fetched the users room list at some point in time after the from/to

--- a/synapse/types/__init__.py
+++ b/synapse/types/__init__.py
@@ -557,10 +557,15 @@ class AbstractMultiWriterStreamToken(metaclass=abc.ABCMeta):
     def bound_stream_token(self, max_stream: int) -> "Self":
         """Bound the stream positions to a maximum value"""
 
+        min_pos = min(self.stream, max_stream)
         return type(self)(
-            stream=min(self.stream, max_stream),
+            stream=min_pos,
             instance_map=immutabledict(
-                {k: min(s, max_stream) for k, s in self.instance_map.items()}
+                {
+                    k: min(s, max_stream)
+                    for k, s in self.instance_map.items()
+                    if min(s, max_stream) > min_pos
+                }
             ),
         )
 

--- a/synapse/types/__init__.py
+++ b/synapse/types/__init__.py
@@ -668,6 +668,11 @@ class RoomStreamToken(AbstractMultiWriterStreamToken):
 
                 instance_map = {}
                 for part in parts[1:]:
+                    if not part:
+                        # Handle tokens of the form `m5~`, which were created by
+                        # a bug
+                        continue
+
                     key, value = part.split(".")
                     instance_id = int(key)
                     pos = int(value)
@@ -778,6 +783,11 @@ class MultiWriterStreamToken(AbstractMultiWriterStreamToken):
 
                 instance_map = {}
                 for part in parts[1:]:
+                    if not part:
+                        # Handle tokens of the form `m5~`, which were created by
+                        # a bug
+                        continue
+
                     key, value = part.split(".")
                     instance_id = int(key)
                     pos = int(value)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -188,6 +188,9 @@ class MultiWriterTokenTestCase(unittest.HomeserverTestCase):
         with self.assertRaises(ValueError):
             self.token_type(stream=5, instance_map=immutabledict({"foo": 4}))
 
+        with self.assertRaises(ValueError):
+            self.token_type(stream=5, instance_map=immutabledict({"foo": 5}))
+
     def test_parse_bad_token(self) -> None:
         """Test that we can parse tokens produced by a bug in Synapse of the
         form `m5~`"""

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -161,16 +161,9 @@ class RoomStreamTokenTestCase(unittest.HomeserverTestCase):
         parsed_token = self.get_success(RoomStreamToken.parse(store, string_token))
         self.assertEqual(parsed_token, token)
 
-    @skipUnless(USE_POSTGRES_FOR_TESTS, "Requires Postgres")
-    def test_instance_map_behind(self) -> None:
-        """Test for stream token with instance map, where instance map entries
-        are from before stream token."""
-        store = self.hs.get_datastores().main
+    def test_instance_map_assertion(self) -> None:
+        """Test that we assert values in the instance map are greater than the
+        min stream position"""
 
-        token = RoomStreamToken(stream=5, instance_map=immutabledict({"foo": 4}))
-
-        string_token = self.get_success(token.to_string(store))
-        self.assertEqual(string_token, "s5")
-
-        parsed_token = self.get_success(RoomStreamToken.parse(store, string_token))
-        self.assertEqual(parsed_token, RoomStreamToken(stream=5))
+        with self.assertRaises(ValueError):
+            RoomStreamToken(stream=5, instance_map=immutabledict({"foo": 4}))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -153,7 +153,7 @@ class MultiWriterTokenTestCase(unittest.HomeserverTestCase):
     token_type: Type[AbstractMultiWriterStreamToken]
 
     def test_basic_token(self) -> None:
-        """Test that a simple stream token be serialized and unserialized"""
+        """Test that a simple stream token can be serialized and unserialized"""
         store = self.hs.get_datastores().main
 
         token = self.token_type(stream=5)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -167,3 +167,11 @@ class RoomStreamTokenTestCase(unittest.HomeserverTestCase):
 
         with self.assertRaises(ValueError):
             RoomStreamToken(stream=5, instance_map=immutabledict({"foo": 4}))
+
+    def test_parse_bad_token(self) -> None:
+        """Test that we can parse tokens produced by a bug in Synapse of the
+        form `m5~`"""
+        store = self.hs.get_datastores().main
+
+        parsed_token = self.get_success(RoomStreamToken.parse(store, "m5~"))
+        self.assertEqual(parsed_token, RoomStreamToken(stream=5))


### PR DESCRIPTION
This is because we serialized the token wrong if the instance map
contained entries from before the minimum token.