### PR TITLE
Sliding sync: remove the list ops from the response

### DIFF
--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -792,14 +792,6 @@ class SlidingSyncRestServlet(RestServlet):
             "lists": {
                 "foo-list": {
                     "count": 1337,
-                    "ops": [{
-                        "op": "SYNC",
-                        "range": [0, 99],
-                        "room_ids": [
-                            "!foo:bar",
-                            // ... 99 more room IDs
-                        ]
-                    }]
                 }
             },
             // Aggregated rooms from lists and room subscriptions
@@ -977,20 +969,10 @@ class SlidingSyncRestServlet(RestServlet):
     def encode_lists(
         self, lists: Mapping[str, SlidingSyncResult.SlidingWindowList]
     ) -> JsonDict:
-        def encode_operation(
-            operation: SlidingSyncResult.SlidingWindowList.Operation,
-        ) -> JsonDict:
-            return {
-                "op": operation.op.value,
-                "range": operation.range,
-                "room_ids": operation.room_ids,
-            }
-
         serialized_lists = {}
         for list_key, list_result in lists.items():
             serialized_lists[list_key] = {
                 "count": list_result.count,
-                "ops": [encode_operation(op) for op in list_result.ops],
             }
 
         return serialized_lists

--- a/synapse/types/handlers/sliding_sync.py
+++ b/synapse/types/handlers/sliding_sync.py
@@ -29,7 +29,6 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    Tuple,
     TypeVar,
     cast,
 )
@@ -218,27 +217,9 @@ class SlidingSyncResult:
         Attributes:
             count: The total number of entries in the list. Always present if this list
                 is.
-            ops: The sliding list operations to perform.
         """
 
-        @attr.s(slots=True, frozen=True, auto_attribs=True)
-        class Operation:
-            """
-            Attributes:
-                op: The operation type to perform.
-                range: Which index positions are affected by this operation. These are
-                    both inclusive.
-                room_ids: Which room IDs are affected by this operation. These IDs match
-                    up to the positions in the `range`, so the last room ID in this list
-                    matches the 9th index. The room data is held in a separate object.
-            """
-
-            op: OperationType
-            range: Tuple[int, int]
-            room_ids: List[str]
-
         count: int
-        ops: List[Operation]
 
     @attr.s(slots=True, frozen=True, auto_attribs=True)
     class Extensions:

--- a/tests/rest/client/sliding_sync/test_rooms_meta.py
+++ b/tests/rest/client/sliding_sync/test_rooms_meta.py
@@ -587,21 +587,6 @@ class SlidingSyncRoomsMetaTestCase(SlidingSyncBase):
             response_body["lists"].keys(),
         )
 
-        # Make sure the list includes the rooms in the right order
-        self.assertListEqual(
-            list(response_body["lists"]["foo-list"]["ops"]),
-            [
-                {
-                    "op": "SYNC",
-                    "range": [0, 1],
-                    # room1 sorts before room2 because it has the latest event (the
-                    # reaction)
-                    "room_ids": [room_id1, room_id2],
-                }
-            ],
-            response_body["lists"]["foo-list"],
-        )
-
         # The `bump_stamp` for room1 should point at the latest message (not the
         # reaction since it's not one of the `DEFAULT_BUMP_EVENT_TYPES`)
         self.assertEqual(

--- a/tests/rest/client/sliding_sync/test_rooms_required_state.py
+++ b/tests/rest/client/sliding_sync/test_rooms_required_state.py
@@ -735,14 +735,13 @@ class SlidingSyncRoomsRequiredStateTestCase(SlidingSyncBase):
         response_body, _ = self.do_sync(sync_body, tok=user1_tok)
 
         # The list should include both rooms now because we don't need full state
-        for list_key in response_body["lists"].keys():
-            self.assertIncludes(
-                set(response_body["lists"][list_key]["ops"][0]["room_ids"]),
-                {room_id2, room_id1},
-                exact=True,
-                message=f"Expected all rooms to show up for list_key={list_key}. Response "
-                + str(response_body["lists"][list_key]),
-            )
+        self.assertIncludes(
+            set(response_body["rooms"].keys()),
+            {room_id2, room_id1},
+            exact=True,
+            message="Expected all rooms to show up. Response "
+            + str(response_body["rooms"]),
+        )
 
         # Take each of the list variants and apply them to room subscriptions to make
         # sure the same rules apply
@@ -826,14 +825,13 @@ class SlidingSyncRoomsRequiredStateTestCase(SlidingSyncBase):
 
         # Make sure the list includes room1 but room2 is excluded because it's still
         # partially-stated
-        for list_key in response_body["lists"].keys():
-            self.assertIncludes(
-                set(response_body["lists"][list_key]["ops"][0]["room_ids"]),
-                {room_id1},
-                exact=True,
-                message=f"Expected only fully-stated rooms to show up for list_key={list_key}. Response "
-                + str(response_body["lists"][list_key]),
-            )
+        self.assertIncludes(
+            set(response_body["rooms"].keys()),
+            {room_id1},
+            exact=True,
+            message="Expected only fully-stated rooms to show up. Response "
+            + str(response_body["rooms"]),
+        )
 
         # Take each of the list variants and apply them to room subscriptions to make
         # sure the same rules apply


### PR DESCRIPTION
This isn't in MSC4186, sync ops don't make any sense in the API, nothing currently uses it, and it takes up a lot of space in the sync result.

We probably *do* want to indicate which rooms are in which lists, but that can be added later.