### PR TITLE
Replace deprecated `HTTPAdapter.get_connection` method with  `get_connection_with_tls_context`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -745,7 +745,6 @@ jobs:
           # The newsfile lint may be skipped on non PR builds.
           skippable: |
             trial
-            trial-olddeps
             sytest
             portdb
             export-data

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -745,6 +745,7 @@ jobs:
           # The newsfile lint may be skipped on non PR builds.
           skippable: |
             trial
+            trial-olddeps
             sytest
             portdb
             export-data

--- a/changelog.d/17536.misc
+++ b/changelog.d/17536.misc
@@ -1,0 +1,1 @@
+Replace override of deprecated method `HTTPAdapter.get_connection` with `get_connection_with_tls_context`.

--- a/scripts-dev/federation_client.py
+++ b/scripts-dev/federation_client.py
@@ -298,22 +298,6 @@ class MatrixConnectionAdapter(HTTPAdapter):
 
         return super().send(request, *args, **kwargs)
 
-    # def get_connection(
-    #     self, url: str, proxies: Optional[Dict[str, str]] = None,
-    # ) -> HTTPConnectionPool:
-    #     # overrides the get_connection() method in the base class
-    #     parsed = urlparse.urlsplit(url)
-    #     (host, port, ssl_server_name) = self._lookup(parsed.netloc)
-    #     print(
-    #         f"Connecting to {host}:{port} with SNI {ssl_server_name}", file=sys.stderr
-    #     )
-    #     return self.poolmanager.connection_from_host(
-    #         host,
-    #         port=port,
-    #         scheme="https",
-    #         pool_kwargs={"server_hostname": ssl_server_name},
-    #     )
-
     def get_connection_with_tls_context(
         self,
         request: PreparedRequest,
@@ -322,11 +306,9 @@ class MatrixConnectionAdapter(HTTPAdapter):
         cert: Optional[Union[Tuple[str, str], str]] = None,
     ) -> HTTPConnectionPool:
         # overrides the get_connection_with_tls_context() method in the base class
-        # return self.get_connection(request.url, proxies)
-        # overrides the get_connection() method in the base class
         parsed = urlparse.urlsplit(request.url)
 
-        # Extract the hostname from the request URL and ensure it's a str.
+        # Extract the server name from the request URL, and ensure it's a str.
         hostname = parsed.netloc
         if isinstance(hostname, bytes):
             hostname = hostname.decode("utf-8")

--- a/scripts-dev/federation_client.py
+++ b/scripts-dev/federation_client.py
@@ -43,7 +43,7 @@ import argparse
 import base64
 import json
 import sys
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Mapping, Optional, Tuple, Union
 from urllib import parse as urlparse
 
 import requests
@@ -75,7 +75,7 @@ def encode_canonical_json(value: object) -> bytes:
         value,
         # Encode code-points outside of ASCII as UTF-8 rather than \u escapes
         ensure_ascii=False,
-        # Remove unecessary white space.
+        # Remove unnecessary white space.
         separators=(",", ":"),
         # Sort the keys of dictionaries.
         sort_keys=True,
@@ -298,12 +298,41 @@ class MatrixConnectionAdapter(HTTPAdapter):
 
         return super().send(request, *args, **kwargs)
 
-    def get_connection(
-        self, url: str, proxies: Optional[Dict[str, str]] = None
+    # def get_connection(
+    #     self, url: str, proxies: Optional[Dict[str, str]] = None,
+    # ) -> HTTPConnectionPool:
+    #     # overrides the get_connection() method in the base class
+    #     parsed = urlparse.urlsplit(url)
+    #     (host, port, ssl_server_name) = self._lookup(parsed.netloc)
+    #     print(
+    #         f"Connecting to {host}:{port} with SNI {ssl_server_name}", file=sys.stderr
+    #     )
+    #     return self.poolmanager.connection_from_host(
+    #         host,
+    #         port=port,
+    #         scheme="https",
+    #         pool_kwargs={"server_hostname": ssl_server_name},
+    #     )
+
+    def get_connection_with_tls_context(
+        self,
+        request: PreparedRequest,
+        verify: Optional[Union[bool, str]],
+        proxies: Optional[Mapping[str, str]] = None,
+        cert: Optional[Union[Tuple[str, str], str]] = None,
     ) -> HTTPConnectionPool:
+        # overrides the get_connection_with_tls_context() method in the base class
+        # return self.get_connection(request.url, proxies)
         # overrides the get_connection() method in the base class
-        parsed = urlparse.urlsplit(url)
-        (host, port, ssl_server_name) = self._lookup(parsed.netloc)
+        parsed = urlparse.urlsplit(request.url)
+
+        # Extract the hostname from the request URL and ensure it's a str.
+        hostname = parsed.netloc
+        if isinstance(hostname, bytes):
+            hostname = hostname.decode("utf-8")
+        assert isinstance(hostname, str)
+
+        (host, port, ssl_server_name) = self._lookup(hostname)
         print(
             f"Connecting to {host}:{port} with SNI {ssl_server_name}", file=sys.stderr
         )


### PR DESCRIPTION
This PR replaces the deprecated `get_connection` method in `MatrixConnectionAdapter` with a similar implementation in `get_connection_with_tls_context`. It also fixes a couple mypy errors that were firing on the arguments of `get_connection`.

See context for the deprecated method here: https://github.com/psf/requests/pull/6710

Fixes the errors raised in https://github.com/element-hq/synapse/pull/17524