### PR TITLE
Speed up room keys query by using read/write lock

### DIFF
--- a/changelog.d/17461.misc
+++ b/changelog.d/17461.misc
@@ -1,1 +1,1 @@
-Speed up fetching room keys.
+Speed up fetching room keys from backup.

--- a/changelog.d/17461.misc
+++ b/changelog.d/17461.misc
@@ -1,0 +1,1 @@
+Speed up fetching room keys.


### PR DESCRIPTION
Linaerizing all access slows things down when devices try and fetch lots of keys on login