### PR TITLE
Sliding Sync: Fix outlier re-persisting causing problems with sliding sync tables

### DIFF
--- a/changelog.d/17635.misc
+++ b/changelog.d/17635.misc
@@ -1,0 +1,1 @@
+Pre-populate room data used in experimental [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575) Sliding Sync `/sync` endpoint for quick filtering/sorting.

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -230,6 +230,8 @@ class EventContentFields:
 
     ROOM_NAME: Final = "name"
 
+    MEMBERSHIP: Final = "membership"
+
     # Used in m.room.guest_access events.
     GUEST_ACCESS: Final = "guest_access"
 

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -475,8 +475,9 @@ class PersistEventsStore:
                     # can't rely on `stream_ordering`/`instance_name` being correct. We
                     # could be working with events that were previously persisted as an
                     # `outlier` with one `stream_ordering` but are now being persisted
-                    # again and de-outliered and assigned a different `stream_ordering`.
-                    # Since we call `_calculate_sliding_sync_table_changes()` before
+                    # again and de-outliered and assigned a different `stream_ordering`
+                    # that won't end up being used. Since we call
+                    # `_calculate_sliding_sync_table_changes()` before
                     # `_update_outliers_txn()` which fixes this discrepancy (always use
                     # the `stream_ordering` from the first time it was persisted), we're
                     # working with an unreliable `stream_ordering` value that will
@@ -1848,12 +1849,12 @@ class PersistEventsStore:
             # `_calculate_sliding_sync_table_changes()` is ran. We could be working with
             # events that were previously persisted as an `outlier` with one
             # `stream_ordering` but are now being persisted again and de-outliered and
