### PR TITLE
Sliding Sync: Slight optimization when fetching state for the room (`get_events_as_list(...)`)

### DIFF
--- a/changelog.d/17718.misc
+++ b/changelog.d/17718.misc
@@ -1,0 +1,1 @@
+Slight optimization when fetching state/events for Sliding Sync.

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -443,13 +443,11 @@ class SlidingSyncHandler:
             to_token=to_token,
         )
 
-        event_map = await self.store.get_events(list(state_ids.values()))
+        events = await self.store.get_events_as_list(list(state_ids.values()))
 
         state_map = {}
-        for key, event_id in state_ids.items():
-            event = event_map.get(event_id)
-            if event:
-                state_map[key] = event
+        for event in events:
+            state_map[(event.type, event.state_key)] = event
 
         return state_map
 

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -365,10 +365,6 @@ class GetEventsTestCase(unittest.HomeserverTestCase):
         # Sanity check that we go the events back
         self.assertIncludes(fetched_event_map.keys(), event_ids, exact=True)
 
-        # Sleep so the traces get flushed
-        # TODO: Remove
-        time.sleep(6)
-
 
 class DatabaseOutageTestCase(unittest.HomeserverTestCase):
     """Test event fetching during a database outage."""

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -325,7 +325,7 @@ class GetEventsTestCase(unittest.HomeserverTestCase):
         self.store: EventsWorkerStore = hs.get_datastores().main
 
     def test_get_lots_of_messages(self) -> None:
-        num_events = 10000
+        num_events = 100
 
         user_id = self.register_user("user", "pass")
         user_tok = self.login(user_id, "pass")
@@ -357,7 +357,7 @@ class GetEventsTestCase(unittest.HomeserverTestCase):
         with LoggingContext("test") as _ctx:
             with start_active_span("test_get_lots_of_messages"):
                 set_tag("num_events", num_events)
-                set_tag("setup_time", setup_end_ts - setup_start_ts)
+                set_tag("setup_time_seconds", setup_end_ts - setup_start_ts)
 
                 # This is the function under test
                 fetched_event_map = self.get_success(self.store.get_events(event_ids))

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -308,6 +308,7 @@ class GetEventsTestCase(unittest.HomeserverTestCase):
         self.store: EventsWorkerStore = hs.get_datastores().main
 
     def test_get_lots_of_messages(self) -> None:
+        """Sanity check that `get_events(...)`/`get_events_as_list(...)` works"""
         num_events = 100
 
         user_id = self.register_user("user", "pass")

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -362,7 +362,7 @@ class GetEventsTestCase(unittest.HomeserverTestCase):
                 # This is the function under test
                 fetched_event_map = self.get_success(self.store.get_events(event_ids))
 
-        # Sanity check that we go the events back
+        # Sanity check that we got the events back
         self.assertIncludes(fetched_event_map.keys(), event_ids, exact=True)
 
 

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -395,6 +395,11 @@ class HomeserverTestCase(TestCase):
         self._hs_args = {"clock": self.clock, "reactor": self.reactor}
         self.hs = self.make_homeserver(self.reactor, self.clock)
 
+        from synapse.logging.opentracing import init_tracer
+
+        # Start the tracer
+        init_tracer(self.hs)  # noqa
+
         self.hs.get_datastores().main.tests_allow_no_chain_cover_index = False
 
         # Honour the `use_frozen_dicts` config option. We have to do this

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -395,11 +395,6 @@ class HomeserverTestCase(TestCase):
         self._hs_args = {"clock": self.clock, "reactor": self.reactor}
         self.hs = self.make_homeserver(self.reactor, self.clock)
 
-        from synapse.logging.opentracing import init_tracer
-
-        # Start the tracer
-        init_tracer(self.hs)  # noqa
-
         self.hs.get_datastores().main.tests_allow_no_chain_cover_index = False
 
         # Honour the `use_frozen_dicts` config option. We have to do this


### PR DESCRIPTION
Spawning from @kegsay [pointing out](https://matrix.to/#/!cnVVNLKqgUzNTOFQkz:matrix.org/$ExOO7J8uPUQSyH-9Uxc_QCa8jlXX9uK4VRtkSC0EI3o?via=element.io&via=matrix.org&via=jki.re) that the Sliding Sync endpoint doesn't handle a large room with a lot of state well on initial sync (requesting all state via `required_state: [ ["*","*"] ]`) (it just takes forever).

After investigating further, the slow part is just `get_events_as_list(...)` fetching all of the current state ID's out for the room (which can be 100k+ events for rooms with a lot of membership). This is just a slow thing in Synapse in general and the same thing happens in Sync v2 or the `/state` endpoint.


---

The only idea I had to improve things was to use `batch_iter` to only try fetching a fixed amount at a time instead of working with large maps, lists, and sets. This doesn't seem to have much effect though.

There is already a `batch_iter(event_ids, 200)` in `_fetch_event_rows(...)` for when we actually have to touch the database and that's inside a queue to deduplicate work.

I did notice one slight optimization to use `get_events_as_list(...)` directly instead of `get_events(...)`. `get_events(...)` just turns the result from `get_events_as_list(...)`  into a dict and since we're just iterating over the events, we don't need the dict/map.


### Dev notes

#### Run the new tests

```sh
SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.storage.databases.main.test_events_worker.GetEventsTestCase

SYNAPSE_POSTGRES=1 SYNAPSE_POSTGRES_USER=postgres SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.storage.databases.main.test_events_worker.GetEventsTestCase
```


#### Enable Jaeger tracing in Twisted Trial tests:

Run Jaeger locally with Docker: https://www.jaegertracing.io/docs/1.6/getting-started/#all-in-one-docker-image

Add the following to `tests/unittest.py` in `setUp(...)`:

```py
        from synapse.logging.opentracing import init_tracer

        # Start the tracer
        init_tracer(self.hs)  # noqa
```


Add the following to your tests (in `tests/rest/client/test_asdf.py` for example):

```py
    def default_config(self) -> JsonDict:
        config = super().default_config()
        config["opentracing"] = {
            "enabled": True,
            "jaeger_config": {
                "sampler": {"type": "const", "param": 1},
                "logging": False,
            },
        }
        return config
```

Add a sleep to the end of the test you're running so the traces have a chance to flow to Jaeger before the process exits.

```py
import time
time.sleep(6)
```

If you're not tracing an endpoint/servlet (which will already have a logging context and tracing span), you will need to wrap your function under test in a logging context for the tracing to be happy. Also be sure to add `@trace` decorators to what you want to trace downstream.

```py
def test_asdf(self) -> None:
    with LoggingContext("test") as _ctx:
        my_custom_function()
```


Run your tests.

Visit http://localhost:16686/ and choose the `test master` service and find the traces you're interesting in.



### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
