### PR TITLE
Use a larger, dedicated threadpool for media sending

### DIFF
--- a/changelog.d/17564.misc
+++ b/changelog.d/17564.misc
@@ -1,0 +1,1 @@
+Speed up responding to media requests.

--- a/synapse/media/storage_provider.py
+++ b/synapse/media/storage_provider.py
@@ -178,7 +178,7 @@ class FileStorageProviderBackend(StorageProvider):
 
         backup_fname = os.path.join(self.base_directory, path)
         if os.path.isfile(backup_fname):
-            return FileResponder(self.reactor, open(backup_fname, "rb"))
+            return FileResponder(self.hs, open(backup_fname, "rb"))
 
         return None
 

--- a/synapse/media/thumbnailer.py
+++ b/synapse/media/thumbnailer.py
@@ -374,11 +374,11 @@ class ThumbnailProvider:
                 await respond_with_multipart_responder(
                     self.hs.get_clock(),
                     request,
-                    FileResponder(self.reactor, open(file_path, "rb")),
+                    FileResponder(self.hs, open(file_path, "rb")),
                     media_info,
                 )
             else:
-                await respond_with_file(request, desired_type, file_path)
+                await respond_with_file(self.hs, request, desired_type, file_path)
         else:
             logger.warning("Failed to generate thumbnail")
             raise SynapseError(400, "Failed to generate thumbnail.")
@@ -456,7 +456,7 @@ class ThumbnailProvider:
         )
 
         if file_path:
-            await respond_with_file(request, desired_type, file_path)
+            await respond_with_file(self.hs, request, desired_type, file_path)
         else:
             logger.warning("Failed to generate thumbnail")
             raise SynapseError(400, "Failed to generate thumbnail.")

--- a/tests/server.py
+++ b/tests/server.py
@@ -1166,6 +1166,12 @@ def setup_test_homeserver(
 
     hs.get_auth_handler().validate_hash = validate_hash  # type: ignore[assignment]
 
+    # We need to replace the media threadpool with the fake test threadpool.
+    def thread_pool() -> threads.ThreadPool:
+        return reactor.getThreadPool()
+
+    hs.get_media_sender_thread_pool = thread_pool  # type: ignore[method-assign]
+
     # Load any configured modules into the homeserver
     module_api = hs.get_module_api()
     for module, module_config in hs.config.modules.loaded_modules:

--- a/tests/server.py
+++ b/tests/server.py
@@ -1167,7 +1167,7 @@ def setup_test_homeserver(
     hs.get_auth_handler().validate_hash = validate_hash  # type: ignore[assignment]
 
     # We need to replace the media threadpool with the fake test threadpool.
-    def thread_pool() -> threads.ThreadPool:
+    def thread_pool() -> threadpool.ThreadPool:
         return reactor.getThreadPool()
 
     hs.get_media_sender_thread_pool = thread_pool  # type: ignore[method-assign]


### PR DESCRIPTION
Otherwise we end up using the default one with just 10 threads.