### PR TITLE
Sliding Sync: Shortcut for checking if certain background updates have completed

### DIFF
--- a/changelog.d/17724.misc
+++ b/changelog.d/17724.misc
@@ -1,0 +1,1 @@
+Shortcut for checking if certain background updates have completed (utilized in Sliding Sync).

--- a/synapse/storage/background_updates.py
+++ b/synapse/storage/background_updates.py
@@ -490,6 +490,12 @@ class BackgroundUpdater:
         if self._all_done:
             return True
 
+        # We now check if we have completed all pending background updates. We
+        # do this as once this returns True then it will set `self._all_done`
+        # and we can skip checking the database in future.
+        if await self.has_completed_background_updates():
+            return True
+
         rows = await self.db_pool.simple_select_many_batch(
             table="background_updates",
             column="update_name",


### PR DESCRIPTION
Shortcut for checking if certain background updates have completed

Pulling this change out from one of @erikjohnston's branches (https://github.com/element-hq/synapse/compare/develop...erikj/ss_perf)

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
