### PR TITLE
Sliding Sync: Add Account Data extension (MSC3959)

### DIFF
--- a/changelog.d/17477.feature
+++ b/changelog.d/17477.feature
@@ -1,0 +1,1 @@
+Add Account Data extension support to experimental [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575) Sliding Sync `/sync` endpoint.

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -1979,7 +1979,7 @@ class SlidingSyncHandler:
         lists: Dict[str, SlidingSyncResult.SlidingWindowList],
         account_data_request: SlidingSyncConfig.Extensions.AccountDataExtension,
         to_token: StreamToken,
-        from_token: Optional[StreamToken],
+        from_token: Optional[SlidingSyncStreamToken],
     ) -> Optional[SlidingSyncResult.Extensions.AccountDataExtension]:
         """Handle Account Data extension (MSC3959)
 
@@ -2000,12 +2000,12 @@ class SlidingSyncHandler:
         if from_token is not None:
             global_account_data_map = (
                 await self.store.get_updated_global_account_data_for_user(
-                    user_id, from_token.account_data_key
+                    user_id, from_token.stream_token.account_data_key
                 )
             )
 
             have_push_rules_changed = await self.store.have_push_rules_changed_for_user(
-                user_id, from_token.push_rules_key
+                user_id, from_token.stream_token.push_rules_key
             )
             if have_push_rules_changed:
                 global_account_data_map = dict(global_account_data_map)
@@ -2075,7 +2075,7 @@ class SlidingSyncHandler:
             if from_token is not None:
                 account_data_by_room_map = (
                     await self.store.get_updated_room_account_data_for_user(
-                        user_id, from_token.account_data_key
+                        user_id, from_token.stream_token.account_data_key
                     )
                 )
             else:

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -1816,9 +1816,19 @@ class SlidingSyncHandler:
                 from_token=from_token,
             )
 
+        account_data_response = None
+        if sync_config.extensions.account_data is not None:
+            account_data_response = await self.get_account_data_extension_response(
+                sync_config=sync_config,
+                account_data_request=sync_config.extensions.account_data,
+                to_token=to_token,
+                from_token=from_token,
+            )
+
         return SlidingSyncResult.Extensions(
             to_device=to_device_response,
             e2ee=e2ee_response,
+            account_data=account_data_response,
         )
 
     async def get_to_device_extension_response(

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -927,7 +927,6 @@ class SlidingSyncRestServlet(RestServlet):
 
         return 200, response_content
 
-    # TODO: Is there a better way to encode things?
     async def encode_response(
         self,
         requester: Requester,
@@ -1114,6 +1113,24 @@ class SlidingSyncRestServlet(RestServlet):
                 serialized_extensions["e2ee"]["device_lists"]["left"] = list(
                     extensions.e2ee.device_list_updates.left
                 )
+
+        if extensions.account_data is not None:
+            serialized_extensions["account_data"] = {
+                # Same as the the top-level `account_data.events` field in Sync v2.
+                "global": [
+                    {"type": account_data_type, "content": content}
+                    for account_data_type, content in extensions.account_data.global_account_data_map.items()
+                ],
+                # Same as the joined room's account_data field in Sync v2, e.g the path
+                # `rooms.join["!foo:bar"].account_data.events`.
+                "rooms": {
+                    room_id: [
+                        {"type": account_data_type, "content": content}
+                        for account_data_type, content in event_map.items()
+                    ]
+                    for room_id, event_map in extensions.account_data.account_data_by_room_map.items()
+                },
+            }
 
         return serialized_extensions
 

--- a/synapse/types/handlers/__init__.py
+++ b/synapse/types/handlers/__init__.py
@@ -322,6 +322,21 @@ class SlidingSyncResult:
                     or self.device_list_updates
                     or self.device_unused_fallback_key_types
                 )
+            
+        @attr.s(slots=True, frozen=True, auto_attribs=True)
+        class AccountDataExtension:
+            """The Account Data extension (MSC3959)
+
+            Attributes:
+                global: Same as the the top-level `account_data.events` field in Sync v2.
+                rooms: Same as the joined room's account_data field in Sync v2, e.g the path `rooms.join["!foo:bar"].account_data.events`.
+            """
+
+            global_events: List[JsonDict]
+            rooms: Dict[str, List[Dict[str, JsonDict]]]
+
+            def __bool__(self) -> bool:
+                return bool(self.events)
 
         to_device: Optional[ToDeviceExtension] = None
         e2ee: Optional[E2eeExtension] = None

--- a/synapse/types/handlers/__init__.py
+++ b/synapse/types/handlers/__init__.py
@@ -322,27 +322,32 @@ class SlidingSyncResult:
                     or self.device_list_updates
                     or self.device_unused_fallback_key_types
                 )
-            
+
         @attr.s(slots=True, frozen=True, auto_attribs=True)
         class AccountDataExtension:
             """The Account Data extension (MSC3959)
 
             Attributes:
