### PR TITLE
Sliding Sync: Look for `bump _stamp` in the room timeline

### DIFF
--- a/changelog.d/17684.misc
+++ b/changelog.d/17684.misc
@@ -1,0 +1,1 @@
+Speed up sliding sync by reducing number of database calls.

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -1206,7 +1206,10 @@ class SlidingSyncHandler:
             latest_room_bump_stamp is not None
             and latest_room_bump_stamp < min_to_token_position
         ):
-            return latest_room_bump_stamp
+            if latest_room_bump_stamp > 0:
+                return latest_room_bump_stamp
+            else:
+                return None
 
         # Otherwise, if it's within or after the `to_token`, we need to find the
         # last bump event before the `to_token`.

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -1144,6 +1144,7 @@ class SlidingSyncHandler:
             highlight_count=0,
         )
 
+    @trace
     async def _get_bump_stamp(
         self, room_id: str, to_token: StreamToken, timeline: List[EventBase]
     ) -> Optional[int]:


### PR DESCRIPTION
This allows us to skip checking the database a lot of the time.