### PR TITLE
Fix background update for sliding sync (find previous membership)

### DIFF
--- a/changelog.d/17632.misc
+++ b/changelog.d/17632.misc
@@ -1,0 +1,1 @@
+Store sliding sync per-connection state in the database.

--- a/changelog.d/17632.misc
+++ b/changelog.d/17632.misc
@@ -1,1 +1,1 @@
-Store sliding sync per-connection state in the database.
+Pre-populate room data used in experimental [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575) Sliding Sync `/sync` endpoint for quick filtering/sorting.

--- a/synapse/storage/databases/main/events_bg_updates.py
+++ b/synapse/storage/databases/main/events_bg_updates.py
@@ -1967,12 +1967,13 @@ class EventsBackgroundUpdatesStore(StreamWorkerStore, StateDeltasStore, SQLBaseS
             txn.execute(
                 """
                 SELECT event_id, membership
-                FROM room_memberships
+                FROM room_memberships AS m
+                INNER JOIN events AS e USING (room_id, event_id)
                 WHERE
                     room_id = ?
-                    AND user_id = ?
-                    AND event_stream_ordering < ?
-                ORDER BY event_stream_ordering DESC
+                    AND m.user_id = ?
+                    AND e.stream_ordering < ?
+                ORDER BY e.stream_ordering DESC
                 LIMIT 1
                 """,
                 (


### PR DESCRIPTION
This reverts commit https://github.com/element-hq/synapse/commit/ab414f2ab8a294fbffb417003eeea0f14bbd6588.

Introduced in https://github.com/element-hq/synapse/pull/17512