### PR TITLE
Stabilise MSC4156: `server_name` -> `via`

### DIFF
--- a/changelog.d/17650.removal
+++ b/changelog.d/17650.removal
@@ -1,0 +1,1 @@
+Stabilise [MSC4156](https://github.com/matrix-org/matrix-spec-proposals/pull/4156) by removing the `msc4156_enabled` config setting and defaulting it to `true`.

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -445,6 +445,3 @@ class ExperimentalConfig(Config):
 
         # MSC4151: Report room API (Client-Server API)
         self.msc4151_enabled: bool = experimental.get("msc4151_enabled", False)
-
-        # MSC4156: Migrate server_name to via
-        self.msc4156_enabled: bool = experimental.get("msc4156_enabled", False)

--- a/synapse/rest/client/knock.py
+++ b/synapse/rest/client/knock.py
@@ -72,9 +72,7 @@ class KnockRoomAliasServlet(RestServlet):
             # twisted.web.server.Request.args is incorrectly defined as Optional[Any]
             args: Dict[bytes, List[bytes]] = request.args  # type: ignore
             # Prefer via over server_name (deprecated with MSC4156)
-            remote_room_hosts = parse_strings_from_args(
-                args, "via", required=False
-            )
+            remote_room_hosts = parse_strings_from_args(args, "via", required=False)
             if remote_room_hosts is None:
                 remote_room_hosts = parse_strings_from_args(
                     args, "server_name", required=False

--- a/synapse/rest/client/knock.py
+++ b/synapse/rest/client/knock.py
@@ -53,7 +53,6 @@ class KnockRoomAliasServlet(RestServlet):
         super().__init__()
         self.room_member_handler = hs.get_room_member_handler()
         self.auth = hs.get_auth()
-        self._support_via = hs.config.experimental.msc4156_enabled
 
     async def on_POST(
         self,
@@ -72,15 +71,13 @@ class KnockRoomAliasServlet(RestServlet):
 
             # twisted.web.server.Request.args is incorrectly defined as Optional[Any]
             args: Dict[bytes, List[bytes]] = request.args  # type: ignore
+            # Prefer via over server_name (deprecated with MSC4156)
             remote_room_hosts = parse_strings_from_args(
-                args, "server_name", required=False
+                args, "via", required=False
             )
-            if self._support_via:
+            if remote_room_hosts == None:
                 remote_room_hosts = parse_strings_from_args(
-                    args,
-                    "org.matrix.msc4156.via",
-                    default=remote_room_hosts,
-                    required=False,
+                    args, "server_name", required=False
                 )
         elif RoomAlias.is_valid(room_identifier):
             handler = self.room_member_handler

--- a/synapse/rest/client/knock.py
+++ b/synapse/rest/client/knock.py
@@ -75,7 +75,7 @@ class KnockRoomAliasServlet(RestServlet):
             remote_room_hosts = parse_strings_from_args(
                 args, "via", required=False
             )
-            if remote_room_hosts == None:
+            if remote_room_hosts is None:
                 remote_room_hosts = parse_strings_from_args(
                     args, "server_name", required=False
                 )

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -419,7 +419,6 @@ class JoinRoomAliasServlet(ResolveRoomIdMixin, TransactionRestServlet):
         super().__init__(hs)
         super(ResolveRoomIdMixin, self).__init__(hs)  # ensure the Mixin is set up
         self.auth = hs.get_auth()
-        self._support_via = hs.config.experimental.msc4156_enabled
 
     def register(self, http_server: HttpServer) -> None:
         # /join/$room_identifier[/$txn_id]
@@ -437,13 +436,13 @@ class JoinRoomAliasServlet(ResolveRoomIdMixin, TransactionRestServlet):
 
         # twisted.web.server.Request.args is incorrectly defined as Optional[Any]
         args: Dict[bytes, List[bytes]] = request.args  # type: ignore
-        remote_room_hosts = parse_strings_from_args(args, "server_name", required=False)
-        if self._support_via:
+        # Prefer via over server_name (deprecated with MSC4156)
+        remote_room_hosts = parse_strings_from_args(
+            args, "via", required=False
+        )
+        if remote_room_hosts == None:
             remote_room_hosts = parse_strings_from_args(
-                args,
-                "org.matrix.msc4156.via",
-                default=remote_room_hosts,
-                required=False,
+                args, "server_name", required=False
             )
         room_id, remote_room_hosts = await self.resolve_room_id(
             room_identifier,

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -440,7 +440,7 @@ class JoinRoomAliasServlet(ResolveRoomIdMixin, TransactionRestServlet):
         remote_room_hosts = parse_strings_from_args(
             args, "via", required=False
         )
-        if remote_room_hosts == None:
+        if remote_room_hosts is None:
             remote_room_hosts = parse_strings_from_args(
                 args, "server_name", required=False
             )

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -437,9 +437,7 @@ class JoinRoomAliasServlet(ResolveRoomIdMixin, TransactionRestServlet):
         # twisted.web.server.Request.args is incorrectly defined as Optional[Any]
         args: Dict[bytes, List[bytes]] = request.args  # type: ignore
         # Prefer via over server_name (deprecated with MSC4156)
-        remote_room_hosts = parse_strings_from_args(
-            args, "via", required=False
-        )
+        remote_room_hosts = parse_strings_from_args(args, "via", required=False)
         if remote_room_hosts is None:
             remote_room_hosts = parse_strings_from_args(
                 args, "server_name", required=False


### PR DESCRIPTION
[MSC4156](https://github.com/matrix-org/matrix-spec-proposals/pull/4156) has been merged so unstable prefixes are no longer required.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
