### PR TITLE
Sliding Sync: Return room tags in account data extension

### DIFF
--- a/changelog.d/17707.feature
+++ b/changelog.d/17707.feature
@@ -1,0 +1,1 @@
+Return room tags in Sliding Sync account data extension.

--- a/synapse/handlers/sliding_sync/extensions.py
+++ b/synapse/handlers/sliding_sync/extensions.py
@@ -427,7 +427,7 @@ class SlidingSyncExtensionHandler:
         # account data events.
         #
         # This is is a list so we can avoid making copies of immutable data and instead
-        # just provide a multiple maps that need to be combined. Normally, we could
+        # just provide multiple maps that need to be combined. Normally, we could
         # reach for `ChainMap` in this scenario, but this is a nested map and accessing
         # the ChainMap by room_id won't combine the two maps for that room (we would
         # need a new `NestedChainMap` type class).

--- a/synapse/handlers/sliding_sync/extensions.py
+++ b/synapse/handlers/sliding_sync/extensions.py
@@ -397,6 +397,7 @@ class SlidingSyncExtensionHandler:
                 user_id, from_token.stream_token.push_rules_key
             )
             if have_push_rules_changed:
+                # TODO: This should take into account the `from_token` and `to_token`
                 global_account_data_map[
                     AccountDataTypes.PUSH_RULES
                 ] = await self.push_rules_handler.push_rules_for_user(sync_config.user)

