### PR TITLE
Fix fetching signing keys when `old_verify_keys` is omitted

### DIFF
--- a/changelog.d/17568.bugfix
+++ b/changelog.d/17568.bugfix
@@ -1,0 +1,1 @@
+Fix fetching federation signing keys from servers that omit `old_verify_keys`. Contributed by @tulir @ Beeper

--- a/changelog.d/17568.bugfix
+++ b/changelog.d/17568.bugfix
@@ -1,1 +1,1 @@
-Fix fetching federation signing keys from servers that omit `old_verify_keys`. Contributed by @tulir @ Beeper
+Fix fetching federation signing keys from servers that omit `old_verify_keys`. Contributed by @tulir @ Beeper.

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -589,7 +589,7 @@ class BaseV2KeyFetcher(KeyFetcher):
                 % (server_name,)
             )
 
-        for key_id, key_data in response_json["old_verify_keys"].items():
+        for key_id, key_data in response_json.get("old_verify_keys", {}).items():
             if is_signing_algorithm_supported(key_id):
                 key_base64 = key_data["key"]
                 key_bytes = decode_base64(key_base64)


### PR DESCRIPTION
`old_verify_keys` isn't marked as required in https://spec.matrix.org/v1.11/server-server-api/#get_matrixkeyv2server and there's no functional difference between an empty object and omitting the object, so I don't think there's any reason synapse should explode when the field is omitted.