### PR TITLE
Sliding Sync: Support filtering by 'tags' / 'not_tags' in SSS

### DIFF
--- a/changelog.d/17662.feature
+++ b/changelog.d/17662.feature
@@ -1,0 +1,1 @@
+Add support for the `tags` and `not_tags` filters for simplified sliding sync.

--- a/synapse/handlers/sliding_sync/room_lists.py
+++ b/synapse/handlers/sliding_sync/room_lists.py
@@ -54,7 +54,6 @@ from synapse.storage.roommember import (
     RoomsForUserStateReset,
 )
 from synapse.types import (
-    JsonMapping,
     MutableStateMap,
     PersistedEventPosition,
     RoomStreamToken,

--- a/synapse/handlers/sliding_sync/room_lists.py
+++ b/synapse/handlers/sliding_sync/room_lists.py
@@ -285,9 +285,6 @@ class SlidingSyncRoomLists:
         )
         dm_room_ids = await self._get_dm_rooms_for_user(user_id)
 
-        # Fetch the user tags for their rooms
-        room_tags = await self.store.get_tags_for_user(user_id)
-
         # Handle state resets in the from -> to token range.
         state_reset_rooms = (
             newly_left_room_map.keys() - room_membership_for_user_map.keys()
@@ -337,7 +334,6 @@ class SlidingSyncRoomLists:
                             list_config.filters,
                             to_token,
                             dm_room_ids,
-                            room_tags,
                         )
 
                     # Find which rooms are partially stated and may need to be filtered out
@@ -1677,7 +1673,6 @@ class SlidingSyncRoomLists:
         filters: SlidingSyncConfig.SlidingSyncList.Filters,
         to_token: StreamToken,
         dm_room_ids: AbstractSet[str],
-        room_tags: Mapping[str, Mapping[str, JsonMapping]],
     ) -> Dict[str, RoomsForUserSlidingSync]:
         """
         Filter rooms based on the sync request.
@@ -1785,21 +1780,36 @@ class SlidingSyncRoomLists:
                 # )
                 raise NotImplementedError()
 
-        if filters.tags is not None:
+        # Filter by room tags according to the users account data
+        if filters.tags is not None or filters.not_tags is not None:
             with start_active_span("filters.tags"):
-                filtered_room_id_set = {
-                    room_id
-                    for room_id in filtered_room_id_set
-                    if set(room_tags.get(room_id, [])) & set(filters.tags)
+                # Fetch the user tags for their rooms
+                room_tags = await self.store.get_tags_for_user(user_id)
+                room_id_to_tag_name_set: Dict[str, Set[str]] = {
+                    room_id: set(tags.keys()) for room_id, tags in room_tags.items()
                 }
 
-        if filters.not_tags is not None:
-            with start_active_span("filters.not_tags"):
-                filtered_room_id_set = {
-                    room_id
-                    for room_id in filtered_room_id_set
-                    if not set(room_tags.get(room_id, [])) & set(filters.not_tags)
-                }
+                if filters.tags is not None:
+                    tags_set = set(filters.tags)
+                    filtered_room_id_set = {
+                        room_id
+                        for room_id in filtered_room_id_set
+                        # Remove rooms that don't have one of the tags in the filter
+                        if room_id_to_tag_name_set.get(room_id, set()).intersection(
+                            tags_set
+                        )
+                    }
+
+                if filters.not_tags is not None:
+                    not_tags_set = set(filters.not_tags)
+                    filtered_room_id_set = {
+                        room_id
+                        for room_id in filtered_room_id_set
+                        # Remove rooms if they have any of the tags in the filter
+                        if not room_id_to_tag_name_set.get(room_id, set()).intersection(
+                            not_tags_set
+                        )
+                    }
 
         # Assemble a new sync room map but only with the `filtered_room_id_set`
         return {room_id: sync_room_map[room_id] for room_id in filtered_room_id_set}

--- a/synapse/handlers/sliding_sync/room_lists.py
+++ b/synapse/handlers/sliding_sync/room_lists.py
@@ -1525,6 +1525,8 @@ class SlidingSyncRoomLists:
             A filtered dictionary of room IDs along with membership information in the
             room at the time of `to_token`.
         """
+        user_id = user.to_string()
+
         room_id_to_stripped_state_map: Dict[
             str, Optional[StateMap[StrippedStateEvent]]
         ] = {}
@@ -1658,9 +1660,36 @@ class SlidingSyncRoomLists:
                 # )
                 raise NotImplementedError()
 
+        # Filter by room tags according to the users account data
         if filters.tags is not None or filters.not_tags is not None:
             with start_active_span("filters.tags"):
-                raise NotImplementedError()
+                # Fetch the user tags for their rooms
+                room_tags = await self.store.get_tags_for_user(user_id)
+                room_id_to_tag_name_set: Dict[str, Set[str]] = {
+                    room_id: set(tags.keys()) for room_id, tags in room_tags.items()
+                }
+
+                if filters.tags is not None:
+                    tags_set = set(filters.tags)
+                    filtered_room_id_set = {
+                        room_id
+                        for room_id in filtered_room_id_set
+                        # Remove rooms that don't have one of the tags in the filter
+                        if room_id_to_tag_name_set.get(room_id, set()).intersection(
+                            tags_set
+                        )
+                    }
+
+                if filters.not_tags is not None:
+                    not_tags_set = set(filters.not_tags)
+                    filtered_room_id_set = {
+                        room_id
+                        for room_id in filtered_room_id_set
+                        # Remove rooms if they have any of the tags in the filter
+                        if not room_id_to_tag_name_set.get(room_id, set()).intersection(
+                            not_tags_set
+                        )
+                    }
 
         # Assemble a new sync room map but only with the `filtered_room_id_set`
         return {room_id: sync_room_map[room_id] for room_id in filtered_room_id_set}

--- a/tests/handlers/test_sliding_sync.py
+++ b/tests/handlers/test_sliding_sync.py
@@ -3232,9 +3232,7 @@ class FilterRoomsTestCase(HomeserverTestCase):
 
         # Get the rooms the user should be syncing with
         room_membership_for_user_map = self.get_success(
-            self.store.get_sliding_sync_rooms_for_user(
-                user1_id
-            )
+            self.store.get_sliding_sync_rooms_for_user(user1_id)
         )
 
         # Try with `tags=foo`
@@ -3297,9 +3295,7 @@ class FilterRoomsTestCase(HomeserverTestCase):
         # )
 
         room_membership_for_user_map = self.get_success(
-            self.store.get_sliding_sync_rooms_for_user(
-                user1_id
-            )
+            self.store.get_sliding_sync_rooms_for_user(user1_id)
         )
 
         # Try with `not_tags=foo`

--- a/tests/handlers/test_sliding_sync.py
+++ b/tests/handlers/test_sliding_sync.py
@@ -3310,7 +3310,9 @@ class FilterRoomsTestCase(HomeserverTestCase):
             )
         )
 
-        self.assertEqual(foo_filtered_room_map.keys(), {untagged_room_id, bartag_room_id})
+        self.assertEqual(
+            foo_filtered_room_map.keys(), {untagged_room_id, bartag_room_id}
+        )
 
         # Try with not_tags=[foo,bar]
         foobar_filtered_room_map = self.get_success(


### PR DESCRIPTION
This appears to be enough to make Element Web work (or at least move it on to the next hurdle), although I'm not super confident in it, especially the tests since the `is_dm` tests were testing a different filter method. The tests are also just at the lowest unit level rather than anything higher. I'm not sure what the difference is between the two filter methods - I guess we would need to add both?

Simplified Sliding Sync (SSS)

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