--- a/synapse/handlers/sliding_sync/extensions.py
+++ b/synapse/handlers/sliding_sync/extensions.py
@@ -19,6 +19,7 @@ from typing import (
     AbstractSet,
     ChainMap,
     Dict,
+    List,
     Mapping,
     MutableMapping,
     Optional,
@@ -422,8 +423,15 @@ class SlidingSyncExtensionHandler:
 
         # Fetch room account data
         #
-        # Mapping from room_id to mapping of `type` to `content` of room account data events.
-        account_data_by_room_map: Dict[str, Dict[str, JsonMapping]] = {}
+        # List of -> Mapping from room_id to mapping of `type` to `content` of room
+        # account data events.
+        #
+        # This is is a list so we can avoid making copies of immutable data and instead
+        # just provide a multiple maps that need to be combined. Normally, we could
+        # reach for `ChainMap` in this scenario, but this is a nested map and accessing
+        # the ChainMap by room_id won't combine the two maps for that room (we would
+        # need a new `NestedChainMap` type class).
+        account_data_by_room_maps: List[Mapping[str, Mapping[str, JsonMapping]]] = []
         relevant_room_ids = self.find_relevant_room_ids_for_extension(
             requested_lists=account_data_request.lists,
             requested_room_ids=account_data_request.rooms,
@@ -449,40 +457,44 @@ class SlidingSyncExtensionHandler:
                     account_data_by_room_map.setdefault(room_id, {})[
                         AccountDataTypes.TAG
                     ] = {"tags": tags}
+
+                account_data_by_room_maps.append(account_data_by_room_map)
             else:
                 # TODO: This should take into account the `to_token`
                 immutable_account_data_by_room_map = (
                     await self.store.get_room_account_data_for_user(user_id)
                 )
-                # We have to make a copy of the immutable data from the cache as we will
-                # be mutating it below.
-                #
-                # FIXME: It would be good to avoid this big copy
-                for (
-                    room_id,
-                    room_account_data_map,
-                ) in immutable_account_data_by_room_map.items():
-                    account_data_by_room_map[room_id] = dict(room_account_data_map)
+                account_data_by_room_maps.append(immutable_account_data_by_room_map)
 
                 # Add room tags
                 #
                 # TODO: This should take into account the `to_token`
                 tags_by_room = await self.store.get_tags_for_user(user_id)
-                for room_id, tags in tags_by_room.items():
-                    account_data_by_room_map.setdefault(room_id, {})[
-                        AccountDataTypes.TAG
-                    ] = {"tags": tags}
+                account_data_by_room_maps.append(
+                    {
+                        room_id: {AccountDataTypes.TAG: {"tags": tags}}
+                        for room_id, tags in tags_by_room.items()
+                    }
+                )
 
-        # Filter down to the relevant rooms
-        account_data_by_room_map = {
-            room_id: account_data_map
-            for room_id, account_data_map in account_data_by_room_map.items()
-            if room_id in relevant_room_ids
+        # Filter down to the relevant rooms ... and combine the maps
+        relevant_account_data_by_room_map: Mapping[str, Mapping[str, JsonMapping]] = {
+            room_id: ChainMap(
+                {},
+                *(
+                    # Cast is safe because `ChainMap` only mutates the top-most map,
+                    # see https://github.com/python/typeshed/issues/8430
+                    cast(MutableMapping[str, JsonMapping], room_map[room_id])
+                    for room_map in account_data_by_room_maps
+                    if room_map.get(room_id)
+                ),
+            )
+            for room_id in relevant_room_ids
         }
 
         return SlidingSyncResult.Extensions.AccountDataExtension(
             global_account_data_map=global_account_data_map,
-            account_data_by_room_map=account_data_by_room_map,
+            account_data_by_room_map=relevant_account_data_by_room_map,
         )
 
     @trace

--- a/synapse/storage/databases/main/account_data.py
+++ b/synapse/storage/databases/main/account_data.py
@@ -177,7 +177,7 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
 
         def get_room_account_data_for_user_txn(
             txn: LoggingTransaction,
-        ) -> Dict[str, Dict[str, JsonDict]]:
+        ) -> Dict[str, Dict[str, JsonMapping]]:
             # The 'content != '{}' condition below prevents us from using
             # `simple_select_list_txn` here, as it doesn't support conditions
             # other than 'equals'.
@@ -194,7 +194,7 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
 
             txn.execute(sql, (user_id,))
 
-            by_room: Dict[str, Dict[str, JsonDict]] = {}
+            by_room: Dict[str, Dict[str, JsonMapping]] = {}
             for room_id, account_data_type, content in txn:
                 room_data = by_room.setdefault(room_id, {})
 
@@ -429,7 +429,7 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
 
     async def get_updated_room_account_data_for_user(
         self, user_id: str, stream_id: int
-    ) -> Dict[str, Dict[str, JsonDict]]:
+    ) -> Dict[str, Dict[str, JsonMapping]]:
         """Get all the room account_data that's changed for a user.
 
         Args:
@@ -442,14 +442,14 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
 
         def get_updated_room_account_data_for_user_txn(
             txn: LoggingTransaction,
-        ) -> Dict[str, Dict[str, JsonDict]]:
+        ) -> Dict[str, Dict[str, JsonMapping]]:
             sql = """
                 SELECT room_id, account_data_type, content FROM room_account_data
                 WHERE user_id = ? AND stream_id > ?
             """
             txn.execute(sql, (user_id, stream_id))
 
-            account_data_by_room: Dict[str, Dict[str, JsonDict]] = {}
+            account_data_by_room: Dict[str, Dict[str, JsonMapping]] = {}
             for row in txn:
                 room_account_data = account_data_by_room.setdefault(row[0], {})
                 room_account_data[row[1]] = db_to_json(row[2])

--- a/synapse/storage/databases/main/account_data.py
+++ b/synapse/storage/databases/main/account_data.py
@@ -394,7 +394,7 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
 
     async def get_updated_global_account_data_for_user(
         self, user_id: str, stream_id: int
-    ) -> Mapping[str, JsonMapping]:
+    ) -> Dict[str, JsonMapping]:
         """Get all the global account_data that's changed for a user.
 
         Args:
@@ -407,7 +407,7 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
 
         def get_updated_global_account_data_for_user(
             txn: LoggingTransaction,
-        ) -> Dict[str, JsonDict]:
+        ) -> Dict[str, JsonMapping]:
             sql = """
                 SELECT account_data_type, content FROM account_data
                 WHERE user_id = ? AND stream_id > ?

--- a/synapse/types/handlers/sliding_sync.py
+++ b/synapse/types/handlers/sliding_sync.py
@@ -314,18 +314,14 @@ class SlidingSyncResult:
             """The Account Data extension (MSC3959)
 
             Attributes:
-                global_account_data_map: Mapping from `type` to `content` of
-                    global account data events.
-                account_data_by_room_map: List of -> Mapping from room_id to mapping of
-                    `type` to `content` of room account data events. These are lists so
-                    we can avoid making copies of immutable data and instead just
-                    provide a multiple maps that need to be combined when sending down
-                    the data.
+                global_account_data_map: Mapping from `type` to `content` of global
+                    account data events.
+                account_data_by_room_map: Mapping from room_id to mapping of `type` to
+                    `content` of room account data events.
             """
 
             global_account_data_map: Mapping[str, JsonMapping]
             account_data_by_room_map: Mapping[str, Mapping[str, JsonMapping]]
-            # account_data_by_room_maps: Sequence[Mapping[str, Mapping[str, JsonMapping]]]
 
             def __bool__(self) -> bool:
                 return bool(

--- a/synapse/types/handlers/sliding_sync.py
+++ b/synapse/types/handlers/sliding_sync.py
@@ -314,14 +314,18 @@ class SlidingSyncResult:
             """The Account Data extension (MSC3959)
 
             Attributes:
