### PR TITLE
Remove images from message notification e-mails.

### DIFF
--- a/changelog.d/17598.bugfix
+++ b/changelog.d/17598.bugfix
@@ -1,0 +1,1 @@
+Remove images from message notification e-mails.

--- a/synapse/res/templates/notif.html
+++ b/synapse/res/templates/notif.html
@@ -1,19 +1,6 @@
 {%- for message in notif.messages %}
     <tr class="{{ "historical_message" if message.is_historical else "message" }}">
         <td class="sender_avatar">
-            {%- if loop.index0 == 0 or notif.messages[loop.index0 - 1].sender_name != notif.messages[loop.index0].sender_name %}
-                {%- if message.sender_avatar_url %}
-                    <img alt="" class="sender_avatar" src="{{ message.sender_avatar_url|mxc_to_http(32,32) }}"  />
-                {%- else %}
-                    {%- if message.sender_hash % 3 == 0 %}
-                        <img class="sender_avatar" src="https://riot.im/img/external/avatar-1.png"  />
-                    {%- elif message.sender_hash % 3 == 1 %}
-                        <img class="sender_avatar" src="https://riot.im/img/external/avatar-2.png"  />
-                    {%- else %}
-                        <img class="sender_avatar" src="https://riot.im/img/external/avatar-3.png"  />
-                    {%- endif %}
-                {%- endif %}
-            {%- endif %}
         </td>
         <td class="message_contents">
             {%- if loop.index0 == 0 or notif.messages[loop.index0 - 1].sender_name != notif.messages[loop.index0].sender_name %}
@@ -30,7 +17,7 @@
                     {%- elif message.msgtype == "m.notice" %}
                         {{ message.body_text_html }}
                     {%- elif message.msgtype == "m.image" and message.image_url %}
-                        <img src="{{ message.image_url|mxc_to_http(640, 480, 'scale') }}" />
+                        <span class="filename">{{ message.body_text_plain }} (image)</span>
                     {%- elif message.msgtype == "m.file" %}
                         <span class="filename">{{ message.body_text_plain }}</span>
                     {%- else %}

--- a/synapse/res/templates/room.html
+++ b/synapse/res/templates/room.html
@@ -1,17 +1,6 @@
 <table class="room">
     <tr class="room_header">
         <td class="room_avatar">
-            {%- if room.avatar_url %}
-                <img alt="" src="{{ room.avatar_url|mxc_to_http(48,48) }}" />
-            {%- else %}
-                {%- if room.hash % 3 == 0 %}
-                    <img alt="" src="https://riot.im/img/external/avatar-1.png"  />
-                {%- elif room.hash % 3 == 1 %}
-                    <img alt="" src="https://riot.im/img/external/avatar-2.png"  />
-                {%- else %}
-                    <img alt="" src="https://riot.im/img/external/avatar-3.png"  />
-                {%- endif %}
-            {%- endif %}
         </td>
         <td class="room_name" colspan="2">
             {{ room.title }}


### PR DESCRIPTION
Having these images here has been a liability because it gives cause for complaints about the e-mails,
which then affects our sender reputation.

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Remove images from message notification e-mails 

</li>
<li>

Remove room avatars from message notification e-mails 

</li>
</ol>
