### PR TITLE
Enable guest access on new media endpoints, per MSC4189

### DIFF
--- a/changelog.d/17675.feature
+++ b/changelog.d/17675.feature
@@ -1,0 +1,1 @@
+Guests can use the new media endpoints to download media, as described by [MSC4189](https://github.com/matrix-org/matrix-spec-proposals/pull/4189).

--- a/synapse/rest/client/media.py
+++ b/synapse/rest/client/media.py
@@ -138,7 +138,7 @@ class ThumbnailResource(RestServlet):
     ) -> None:
         # Validate the server name, raising if invalid
         parse_and_validate_server_name(server_name)
-        await self.auth.get_user_by_req(request)
+        await self.auth.get_user_by_req(request, allow_guest=True)
 
         set_cors_headers(request)
         set_corp_headers(request)
@@ -229,7 +229,7 @@ class DownloadResource(RestServlet):
         # Validate the server name, raising if invalid
         parse_and_validate_server_name(server_name)
 
-        await self.auth.get_user_by_req(request)
+        await self.auth.get_user_by_req(request, allow_guest=True)
 
         set_cors_headers(request)
         set_corp_headers(request)


### PR DESCRIPTION
I didn't see tests for other guest access endpoints in my 15 seconds of searching, but if there's guidance on how to set that up, happy to add the respective tests.