### PR TITLE
docs: add note about PYTHONMALLOC for accurate jemalloc memory tracking

### DIFF
--- a/changelog.d/17709.doc
+++ b/changelog.d/17709.doc
@@ -1,2 +1,1 @@
-Add documentation note about PYTHONMALLOC for accurate jemalloc memory tracking
-Contributed by @hensg.
+Add documentation note about PYTHONMALLOC for accurate jemalloc memory tracking. Contributed by @hensg.

--- a/changelog.d/17709.doc
+++ b/changelog.d/17709.doc
@@ -1,0 +1,2 @@
+Add documentation note about PYTHONMALLOC for accurate jemalloc memory tracking
+Contributed by @hensg.

--- a/docs/usage/administration/admin_faq.md
+++ b/docs/usage/administration/admin_faq.md
@@ -255,6 +255,8 @@ line to `/etc/default/matrix-synapse`:
 
     LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
+*Note*: You may need to set `PYTHONMALLOC=malloc` to ensure that `jemalloc` can accurately calculate memory usage. By default, Python uses its internal small-object allocator, which may interfere with jemalloc's ability to track memory consumption correctly. This could prevent the [cache_autotuning](../configuration/config_documentation.md#caches-and-associated-values) feature from functioning as expected, as the Python allocator may not reach the memory threshold set by `max_cache_memory_usage`, thus not triggering the cache eviction process.
+
 This made a significant difference on Python 2.7 - it's unclear how
 much of an improvement it provides on Python 3.x.
 


### PR DESCRIPTION
Added a note in the documentation suggesting that users may set `PYTHONMALLOC=malloc` when using `jemalloc`. This allows jemalloc to track memory usage more accurately by bypassing Python's internal small-object allocator (`pymalloc`), helping to ensure that `cache_autotuning` functions as expected.

This doc change aims to provide more clarity for users configuring jemalloc with Synapse.


Based on: https://github.com/element-hq/synapse/blob/4ac783549c5bac7a490a715d359f330bb0b1a161/synapse/metrics/jemalloc.py#L198-L201