### PR TITLE
Sliding Sync: Batch up fetching receipts

### DIFF
--- a/changelog.d/17589.misc
+++ b/changelog.d/17589.misc
@@ -1,0 +1,1 @@
+Correctly track read receipts that should be sent down in experimental sliding sync.

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -2967,11 +2967,11 @@ class SlidingSyncHandler:
             # from that room but we only want to include receipts for events
             # in the timeline to avoid bloating and blowing up the sync response
             # as the number of users in the room increases. (this behavior is part of the spec)
-            initial_rooms = [
+            initial_rooms = {
                 room_id
                 for room_id in initial_rooms
                 if room_id in actual_room_response_map
-            ]
+            }
             if initial_rooms:
                 initial_receipts = await self.store.get_linearized_receipts_for_rooms(
                     room_ids=initial_rooms,

--- a/synapse/handlers/sliding_sync.py
+++ b/synapse/handlers/sliding_sync.py
@@ -2979,12 +2979,12 @@ class SlidingSyncHandler:
                 )
 
                 for receipt in initial_receipts:
-                    relevant_event_ids = [
+                    relevant_event_ids = {
                         event.event_id
                         for event in actual_room_response_map[
                             receipt["room_id"]
                         ].timeline_events
-                    ]
+                    }
 
                     content = {
                         event_id: content_value


### PR DESCRIPTION
This is to make initial sliding sync a bit faster