### PR TITLE
Sliding sync: Add classes for per-connection state

### DIFF
--- a/changelog.d/17574.misc
+++ b/changelog.d/17574.misc
@@ -1,0 +1,1 @@
+Refactor per-connection state in experimental sliding sync handler.

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -3044,6 +3044,7 @@ class RoomStatusesForStream:
     """For a given stream, e.g. events, records what we have or have not sent
     down for that stream in a given room."""
 
+    # `room_id` -> `HaveSentRoom`
     _statuses: Mapping[str, HaveSentRoom] = attr.Factory(dict)
 
     def have_sent_room(self, room_id: str) -> HaveSentRoom:

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -585,7 +585,7 @@ class SlidingSyncHandler:
         # rooms to get them some results sooner but will end up taking the same
         # amount of time (more with round-trips and re-processing) in the end to
         # get everything again.
-        per_connection_state = await self.connection_store.get_per_connection_state(
+        previous_connection_state = await self.connection_store.get_per_connection_state(
             sync_config, from_token
         )
 
@@ -3123,7 +3123,13 @@ class MutableRoomStatusesForStream(RoomStatusesForStream):
 
 @attr.s(auto_attribs=True)
 class PerConnectionState:
-    """The per-connection state
+    """The per-connection state. A snapshot of what we've sent down the connection before.
+    
+    Currently, we track whether we've sent down various aspects of a given room before.
+    
+    We use the `rooms` field to store the position in the events stream for each room that we've previously sent to the client before. On the next request that includes the room, we can then send only what's changed since that recorded position.
+    
+    Same goes for the `receipts` field so we only need to send the new receipts since the last time you made a sync request.
 
     Attributes:
         rooms: The status of each room for the events stream.

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -3069,6 +3069,9 @@ class RoomStatusMap:
 class MutableRoomStatusMap(RoomStatusMap):
     """A mutable version of `RoomStatusMap`"""
 
+    # We use a ChainMap here so that we can easily track what has been updated
+    # and what hasn't. Note that when we persist the per connection state this
+    # will get flattened to a normal dict (via calling `.copy()`)
     _statuses: typing.ChainMap[str, HaveSentRoom]
 
     def __init__(
@@ -3253,6 +3256,8 @@ class SlidingSyncConnectionStore:
         new_store_token = prev_connection_token + 1
         sync_statuses.pop(new_store_token, None)
 
+        # We copy the `MutablePerConnectionState` so that the inner `ChainMap`s
+        # don't grow forever.
         sync_statuses[new_store_token] = PerConnectionState(
             rooms=per_connection_state.rooms.copy(),
         )

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -3088,10 +3088,9 @@ class MutableRoomStatusesForStream(RoomStatusesForStream):
     def record_sent_rooms(self, room_ids: StrCollection) -> None:
         """Record that we have sent these rooms in the response"""
         for room_id in room_ids:
-            current_status = self._statuses.get(room_id)
+            current_status = self._statuses.get(room_id, HAVE_SENT_ROOM_NEVER)
             if (
-                current_status is not None
-                and current_status.status == HaveSentRoomFlag.LIVE
+                current_status.status == HaveSentRoomFlag.LIVE
             ):
                 continue
 
@@ -3114,8 +3113,8 @@ class MutableRoomStatusesForStream(RoomStatusesForStream):
         #     sent anything down this time either so we leave it as NEVER.
 
         for room_id in room_ids:
-            current_status = self._statuses.get(room_id)
-            if current_status is None or current_status.status != HaveSentRoomFlag.LIVE:
+            current_status = self._statuses.get(room_id, HAVE_SENT_ROOM_NEVER)
+            if current_status.status != HaveSentRoomFlag.LIVE:
                 continue
 
             self._statuses[room_id] = HaveSentRoom.previously(from_token.room_key)

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -3177,7 +3177,7 @@ class SlidingSyncConnectionStore:
             to mapping of room ID to `HaveSentRoom`.
     """
 
-    # `(user_id, conn_id)` -> `token` -> `PerConnectionState`
+    # `(user_id, conn_id)` -> `connection_position` -> `PerConnectionState`
     _connections: Dict[Tuple[str, str], Dict[int, PerConnectionState]] = attr.Factory(
         dict
     )

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -785,7 +785,7 @@ class SlidingSyncHandler:
                 # we haven't sent the room down, or we have but there are missing
                 # updates).
                 for room_id in relevant_room_map:
-                    status = per_connection_state.rooms.have_sent_room(room_id)
+                    status = previous_connection_state.rooms.have_sent_room(room_id)
                     if (
                         # The room was never sent down before so the client needs to know
                         # about it regardless of any updates.
@@ -821,7 +821,7 @@ class SlidingSyncHandler:
         async def handle_room(room_id: str) -> None:
             room_sync_result = await self.get_room_sync_data(
                 sync_config=sync_config,
-                per_connection_state=per_connection_state,
+                per_connection_state=previous_connection_state,
                 room_id=room_id,
                 room_sync_config=relevant_rooms_to_send_map[room_id],
                 room_membership_for_user_at_to_token=room_membership_for_user_map[
@@ -854,7 +854,7 @@ class SlidingSyncHandler:
         )
 
         if has_lists or has_room_subscriptions:
-            new_connection_state = per_connection_state.get_mutable()
+            new_connection_state = previous_connection_state.get_mutable()
 
             # We now calculate if any rooms outside the range have had updates,
             # which we are not sending down.
@@ -3212,7 +3212,8 @@ class SlidingSyncConnectionStore:
 
         connection_position = from_token.connection_position
         if connection_position == 0:
-            # Initial sync (request without a `from_token`) starts at `0` so there is no existing per-connection state
+            # Initial sync (request without a `from_token`) starts at `0` so
+            # there is no existing per-connection state
             return PerConnectionState()
 
         conn_key = self._get_connection_key(sync_config)

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -3042,7 +3042,7 @@ HAVE_SENT_ROOM_LIVE = HaveSentRoom(HaveSentRoomFlag.LIVE, None)
 
 
 @attr.s(auto_attribs=True, slots=True, frozen=True)
-class RoomStatusesForStream:
+class RoomStatusMap:
     """For a given stream, e.g. events, records what we have or have not sent
     down for that stream in a given room."""
 
@@ -3053,21 +3053,21 @@ class RoomStatusesForStream:
         """Return whether we have previously sent the room down"""
         return self._statuses.get(room_id, HAVE_SENT_ROOM_NEVER)
 
-    def get_mutable(self) -> "MutableRoomStatusesForStream":
+    def get_mutable(self) -> "MutableRoomStatusMap":
         """Get a mutable copy of this state."""
-        return MutableRoomStatusesForStream(
+        return MutableRoomStatusMap(
             statuses=self._statuses,
         )
 
-    def copy(self) -> "RoomStatusesForStream":
+    def copy(self) -> "RoomStatusMap":
         """Make a copy of the class. Useful for converting from a mutable to
         immutable version."""
 
-        return RoomStatusesForStream(statuses=dict(self._statuses))
+        return RoomStatusMap(statuses=dict(self._statuses))
 
 
-class MutableRoomStatusesForStream(RoomStatusesForStream):
-    """A mutable version of `RoomStatusesForStream`"""
+class MutableRoomStatusMap(RoomStatusMap):
+    """A mutable version of `RoomStatusMap`"""
 
     _statuses: typing.ChainMap[str, HaveSentRoom]
 
@@ -3134,7 +3134,7 @@ class PerConnectionState:
         rooms: The status of each room for the events stream.
     """
 
-    rooms: RoomStatusesForStream = attr.Factory(RoomStatusesForStream)
+    rooms: RoomStatusMap = attr.Factory(RoomStatusMap)
 
     def get_mutable(self) -> "MutablePerConnectionState":
         """Get a mutable copy of this state."""
@@ -3147,7 +3147,7 @@ class PerConnectionState:
 class MutablePerConnectionState(PerConnectionState):
     """A mutable version of `PerConnectionState`"""
 
-    rooms: MutableRoomStatusesForStream
+    rooms: MutableRoomStatusMap
 
     def has_updates(self) -> bool:
         return bool(self.rooms.get_updates())

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -3207,8 +3207,7 @@ class SlidingSyncConnectionStore:
 
         connection_position = from_token.connection_position
         if connection_position == 0:
-            # The '0' values is a special value to indicate there is no
-            # per-connection state.
+            # Initial sync (request without a `from_token`) starts at `0` so there is no existing per-connection state
             return PerConnectionState()
 
         conn_key = self._get_connection_key(sync_config)


### PR DESCRIPTION
This is some prep work ahead of correctly tracking receipts, where we will also want to track the room status in terms of last receipt we had sent down.

Essentially, we add two classes `PerConnectionState` and a mutable version, and then operate on those.