### PR TITLE
Sliding Sync: Increase concurrency of sliding sync a bit

### DIFF
--- a/changelog.d/17696.misc
+++ b/changelog.d/17696.misc
@@ -1,0 +1,1 @@
+Speed up sliding sync requests a bit where there are many room changes.

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -267,7 +267,7 @@ class SlidingSyncHandler:
 
         if relevant_rooms_to_send_map:
             with start_active_span("sliding_sync.generate_room_entries"):
-                await concurrently_execute(handle_room, relevant_rooms_to_send_map, 10)
+                await concurrently_execute(handle_room, relevant_rooms_to_send_map, 20)
 
         extensions = await self.extensions.get_extensions_response(
             sync_config=sync_config,


### PR DESCRIPTION
For initial requests a typical page size is 20 rooms, so we may as well do the batching as 20. 

This should speed up bigger syncs a little bit.