### PR TITLE
Handle remote download responses with `UNKNOWN_LENGTH` more gracefully

### DIFF
--- a/changelog.d/17439.bugfix
+++ b/changelog.d/17439.bugfix
@@ -1,0 +1,1 @@
+Limit concurrent remote downloads to 6 per IP address, and decrement remote downloads without a content-length from the ratelimiter after the download is complete.


### PR DESCRIPTION
Prior to this PR, remote downloads which did not provide a `content-length` were decremented from the remote download ratelimiter at the max allowable size, leading to excessive ratelimiting - see https://github.com/element-hq/synapse/issues/17394.

This PR adds a linearizer to limit concurrent remote downloads to 6 per IP address, and decrements remote downloads without a `content-length` from the ratelimiter *after* the download is complete and the response length is known. 

Also adds logic to ensure that responses with a known length respect the `max_download_size`. 