### PR TITLE
Reduce concurrent thread usage in media

### DIFF
--- a/changelog.d/17567.misc
+++ b/changelog.d/17567.misc
@@ -1,0 +1,1 @@
+Speed up responding to media requests.

--- a/synapse/media/_base.py
+++ b/synapse/media/_base.py
@@ -694,7 +694,7 @@ class ThreadedFileSender:
         """This is the loop that drives reading/writing"""
         try:
             while not self.stop_writing:
-                # Start the loop in th threadpool to read data.
+                # Start the loop in the threadpool to read data.
                 more_data = await defer_to_threadpool(
                     self.reactor, self.thread_pool, self._on_thread_read_loop
                 )


### PR DESCRIPTION
Follow on from #17558

Basically, we want to reduce the number of threads we want to use at a time, i.e. reduce the number of threads that are paused/blocked. We do this by returning from the thread when the consumer pauses the producer, rather than pausing in the thread.