### PR TITLE
Remove logging in multipart

### DIFF
--- a/changelog.d/17563.misc
+++ b/changelog.d/17563.misc
@@ -1,0 +1,1 @@
+Reduce log spam of multipart files.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -1088,7 +1088,6 @@ class _MultipartParserProtocol(protocol.Protocol):
                     return
                 # otherwise we are in the file part
                 else:
-                    logger.info("Writing multipart file data to stream")
                     try:
                         self.stream.write(data[start:end])
                     except Exception as e:


### PR DESCRIPTION
This is really spurious and causes a lot of spam. I don't think there is a use for it even at DEBUG level.