### PR TITLE
Refactor Sliding Sync tests to better utilize the `SlidingSyncBase` (pt. 1)

### DIFF
--- a/changelog.d/17481.misc
+++ b/changelog.d/17481.misc
@@ -1,0 +1,1 @@
+Refactor Sliding Sync tests to better utilize the `SlidingSyncBase`.

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -6103,8 +6103,9 @@ class SlidingSyncAccountDataExtensionTestCase(SlidingSyncBase):
         # `SlidingSyncResult.__bool__` for new results.
         self._bump_notifier_wait_for_events(
             user1_id,
-            # We choose presense because we're not testing for presence updates and
-            # don't want to contimainate the results.
+            # We choose `StreamKeyType.PRESENCE` because we're testing for account data
+            # and don't want to contaminate the account data results using
+            # `StreamKeyType.ACCOUNT_DATA`.
             wake_stream_key=StreamKeyType.PRESENCE,
         )
         # Block for a little bit more to ensure we don't see any new results.

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -1238,6 +1238,12 @@ class SlidingSyncBase(unittest.HomeserverTestCase):
 
     sync_endpoint = "/_matrix/client/unstable/org.matrix.simplified_msc3575/sync"
 
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        # Enable sliding sync
+        config["experimental_features"] = {"msc3575_enabled": True}
+        return config
+
     def do_sync(
         self, sync_body: JsonDict, *, since: Optional[str] = None, tok: str
     ) -> Tuple[JsonDict, str]:
@@ -1281,12 +1287,6 @@ class SlidingSyncTestCase(SlidingSyncBase):
         sync.register_servlets,
         devices.register_servlets,
     ]
-
-    def default_config(self) -> JsonDict:
-        config = super().default_config()
-        # Enable sliding sync
-        config["experimental_features"] = {"msc3575_enabled": True}
-        return config
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
@@ -4636,12 +4636,6 @@ class SlidingSyncToDeviceExtensionTestCase(SlidingSyncBase):
         sendtodevice.register_servlets,
     ]
 
-    def default_config(self) -> JsonDict:
-        config = super().default_config()
-        # Enable sliding sync
-        config["experimental_features"] = {"msc3575_enabled": True}
-        return config
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.event_sources = hs.get_event_sources()
@@ -4967,12 +4961,6 @@ class SlidingSyncE2eeExtensionTestCase(SlidingSyncBase):
         sync.register_servlets,
         devices.register_servlets,
     ]
-
-    def default_config(self) -> JsonDict:
-        config = super().default_config()
-        # Enable sliding sync
-        config["experimental_features"] = {"msc3575_enabled": True}
-        return config
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
@@ -5470,12 +5458,6 @@ class SlidingSyncAccountDataExtensionTestCase(SlidingSyncBase):
         sync.register_servlets,
         sendtodevice.register_servlets,
     ]
-
-    def default_config(self) -> JsonDict:
-        config = super().default_config()
-        # Enable sliding sync
-        config["experimental_features"] = {"msc3575_enabled": True}
-        return config
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main


### PR DESCRIPTION
Refactor Sliding Sync tests to better utilize the `SlidingSyncBase` (pt. 1)

`SlidingSyncBase` for tests was first introduced in https://github.com/element-hq/synapse/pull/17452

Part 2: https://github.com/element-hq/synapse/pull/17482

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