-                global: Same as the the top-level `account_data.events` field in Sync v2.
-                rooms: Same as the joined room's account_data field in Sync v2, e.g the path `rooms.join["!foo:bar"].account_data.events`.
+                global_account_data_map: Mapping from `type` to `content` of global account
+                    data events.
+                account_data_by_room_map: Mapping from room_id to mapping of `type` to
+                    `content` of room account data events.
             """
 
-            global_events: List[JsonDict]
-            rooms: Dict[str, List[Dict[str, JsonDict]]]
+            global_account_data_map: Mapping[str, JsonMapping]
+            account_data_by_room_map: Mapping[str, Mapping[str, JsonMapping]]
 
             def __bool__(self) -> bool:
-                return bool(self.events)
+                return bool(
+                    self.global_account_data_map or self.account_data_by_room_map
+                )
 
         to_device: Optional[ToDeviceExtension] = None
         e2ee: Optional[E2eeExtension] = None
+        account_data: Optional[AccountDataExtension] = None
 
         def __bool__(self) -> bool:
-            return bool(self.to_device or self.e2ee)
+            return bool(self.to_device or self.e2ee or self.account_data)
 
     next_pos: StreamToken
     lists: Dict[str, SlidingWindowList]

--- a/synapse/types/rest/client/__init__.py
+++ b/synapse/types/rest/client/__init__.py
@@ -334,8 +334,10 @@ class SlidingSyncBody(RequestBodyModel):
             """
 
             enabled: Optional[StrictBool] = False
-            lists: Optional[List[StrictStr]] = None
-            rooms: Optional[List[StrictStr]] = None
+            # Process all lists defined in the Sliding Window API. (This is the default.)
+            lists: Optional[List[StrictStr]] = ["*"]
+            # Process all room subscriptions defined in the Room Subscription API. (This is the default.)
+            rooms: Optional[List[StrictStr]] = ["*"]
 
         to_device: Optional[ToDeviceExtension] = None
         e2ee: Optional[E2eeExtension] = None

--- a/synapse/types/rest/client/__init__.py
+++ b/synapse/types/rest/client/__init__.py
@@ -322,8 +322,24 @@ class SlidingSyncBody(RequestBodyModel):
 
             enabled: Optional[StrictBool] = False
 
+        class AccountDataExtension(RequestBodyModel):
+            """The Account Data extension (MSC3959)
+
+            Attributes:
+                enabled
+                lists: List of list keys (from the Sliding Window API) to apply this
+                    extension to.
+                rooms: List of room IDs (from the Room Subscription API) to apply this
+                    extension to.
+            """
+
+            enabled: Optional[StrictBool] = False
+            lists: Optional[List[StrictStr]] = None
+            rooms: Optional[List[StrictStr]] = None
+
         to_device: Optional[ToDeviceExtension] = None
         e2ee: Optional[E2eeExtension] = None
+        account_data: Optional[AccountDataExtension] = None
 
     # mypy workaround via https://github.com/pydantic/pydantic/issues/156#issuecomment-1130883884
     if TYPE_CHECKING:


### PR DESCRIPTION
For Sliding Sync, add Account Data (`account_data`) extension ([MSC3959](https://github.com/matrix-org/matrix-spec-proposals/pull/3959))

Based on [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575): Sliding Sync


### Dev notes

Sliding Sync extensions spec for how the `lists` and `rooms` parameters should work: https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md#extensions

```
SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.rest.client.test_sync.SlidingSyncAccountDataExtensionTestCase
```

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
