### PR TITLE
Remove unnecessary call to resume producing in fake channel

### DIFF
--- a/changelog.d/17449.bugfix
+++ b/changelog.d/17449.bugfix
@@ -1,0 +1,1 @@
+Remove unnecessary call to resume producing in fake channel.

--- a/tests/server.py
+++ b/tests/server.py
@@ -289,10 +289,6 @@ class FakeChannel:
         self._reactor.run()
 
         while not self.is_finished():
-            # If there's a producer, tell it to resume producing so we get content
-            if self._producer:
-                self._producer.resumeProducing()
-
             if self._reactor.seconds() > end_time:
                 raise TimedOutException("Timed out waiting for request to finish.")
 


### PR DESCRIPTION
This fell out of the authenticated media work - this bit of code masked a bug but does not break anything when removed, so probably should be removed. 
