### PR TITLE
docs: media worker serves client resources

### DIFF
--- a/changelog.d/17669.doc
+++ b/changelog.d/17669.doc
@@ -1,0 +1,1 @@
+Fix media worker documentation, since it only serves the new authenticated media endpoints if it is configured for it. Contributed by Johannes Krude (@johannes-krude).

--- a/docs/systemd-with-workers/workers/media_worker.yaml
+++ b/docs/systemd-with-workers/workers/media_worker.yaml
@@ -6,6 +6,6 @@ worker_listeners:
     port: 8085
     x_forwarded: true
     resources:
-      - names: [media]
+      - names: [media, client]
 
 worker_log_config: /etc/matrix-synapse/media-worker-log.yaml


### PR DESCRIPTION
The [workers documentation](https://element-hq.github.io/synapse/latest/workers.html#synapseappmedia_repository) mentions that the media worker can handle the new endpoints for authenticated media, but the included example config misses the client resources.

I spent several hours debugging our synapse deployment and reverse proxy configuration to figure out the reason that element-desktop is no longer able to load avatars and uploaded images.

Without the client resource, the media worker responds with M_UNRECOGNIZED to ^/_matrix/client/v1/media/ requests and element-desktop shows "Unable to show image due to error".

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