-                global_account_data_map: Mapping from `type` to `content` of global account
-                    data events.
-                account_data_by_room_map: Mapping from room_id to mapping of `type` to
-                    `content` of room account data events.
+                global_account_data_map: Mapping from `type` to `content` of
+                    global account data events.
+                account_data_by_room_map: List of -> Mapping from room_id to mapping of
+                    `type` to `content` of room account data events. These are lists so
+                    we can avoid making copies of immutable data and instead just
+                    provide a multiple maps that need to be combined when sending down
+                    the data.
             """
 
             global_account_data_map: Mapping[str, JsonMapping]
             account_data_by_room_map: Mapping[str, Mapping[str, JsonMapping]]
+            # account_data_by_room_maps: Sequence[Mapping[str, Mapping[str, JsonMapping]]]
 
             def __bool__(self) -> bool:
                 return bool(

--- a/tests/rest/client/sliding_sync/test_extension_account_data.py
+++ b/tests/rest/client/sliding_sync/test_extension_account_data.py
@@ -93,10 +93,6 @@ class SlidingSyncAccountDataExtensionTestCase(SlidingSyncBase):
             {AccountDataTypes.PUSH_RULES},
             exact=True,
         )
-        logger.info(
-            "global_account_data_map[AccountDataTypes.PUSH_RULES] %s",
-            global_account_data_map[AccountDataTypes.PUSH_RULES],
-        )
         # Push rules are a giant chunk of JSON data so we will just assume the value is correct if they key is here.
         # global_account_data_map[AccountDataTypes.PUSH_RULES]
 

--- a/tests/rest/client/sliding_sync/test_extension_account_data.py
+++ b/tests/rest/client/sliding_sync/test_extension_account_data.py
@@ -312,15 +312,20 @@ class SlidingSyncAccountDataExtensionTestCase(SlidingSyncBase):
             {room_id1},
             exact=True,
         )
+        account_data_map = {
+            event["type"]: event["content"]
+            for event in response_body["extensions"]["account_data"]
+            .get("rooms")
+            .get(room_id1)
+        }
         self.assertIncludes(
-            {
-                event["type"]
-                for event in response_body["extensions"]["account_data"]
-                .get("rooms")
-                .get(room_id1)
-            },
+            account_data_map.keys(),
             {"org.matrix.roorarraz", AccountDataTypes.TAG},
             exact=True,
+        )
+        self.assertEqual(account_data_map["org.matrix.roorarraz"], {"roo": "rar"})
+        self.assertEqual(
+            account_data_map[AccountDataTypes.TAG], {"tags": {"m.favourite": {}}}
         )
 
     def test_room_account_data_incremental_sync(self) -> None:
@@ -436,15 +441,21 @@ class SlidingSyncAccountDataExtensionTestCase(SlidingSyncBase):
             exact=True,
         )
         # We should only see the new room account data that happened after the `from_token`
+        account_data_map = {
+            event["type"]: event["content"]
+            for event in response_body["extensions"]["account_data"]
+            .get("rooms")
+            .get(room_id1)
+        }
         self.assertIncludes(
-            {
-                event["type"]
-                for event in response_body["extensions"]["account_data"]
-                .get("rooms")
-                .get(room_id1)
-            },
+            account_data_map.keys(),
             {"org.matrix.roorarraz2", AccountDataTypes.TAG},
             exact=True,
+        )
+        self.assertEqual(account_data_map["org.matrix.roorarraz2"], {"roo": "rar"})
+        self.assertEqual(
+            account_data_map[AccountDataTypes.TAG],
+            {"tags": {"m.favourite": {}, "m.server_notice": {}}},
         )
 
     def test_wait_for_new_data(self) -> None:

--- a/tests/rest/client/sliding_sync/test_extension_account_data.py
+++ b/tests/rest/client/sliding_sync/test_extension_account_data.py
@@ -255,6 +255,15 @@ class SlidingSyncAccountDataExtensionTestCase(SlidingSyncBase):
                 content={"roo": "rar"},
             )
         )
+        # Add a room tag to mark the room as a favourite
+        self.get_success(
+            self.account_data_handler.add_tag_to_room(
+                user_id=user1_id,
+                room_id=room_id1,
+                tag="m.favourite",
+                content={},
+            )
+        )
 
         # Create another room with some room account data
         room_id2 = self.helper.create_room_as(user1_id, tok=user1_tok)
@@ -264,6 +273,15 @@ class SlidingSyncAccountDataExtensionTestCase(SlidingSyncBase):
                 room_id=room_id2,
                 account_data_type="org.matrix.roorarraz",
                 content={"roo": "rar"},
+            )
+        )
+        # Add a room tag to mark the room as a favourite
+        self.get_success(
+            self.account_data_handler.add_tag_to_room(
+                user_id=user1_id,
+                room_id=room_id2,
+                tag="m.favourite",
+                content={},
             )
         )
 
@@ -301,7 +319,7 @@ class SlidingSyncAccountDataExtensionTestCase(SlidingSyncBase):
                 .get("rooms")
                 .get(room_id1)
             },
-            {"org.matrix.roorarraz"},
+            {"org.matrix.roorarraz", AccountDataTypes.TAG},
             exact=True,
         )
 
@@ -323,6 +341,15 @@ class SlidingSyncAccountDataExtensionTestCase(SlidingSyncBase):
                 content={"roo": "rar"},
             )
         )
+        # Add a room tag to mark the room as a favourite
+        self.get_success(
+            self.account_data_handler.add_tag_to_room(
+                user_id=user1_id,
+                room_id=room_id1,
+                tag="m.favourite",
+                content={},
+            )
+        )
 
         # Create another room with some room account data
         room_id2 = self.helper.create_room_as(user1_id, tok=user1_tok)
@@ -332,6 +359,15 @@ class SlidingSyncAccountDataExtensionTestCase(SlidingSyncBase):
                 room_id=room_id2,
                 account_data_type="org.matrix.roorarraz",
                 content={"roo": "rar"},
+            )
+        )
+        # Add a room tag to mark the room as a favourite
+        self.get_success(
+            self.account_data_handler.add_tag_to_room(
+                user_id=user1_id,
+                room_id=room_id2,
+                tag="m.favourite",
+                content={},
             )
         )
 
@@ -369,6 +405,23 @@ class SlidingSyncAccountDataExtensionTestCase(SlidingSyncBase):
                 content={"roo": "rar"},
             )
         )
+        # Add another room tag
+        self.get_success(
+            self.account_data_handler.add_tag_to_room(
+                user_id=user1_id,
+                room_id=room_id1,
+                tag="m.server_notice",
+                content={},
+            )
+        )
+        self.get_success(
+            self.account_data_handler.add_tag_to_room(
+                user_id=user1_id,
+                room_id=room_id2,
+                tag="m.server_notice",
+                content={},
+            )
+        )
 
         # Make an incremental Sliding Sync request with the account_data extension enabled
         response_body, _ = self.do_sync(sync_body, since=from_token, tok=user1_tok)
@@ -390,7 +443,7 @@ class SlidingSyncAccountDataExtensionTestCase(SlidingSyncBase):
                 .get("rooms")
                 .get(room_id1)
             },
-            {"org.matrix.roorarraz2"},
+            {"org.matrix.roorarraz2", AccountDataTypes.TAG},
             exact=True,
         )
 


### PR DESCRIPTION
Return room tags in account data extension

The account data extension was also updated to avoid copies when we pull the data out of the cache.

Fix https://github.com/element-hq/synapse/issues/17694


### Dev notes

<details>
<summary>Sync v2 incremental sync response with some rooms tags in the account data (favouriting a room)</summary>

```json
{
    "next_batch": "s5241945698_757284974_2782863_3110944073_3359903529_260642965_1380548560_11007322260_0_338462",
    "device_one_time_keys_count": {
        "signed_curve25519": 50
    },
    "org.matrix.msc2732.device_unused_fallback_key_types": [
        "signed_curve25519"
    ],
    "device_unused_fallback_key_types": [
        "signed_curve25519"
    ],
    "rooms": {
        "join": {
            "!xxx:matrix.org": {
                "timeline": {
                    "events": [],
                    "prev_batch": "s5241945695_757284974_2782854_3110944063_3359903514_260642965_1380548559_11007322258_0_338462",
                    "limited": false
                },
                "state": {
                    "events": []
                },
                "account_data": {
                    "events": [
                        {
                            "type": "m.tag",
                            "content": {
                                "tags": {
                                    "m.favourite": {}
                                }
                            }
                        }
                    ]
                },
                "ephemeral": {
                    "events": []
                },
                "unread_notifications": {
                    "notification_count": 0,
                    "highlight_count": 0
                },
                "summary": {}
            }
        }
    }
}
```

</details>

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