-            # assigned a different `stream_ordering`. Since we call
-            # `_calculate_sliding_sync_table_changes()` before `_update_outliers_txn()`
-            # which fixes this discrepancy (always use the `stream_ordering` from the
-            # first time it was persisted), we're working with an unreliable
-            # `stream_ordering` value that will possibly be unused and not make it into
-            # the `events` table.
+            # assigned a different `stream_ordering` that won't end up being used. Since
+            # we call `_calculate_sliding_sync_table_changes()` before
+            # `_update_outliers_txn()` which fixes this discrepancy (always use the
+            # `stream_ordering` from the first time it was persisted), we're working
+            # with an unreliable `stream_ordering` value that will possibly be unused
+            # and not make it into the `events` table.
             txn.execute_batch(
                 f"""
                 INSERT INTO sliding_sync_membership_snapshots

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1743,7 +1743,7 @@ class PersistEventsStore:
                 ]
                 args.extend(iter(sliding_sync_updates_values))
 
-                # We use a sub-query for `stream_ordering` because it's unreliable to
+                # XXX: We use a sub-query for `stream_ordering` because it's unreliable to
                 # pre-calculate from `events_and_contexts` at the time when
                 # `_calculate_sliding_sync_table_changes()` is ran. We could be working
                 # with events that were previously persisted as an `outlier` with one

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -631,9 +631,7 @@ class PersistEventsStore:
 
             # Otherwise, we need to find a couple events that we were reset to.
             if missing_event_ids:
-                remaining_events = await self.store.get_events(
-                    current_state_ids_map.values()
-                )
+                remaining_events = await self.store.get_events(missing_event_ids)
                 # There shouldn't be any missing events
                 assert (
                     remaining_events.keys() == missing_event_ids

--- a/synapse/storage/databases/main/events_bg_updates.py
+++ b/synapse/storage/databases/main/events_bg_updates.py
@@ -1993,9 +1993,9 @@ class EventsBackgroundUpdatesStore(StreamWorkerStore, StateDeltasStore, SQLBaseS
         to_insert_membership_snapshots: Dict[
             Tuple[str, str], SlidingSyncMembershipSnapshotSharedInsertValues
         ] = {}
-        to_insert_membership_infos: Dict[Tuple[str, str], SlidingSyncMembershipInfoWithEventPos] = (
-            {}
-        )
+        to_insert_membership_infos: Dict[
+            Tuple[str, str], SlidingSyncMembershipInfoWithEventPos
+        ] = {}
         for (
             room_id,
             room_id_from_rooms_table,
@@ -2184,15 +2184,17 @@ class EventsBackgroundUpdatesStore(StreamWorkerStore, StateDeltasStore, SQLBaseS
             to_insert_membership_snapshots[(room_id, user_id)] = (
                 sliding_sync_membership_snapshots_insert_map
             )
-            to_insert_membership_infos[(room_id, user_id)] = SlidingSyncMembershipInfoWithEventPos(
-                user_id=user_id,
-                sender=sender,
-                membership_event_id=membership_event_id,
-                membership=membership,
-                membership_event_stream_ordering=membership_event_stream_ordering,
-                # If instance_name is null we default to "master"
-                membership_event_instance_name=membership_event_instance_name
-                or "master",
+            to_insert_membership_infos[(room_id, user_id)] = (
+                SlidingSyncMembershipInfoWithEventPos(
+                    user_id=user_id,
+                    sender=sender,
+                    membership_event_id=membership_event_id,
+                    membership=membership,
+                    membership_event_stream_ordering=membership_event_stream_ordering,
+                    # If instance_name is null we default to "master"
+                    membership_event_instance_name=membership_event_instance_name
+                    or "master",
+                )
             )
 
         def _fill_table_txn(txn: LoggingTransaction) -> None:

--- a/synapse/storage/databases/main/events_bg_updates.py
+++ b/synapse/storage/databases/main/events_bg_updates.py
@@ -37,7 +37,7 @@ from synapse.storage.database import (
 from synapse.storage.databases.main.events import (
     SLIDING_SYNC_RELEVANT_STATE_SET,
     PersistEventsStore,
-    SlidingSyncMembershipInfo,
+    SlidingSyncMembershipInfoWithEventPos,
     SlidingSyncMembershipSnapshotSharedInsertValues,
     SlidingSyncStateInsertValues,
 )
@@ -1993,7 +1993,7 @@ class EventsBackgroundUpdatesStore(StreamWorkerStore, StateDeltasStore, SQLBaseS
         to_insert_membership_snapshots: Dict[
             Tuple[str, str], SlidingSyncMembershipSnapshotSharedInsertValues
         ] = {}
-        to_insert_membership_infos: Dict[Tuple[str, str], SlidingSyncMembershipInfo] = (
+        to_insert_membership_infos: Dict[Tuple[str, str], SlidingSyncMembershipInfoWithEventPos] = (
             {}
         )
         for (
@@ -2184,7 +2184,7 @@ class EventsBackgroundUpdatesStore(StreamWorkerStore, StateDeltasStore, SQLBaseS
             to_insert_membership_snapshots[(room_id, user_id)] = (
                 sliding_sync_membership_snapshots_insert_map
             )
-            to_insert_membership_infos[(room_id, user_id)] = SlidingSyncMembershipInfo(
+            to_insert_membership_infos[(room_id, user_id)] = SlidingSyncMembershipInfoWithEventPos(
                 user_id=user_id,
                 sender=sender,
                 membership_event_id=membership_event_id,

--- a/tests/storage/test_sliding_sync_tables.py
+++ b/tests/storage/test_sliding_sync_tables.py
@@ -927,6 +927,9 @@ class SlidingSyncTablesTestCase(SlidingSyncTablesTestCaseBase):
         )
 
     @parameterized.expand(
+        # Test both an insert an upsert into the
+        # `sliding_sync_joined_rooms`/`sliding_sync_membership_snapshots` to exercise
+        # more possibilities of things going wrong.
         [
             ("insert", True),
             ("upsert", False),

--- a/tests/storage/test_sliding_sync_tables.py
+++ b/tests/storage/test_sliding_sync_tables.py
@@ -38,6 +38,7 @@ from synapse.storage.databases.main.events_bg_updates import (
     _resolve_stale_data_in_sliding_sync_joined_rooms_table,
     _resolve_stale_data_in_sliding_sync_membership_snapshots_table,
 )
+from synapse.types import create_requester
 from synapse.util import Clock
 
 from tests.test_utils.event_injection import create_event
@@ -924,6 +925,125 @@ class SlidingSyncTablesTestCase(SlidingSyncTablesTestCaseBase):
             sliding_sync_membership_snapshots_results.get((room_id1, user2_id)),
             user2_snapshot,
         )
+
+    @parameterized.expand(
+        [
+            ("insert", True),
+            ("upsert", False),
+        ]
+    )
+    def test_joined_room_outlier_and_deoutlier(
+        self, description: str, should_insert: bool
+    ) -> None:
+        """
+        This is a regression test.
+
+        This is to simulate the case where an event is first persisted as an outlier
+        (like a remote invite) and then later persisted again to de-outlier it. The
+        first the time, the `outlier` is persisted with one `stream_ordering` but when
+        persisted again and de-outliered, it is assigned a different `stream_ordering`
+        that won't end up being used. Since we call
+        `_calculate_sliding_sync_table_changes()` before `_update_outliers_txn()` which
+        fixes this discrepancy (always use the `stream_ordering` from the first time it
+        was persisted), make sure we're not using an unreliable `stream_ordering` values
+        that will cause `FOREIGN KEY constraint failed` in the
+        `sliding_sync_joined_rooms`/`sliding_sync_membership_snapshots` tables.
+        """
+        user1_id = self.register_user("user1", "pass")
+        _user1_tok = self.login(user1_id, "pass")
+        user2_id = self.register_user("user2", "pass")
+        user2_tok = self.login(user2_id, "pass")
+
+        room_version = RoomVersions.V10
+        room_id = self.helper.create_room_as(
+            user2_id, tok=user2_tok, room_version=room_version.identifier
+        )
+
+        if should_insert:
+            # Clear these out so we always insert
+            self.get_success(
+                self.store.db_pool.simple_delete(
+                    table="sliding_sync_joined_rooms",
+                    keyvalues={"room_id": room_id},
+                    desc="TODO",
+                )
+            )
+            self.get_success(
+                self.store.db_pool.simple_delete(
+                    table="sliding_sync_membership_snapshots",
+                    keyvalues={"room_id": room_id},
+                    desc="TODO",
+                )
+            )
+
+        # Create a membership event (which triggers an insert into
+        # `sliding_sync_membership_snapshots`)
+        membership_event_dict = {
+            "type": EventTypes.Member,
+            "state_key": user1_id,
+            "sender": user1_id,
+            "room_id": room_id,
+            "content": {EventContentFields.MEMBERSHIP: Membership.JOIN},
+        }
+        # Create a relevant state event (which triggers an insert into
+        # `sliding_sync_joined_rooms`)
+        state_event_dict = {
+            "type": EventTypes.Name,
+            "state_key": "",
+            "sender": user2_id,
+            "room_id": room_id,
+            "content": {EventContentFields.ROOM_NAME: "my super room"},
+        }
+        event_dicts_to_persist = [
+            membership_event_dict,
+            state_event_dict,
+        ]
+
+        for event_dict in event_dicts_to_persist:
+            events_to_persist = []
+
+            # Create the events as an outliers
+            (
+                event,
+                unpersisted_context,
+            ) = self.get_success(
+                self.hs.get_event_creation_handler().create_event(
+                    requester=create_requester(user1_id),
+                    event_dict=event_dict,
+                    outlier=True,
+                )
+            )
+            # FIXME: Should we use an `EventContext.for_outlier(...)` here?
+            # Doesn't seem to matter for this test.
+            context = self.get_success(unpersisted_context.persist(event))
+            events_to_persist.append((event, context))
+
+            # Create the event again but as an non-outlier. This will de-outlier the event
+            # when we persist it.
+            (
+                event,
+                unpersisted_context,
+            ) = self.get_success(
+                self.hs.get_event_creation_handler().create_event(
+                    requester=create_requester(user1_id),
+                    event_dict=event_dict,
+                    outlier=False,
+                )
+            )
+            context = self.get_success(unpersisted_context.persist(event))
+            events_to_persist.append((event, context))
+
+            persist_controller = self.hs.get_storage_controllers().persistence
+            assert persist_controller is not None
+            for event, context in events_to_persist:
+                self.get_success(
+                    persist_controller.persist_event(
+                        event,
+                        context,
+                    )
+                )
+
+        # We're just testing that it does not explode
 
     def test_joined_room_meta_state_reset(self) -> None:
         """


### PR DESCRIPTION
Fix outlier re-persisting causing problems with sliding sync tables

Follow-up to https://github.com/element-hq/synapse/pull/17512

When running on `matrix.org`, we discovered that a remote invite is first persisted as an `outlier` and then re-persisted again where it is de-outliered. The first the time, the `outlier` is persisted with one `stream_ordering` but when persisted again and de-outliered, it is assigned a different `stream_ordering` that won't end up being used. Since we call `_calculate_sliding_sync_table_changes()` before `_update_outliers_txn()` which fixes this discrepancy (always use the `stream_ordering` from the first time it was persisted), we're working with an unreliable `stream_ordering` value that will possibly be unused and not make it into the `events` table.



### TODO

 - [x] Add test

### Developer notes

```
SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.storage.test_sliding_sync_tables.SlidingSyncTablesTestCase.test_joined_room_outlier_and_deoutlier

SYNAPSE_POSTGRES=1 SYNAPSE_POSTGRES_USER=postgres SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.storage.test_sliding_sync_tables.SlidingSyncTablesTestCase.test_joined_room_outlier_and_deoutlier
```


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
