### PR TITLE
Sliding Sync: Speed up incremental sync by avoiding extra work

### DIFF
--- a/changelog.d/17665.misc
+++ b/changelog.d/17665.misc
@@ -1,0 +1,1 @@
+Speed up incremental Sliding Sync requests by avoiding extra work.

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -953,7 +953,7 @@ class SlidingSyncHandler:
         hero_room_state = [
             (EventTypes.Member, hero_user_id) for hero_user_id in hero_user_ids
         ]
-        meta_room_state = hero_room_state
+        meta_room_state = list(hero_room_state)
         if initial or name_changed:
             meta_room_state.append((EventTypes.Name, ""))
         if initial or avatar_changed:

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -1042,6 +1042,7 @@ class SlidingSyncHandler:
         return SlidingSyncResult.RoomResult(
             name=room_name,
             avatar=room_avatar,
+            # TODO: These should also be excluded if they haven't changed
             heroes=heroes,
             is_dm=room_membership_for_user_at_to_token.is_dm,
             initial=initial,
@@ -1054,6 +1055,7 @@ class SlidingSyncHandler:
             unstable_expanded_timeline=unstable_expanded_timeline,
             num_live=num_live,
             bump_stamp=bump_stamp,
+            # TODO: These should also be excluded if they haven't changed
             joined_count=room_membership_summary.get(
                 Membership.JOIN, empty_membership_summary
             ).count,

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -1106,7 +1106,6 @@ class SlidingSyncHandler:
         return SlidingSyncResult.RoomResult(
             name=room_name,
             avatar=room_avatar,
-            # TODO: Add test to make sure these should also be excluded if they haven't changed
             heroes=heroes,
             is_dm=room_membership_for_user_at_to_token.is_dm,
             initial=initial,

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -42,6 +42,7 @@ from synapse.storage.databases.main.stream import PaginateFunction
 from synapse.storage.roommember import MemberSummary
 from synapse.types import (
     JsonDict,
+    MutableStateMap,
     PersistedEventPosition,
     Requester,
     RoomStreamToken,
@@ -744,26 +745,75 @@ class SlidingSyncHandler:
         # indicate to the client that a state reset happened. Perhaps we should indicate
         # this by setting `initial: True` and empty `required_state`.
 
-        # Check whether the room has a name set
-        name_state_ids = await self.get_current_state_ids_at(
-            room_id=room_id,
-            room_membership_for_user_at_to_token=room_membership_for_user_at_to_token,
-            state_filter=StateFilter.from_types([(EventTypes.Name, "")]),
-            to_token=to_token,
-        )
-        name_event_id = name_state_ids.get((EventTypes.Name, ""))
-
-        room_membership_summary: Mapping[str, MemberSummary]
-        empty_membership_summary = MemberSummary([], 0)
-        if room_membership_for_user_at_to_token.membership in (
-            Membership.LEAVE,
-            Membership.BAN,
-        ):
-            # TODO: Figure out how to get the membership summary for left/banned rooms
-            room_membership_summary = {}
+        # Get the changes to current state in the token range from the
+        # `current_state_delta_stream` table.
+        #
+        # For incremental syncs, we can do this first to determine if something relevant
+        # has changed and strategically avoid fetching other costly things.
+        room_state_delta_id_map: MutableStateMap[str] = {}
+        name_event_id: Optional[str] = None
+        membership_changed = False
+        name_changed = False
+        avatar_changed = False
+        if initial:
+            # Check whether the room has a name set
+            name_state_ids = await self.get_current_state_ids_at(
+                room_id=room_id,
+                room_membership_for_user_at_to_token=room_membership_for_user_at_to_token,
+                state_filter=StateFilter.from_types([(EventTypes.Name, "")]),
+                to_token=to_token,
+            )
+            name_event_id = name_state_ids.get((EventTypes.Name, ""))
         else:
-            room_membership_summary = await self.store.get_room_summary(room_id)
-            # TODO: Reverse/rewind back to the `to_token`
+            assert from_bound is not None
+
+            # TODO: Limit the number of state events we're about to send down
+            # the room, if its too many we should change this to an
+            # `initial=True`?
+            deltas = await self.store.get_current_state_deltas_for_room(
+                room_id=room_id,
+                from_token=from_bound,
+                to_token=to_token.room_key,
+            )
+            for delta in deltas:
+                # TODO: Handle state resets where event_id is None
+                if delta.event_id is not None:
+                    room_state_delta_id_map[(delta.event_type, delta.state_key)] = (
+                        delta.event_id
+                    )
+
+                if delta.event_type == EventTypes.Member:
+                    membership_changed = True
+                elif delta.event_type == EventTypes.Name and delta.state_key == "":
+                    name_changed = True
+                elif (
+                    delta.event_type == EventTypes.RoomAvatar and delta.state_key == ""
+                ):
+                    avatar_changed = True
+
+        room_membership_summary: Optional[Mapping[str, MemberSummary]] = None
+        empty_membership_summary = MemberSummary([], 0)
+        # We need the room summary for:
+        #  - Always for initial syncs (or the first time we send down the room)
+        #  - When the room has no name, we need `heroes`
+        #  - When the membership has changed so we need to give updated `heroes` and
+        #    `joined_count`/`invited_count`.
+        #
+        # Ideally, instead of just looking at `name_changed`, we'd check if the room
+        # name is not set but this is a good enough approximation that saves us from
+        # having to pull out the full event. This just means, we're generating the
+        # summary whenever the room name changes instead of only when it changes to
+        # `None`.
+        if initial or name_changed or membership_changed:
+            if room_membership_for_user_at_to_token.membership in (
+                Membership.LEAVE,
+                Membership.BAN,
+            ):
+                # TODO: Figure out how to get the membership summary for left/banned rooms
+                room_membership_summary = {}
+            else:
+                room_membership_summary = await self.store.get_room_summary(room_id)
+                # TODO: Reverse/rewind back to the `to_token`
 
         # `heroes` are required if the room name is not set.
         #
@@ -777,7 +827,12 @@ class SlidingSyncHandler:
         # TODO: Should we also check for `EventTypes.CanonicalAlias`
         # (`m.room.canonical_alias`) as a fallback for the room name? see
         # https://github.com/matrix-org/matrix-spec-proposals/pull/3575#discussion_r1671260153
-        if name_event_id is None:
+        #
+        # We need to fetch the `heroes` if the room name is not set. But we only need to
+        # get them on initial syncs (or the first time we send down the room) or if the
+        # membership has changed which may change the heroes.
+        if name_event_id is None and (initial or (not initial and membership_changed)):
+            assert room_membership_summary is not None
             hero_user_ids = extract_heroes_from_room_summary(
                 room_membership_summary, me=user.to_string()
             )
@@ -895,9 +950,14 @@ class SlidingSyncHandler:
 
         # We need this base set of info for the response so let's just fetch it along
         # with the `required_state` for the room
-        meta_room_state = [(EventTypes.Name, ""), (EventTypes.RoomAvatar, "")] + [
+        meta_room_state = [
             (EventTypes.Member, hero_user_id) for hero_user_id in hero_user_ids
         ]
+        if initial or name_changed:
+            meta_room_state.append((EventTypes.Name, ""))
+        if initial or avatar_changed:
+            meta_room_state.append((EventTypes.RoomAvatar, ""))
+
         state_filter = StateFilter.all()
         if required_state_filter != StateFilter.all():
             state_filter = StateFilter(
@@ -920,18 +980,8 @@ class SlidingSyncHandler:
         else:
             assert from_bound is not None
 
-            # TODO: Limit the number of state events we're about to send down
-            # the room, if its too many we should change this to an
-            # `initial=True`?
-            deltas = await self.store.get_current_state_deltas_for_room(
-                room_id=room_id,
-                from_token=from_bound,
-                to_token=to_token.room_key,
-            )
-            # TODO: Filter room state before fetching events
-            # TODO: Handle state resets where event_id is None
             events = await self.store.get_events(
-                [d.event_id for d in deltas if d.event_id]
+                state_filter.filter_state(room_state_delta_id_map).values()
             )
             room_state = {(s.type, s.state_key): s for s in events.values()}
 
@@ -1039,10 +1089,24 @@ class SlidingSyncHandler:
 
         set_tag(SynapseTags.RESULT_PREFIX + "initial", initial)
 
+        joined_count: Optional[int] = None
+        if initial or membership_changed:
+            assert room_membership_summary is not None
+            joined_count = room_membership_summary.get(
+                Membership.JOIN, empty_membership_summary
+            ).count
+
+        invited_count: Optional[int] = None
+        if initial or membership_changed:
+            assert room_membership_summary is not None
+            invited_count = room_membership_summary.get(
+                Membership.INVITE, empty_membership_summary
+            ).count
+
         return SlidingSyncResult.RoomResult(
             name=room_name,
             avatar=room_avatar,
-            # TODO: These should also be excluded if they haven't changed
+            # TODO: Add test to make sure these should also be excluded if they haven't changed
             heroes=heroes,
             is_dm=room_membership_for_user_at_to_token.is_dm,
             initial=initial,
@@ -1055,13 +1119,8 @@ class SlidingSyncHandler:
             unstable_expanded_timeline=unstable_expanded_timeline,
             num_live=num_live,
             bump_stamp=bump_stamp,
-            # TODO: These should also be excluded if they haven't changed
-            joined_count=room_membership_summary.get(
-                Membership.JOIN, empty_membership_summary
-            ).count,
-            invited_count=room_membership_summary.get(
-                Membership.INVITE, empty_membership_summary
-            ).count,
+            joined_count=joined_count,
+            invited_count=invited_count,
             # TODO: These are just dummy values. We could potentially just remove these
             # since notifications can only really be done correctly on the client anyway
             # (encrypted rooms).

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -1011,11 +1011,15 @@ class SlidingSyncRestServlet(RestServlet):
         for room_id, room_result in rooms.items():
             serialized_rooms[room_id] = {
                 "bump_stamp": room_result.bump_stamp,
-                "joined_count": room_result.joined_count,
-                "invited_count": room_result.invited_count,
                 "notification_count": room_result.notification_count,
                 "highlight_count": room_result.highlight_count,
             }
+
+            if room_result.joined_count is not None:
+                serialized_rooms[room_id]["joined_count"] = room_result.joined_count
+
+            if room_result.invited_count is not None:
+                serialized_rooms[room_id]["invited_count"] = room_result.invited_count
 
             if room_result.name:
                 serialized_rooms[room_id]["name"] = room_result.name

--- a/synapse/types/handlers/sliding_sync.py
+++ b/synapse/types/handlers/sliding_sync.py
@@ -196,8 +196,8 @@ class SlidingSyncResult:
         # Only optional because it won't be included for invite/knock rooms with `stripped_state`
         num_live: Optional[int]
         bump_stamp: int
-        joined_count: int
-        invited_count: int
+        joined_count: Optional[int]
+        invited_count: Optional[int]
         notification_count: int
         highlight_count: int
 

--- a/synapse/types/handlers/sliding_sync.py
+++ b/synapse/types/handlers/sliding_sync.py
@@ -206,6 +206,12 @@ class SlidingSyncResult:
                 # If this is the first time the client is seeing the room, we should not filter it out
                 # under any circumstance.
                 self.initial
+                # We need to let the client know if any of the info has changed
+                or self.name is not None
+                or self.avatar is not None
+                or bool(self.heroes)
+                or self.joined_count is not None
+                or self.invited_count is not None
                 # We need to let the client know if there are any new events
                 or bool(self.required_state)
                 or bool(self.timeline_events)

--- a/tests/rest/client/sliding_sync/test_rooms_meta.py
+++ b/tests/rest/client/sliding_sync/test_rooms_meta.py
@@ -13,7 +13,7 @@
 #
 import logging
 
-from parameterized import parameterized_class
+from parameterized import parameterized, parameterized_class
 
 from twisted.test.proto_helpers import MemoryReactor
 
@@ -192,20 +192,27 @@ class SlidingSyncRoomsMetaTestCase(SlidingSyncBase):
             "avatar",
             response_body["rooms"][room_id1],
         )
-        # TODO: These should also be excluded if they haven't changed
-        # self.assertNotIn(
-        #     "joined_count",
-        #     response_body["rooms"][room_id1],
-        # )
-        # self.assertNotIn(
-        #     "invited_count",
-        #     response_body["rooms"][room_id1],
-        # )
+        self.assertNotIn(
+            "joined_count",
+            response_body["rooms"][room_id1],
+        )
+        self.assertNotIn(
+            "invited_count",
+            response_body["rooms"][room_id1],
+        )
         self.assertIsNone(
             response_body["rooms"][room_id1].get("is_dm"),
         )
 
-    def test_rooms_meta_when_joined_incremental_with_state_change(self) -> None:
+    @parameterized.expand(
+        [
+            ("in_required_state", "true"),
+            ("not_in_required_state", "false"),
+        ]
+    )
+    def test_rooms_meta_when_joined_incremental_with_state_change(
+        self, test_description: str, include_state_in_required_state: bool
+    ) -> None:
         """
         Test that the `rooms` `name` and `avatar` are included in an incremental sync
         response if they changed.
@@ -239,7 +246,11 @@ class SlidingSyncRoomsMetaTestCase(SlidingSyncBase):
                     "ranges": [[0, 1]],
                     # Include some state so when we change the room name, the room comes
                     # down in the incremental sync.
-                    "required_state": [[EventTypes.Name, ""]],
+                    "required_state": (
+                        [[EventTypes.Name, ""]]
+                        if include_state_in_required_state
+                        else []
+                    ),
                     "timeline_limit": 0,
                 }
             }
@@ -271,15 +282,14 @@ class SlidingSyncRoomsMetaTestCase(SlidingSyncBase):
             "avatar",
             response_body["rooms"][room_id1],
         )
-        # TODO: These should also be excluded if they haven't changed
-        # self.assertNotIn(
-        #     "joined_count",
-        #     response_body["rooms"][room_id1],
-        # )
-        # self.assertNotIn(
-        #     "invited_count",
-        #     response_body["rooms"][room_id1],
-        # )
+        self.assertNotIn(
+            "joined_count",
+            response_body["rooms"][room_id1],
+        )
+        self.assertNotIn(
+            "invited_count",
+            response_body["rooms"][room_id1],
+        )
         self.assertIsNone(
             response_body["rooms"][room_id1].get("is_dm"),
         )


### PR DESCRIPTION
Speed up incremental sync by avoiding extra work. We first look at the state delta changes and only fetch and calculate further derived things if they have changed.


This isn't a very good trace comparison because these are just from some synthetic local tests that have too little data and run so fast that there is a lot of variation in the span durations. The main thing to notice is that the `get_current_state_ids_at(...)` chunk isn't happening the after trace.

Before | After
--- | ---
![Trace visualization in Jaeger of aded9b5d1d517d83.json](https://github.com/user-attachments/assets/54e87f74-faf2-4aaf-9116-360d14321bf3) | ![Trace visualization in Jaeger of 48dee2667089b630.json](https://github.com/user-attachments/assets/d6abb735-1777-4f0c-96bd-ec9bb2e4b09a)




Trace before: [`aded9b5d1d517d83.json`](https://gist.github.com/MadLittleMods/aa2ffc3d82d78bcb4040a387731cd2af)

Trace after: [`48dee2667089b630.json`](https://gist.github.com/MadLittleMods/7e7d8b970e6606fcba9b28daa7c93e24)




The real-world trace before ([`0672eb7bbbc4d50e.json`](https://gist.github.com/MadLittleMods/86042251f6bc89c44fb3081dc10e2f2d)) illustrates the problem a little better.

<img width="821px" src="https://github.com/user-attachments/assets/4df72494-541d-4c37-9bf4-4bd23a6efa95">



### Dev notes

#### Enable Jaeger tracing in Twisted Trial tests:

Run Jaeger locally with Docker: https://www.jaegertracing.io/docs/1.6/getting-started/#all-in-one-docker-image

Add the following to `tests/unittest.py` in `setUp(...)`:

```py
        from synapse.logging.opentracing import init_tracer

        # Start the tracer
        init_tracer(self.hs)  # noqa
```


Add the following to `tests/rest/client/sliding_sync/test_sliding_sync.py` in `default_config(...)`

```py
        config["opentracing"] = {
            "enabled": True,
            "jaeger_config": {
                "sampler": {"type": "const", "param": 1},
                "logging": False,
            },
        }
```

Add a sleep to the end of the test you're running so the traces have a chance to flow to Jaeger before the process exits.

```py
import time
time.sleep(6)
```

Run your tests.

Visit http://localhost:16686/ and choose the `test master` service and find the traces you're interesting in.


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
