### PR TITLE
Partially-stated room that we fail to join updates current state and indicates that it's in the room

### DIFF
--- a/synapse/storage/controllers/persist_events.py
+++ b/synapse/storage/controllers/persist_events.py
@@ -1114,6 +1114,9 @@ class EventsPersistenceStorageController:
             if ev_id != existing_state.get(key)
         }
 
+        logger.info("asdf _calculate_state_delta existing_state %s", existing_state)
+        logger.info("asdf _calculate_state_delta current_state %s", current_state)
+
         return DeltaState(to_delete=to_delete, to_insert=to_insert)
 
     async def _is_server_still_joined(

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1131,6 +1131,8 @@ class PersistEventsStore:
     ) -> None:
         """Update the current state stored in the datatabase for the given room"""
 
+        logger.info("asdf state_delta: %s", state_delta)
+
         if state_delta.is_noop():
             return
 

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1155,6 +1155,8 @@ class PersistEventsStore:
         to_delete = delta_state.to_delete
         to_insert = delta_state.to_insert
 
+        logger.info("asdf _update_current_state_txn: %s %s", to_delete, to_insert)
+
         # Figure out the changes of membership to invalidate the
         # `get_rooms_for_user` cache.
         # We find out which membership events we may have deleted

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -681,6 +681,17 @@ class PartialJoinTestCase(unittest.FederatingHomeserverTestCase):
             f" failed do_invite_join!",
         )
 
+        # Sanity check that we're not leaving behind any current state events.
+        current_state_check_rows = self.get_success(
+            store.db_pool.simple_select_list(
+                table="current_state_events",
+                keyvalues={"room_id": room_id},
+                retcols=("event_id",),
+                desc="check current_state_events in test",
+            )
+        )
+        self.assertEqual(len(current_state_check_rows), 0)
+
     def test_duplicate_partial_state_room_syncs(self) -> None:
         """
         Tests that concurrent partial state syncs are not started for the same room.


### PR DESCRIPTION
(This is more bug report than PR, please someone else take this on)

Partially-stated room that we fail to join, updates current state and indicates that it's in the room (`delta_state.no_longer_in_room = False`). 

Test to reproduce:
```
SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.handlers.test_federation.PartialJoinTestCase.test_failed_partial_join_is_clean
```

In `_trial_temp/test.log`, we can observe:

```
asdf _calculate_state_delta existing_state {}
asdf _calculate_state_delta current_state immutabledict({})
asdf state_delta: DeltaState(to_delete=[], to_insert={}, no_longer_in_room=False)
```

Wtf? `no_longer_in_room=False` seems to indicate that they currently in the room :confounded:. There is no `current_state_events` for this room so this doesn't line up.


This behavior was first introduced in https://github.com/matrix-org/synapse/pull/13403 and the only reason it doesn't end up calling `_update_current_state_txn(...)` now is because https://github.com/element-hq/synapse/pull/17215 added some `if state_delta.is_noop():` protection (for something unrelated AFAICT).

It's very confusing for a partially stated room to come through this flow indicating that it is still in the room (`delta_state.no_longer_in_room = False`).

Normally, `no_longer_in_room` is set at https://github.com/element-hq/synapse/blob/92b38c1afd1acd1b88b3ae313f05bcf1bec0e849/synapse/storage/controllers/persist_events.py#L728-L750

But there is a different flow that the partial-stated rooms use that doesn't bother setting `delta_state.no_longer_in_room` at all,

https://github.com/element-hq/synapse/blob/92b38c1afd1acd1b88b3ae313f05bcf1bec0e849/synapse/storage/controllers/persist_events.py#L496-L506

Seems like we should update this flow to accurately say `delta_state.no_longer_in_room = True` and make sure any current state events are cleared out. Although, I'm not sure `current_state_events` are ever added for a partially-stated room in this case.

Overall, it's very easy to overlook this kind of thing because we default `no_longer_in_room` to `False` so you don't need to provide it when creating a `DeltaState(...)`.


---

Found while working on https://github.com/element-hq/synapse/pull/17512

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
