### PR TITLE
Add metrics for sliding sync processing time

### DIFF
--- a/changelog.d/17593.misc
+++ b/changelog.d/17593.misc
@@ -1,0 +1,1 @@
+Add histogram metrics for sliding sync processing time.


### PR DESCRIPTION
This should let us see how quickly we actually process things in practice.