### PR TITLE
Sliding Sync: Handle room_subscriptions that increase the `timeline_limit`

### DIFF
--- a/changelog.d/17503.misc
+++ b/changelog.d/17503.misc
@@ -1,0 +1,1 @@
+Handle requests for more events in a room when using experimental sliding sync.

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -2342,8 +2342,10 @@ class SlidingSyncConnectionStore:
         # end we can treat this as a noop.
         have_updated = False
         for room_id in sent_room_ids:
+            prev_state = new_room_statuses.get(room_id)
             new_room_statuses[room_id] = HaveSentRoom.live()
-            have_updated = True
+            if prev_state != new_room_statuses[room_id]:
+                have_updated = True
 
         # Whether we add/update the entries for unsent rooms depends on the
         # existing entry:

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -2238,13 +2238,16 @@ class HaveSentRoom:
     last_token: Optional[RoomStreamToken]
 
     @staticmethod
+    def live() -> "HaveSentRoom":
+        return HaveSentRoom(HaveSentRoomFlag.LIVE, None)
+
+    @staticmethod
     def previously(last_token: RoomStreamToken) -> "HaveSentRoom":
         """Constructor for `PREVIOUSLY` flag."""
         return HaveSentRoom(HaveSentRoomFlag.PREVIOUSLY, last_token)
 
 
 HAVE_SENT_ROOM_NEVER = HaveSentRoom(HaveSentRoomFlag.NEVER, None)
-HAVE_SENT_ROOM_LIVE = HaveSentRoom(HaveSentRoomFlag.LIVE, None)
 
 
 @attr.s(auto_attribs=True)
@@ -2339,7 +2342,7 @@ class SlidingSyncConnectionStore:
         # end we can treat this as a noop.
         have_updated = False
         for room_id in sent_room_ids:
-            new_room_statuses[room_id] = HAVE_SENT_ROOM_LIVE
+            new_room_statuses[room_id] = HaveSentRoom.live()
             have_updated = True
 
         # Whether we add/update the entries for unsent rooms depends on the

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -1595,6 +1595,12 @@ class SlidingSyncHandler:
                     stream=timeline_events[0].internal_metadata.stream_ordering - 1
                 )
 
+            if ignore_timeline_bound:
+                # If we're ignoring the timeline bound we *must* set limited to
+                # true, as otherwise the client will append the received events
+                # to the timeline, rather than replacing it.
+                limited = True
+
             # Make sure we don't expose any events that the client shouldn't see
             timeline_events = await filter_events_for_client(
                 self.storage_controllers,

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -2354,18 +2354,21 @@ class SlidingSyncConnectionStore:
         #     given token, so we don't need to update the entry.
         #   - NEVER: We have never previously sent down the room, and we haven't
         #     sent anything down this time either so we leave it as NEVER.
+        #
+        # We only need to do this if `from_token` is not None, as if it is then
+        # we know that there are no existing entires.
 
-        # Work out the new state for unsent rooms that were `LIVE`.
         if from_token:
             new_unsent_state = HaveSentRoom.previously(from_token.stream_token.room_key)
-        else:
-            new_unsent_state = HAVE_SENT_ROOM_NEVER
 
-        for room_id in unsent_room_ids:
-            prev_state = new_room_statuses.get(room_id)
-            if prev_state is not None and prev_state.status == HaveSentRoomFlag.LIVE:
-                new_room_statuses[room_id] = new_unsent_state
-                have_updated = True
+            for room_id in unsent_room_ids:
+                prev_state = new_room_statuses.get(room_id)
+                if (
+                    prev_state is not None
+                    and prev_state.status == HaveSentRoomFlag.LIVE
+                ):
+                    new_room_statuses[room_id] = new_unsent_state
+                    have_updated = True
 
         if not have_updated:
             return prev_connection_token


### PR DESCRIPTION
EX will have a low timeline limit in the standard room list, but will then use room subscriptions to request more history for certain rooms (i.e. the rooms the client things are at the top of the room list).

So if we see a timeline limit being increased for a room, then we need to send down some *historical* events. This is done by ignoring any from token for the timeline section and setting `limited=true`