### PR TITLE
Sliding Sync: Avoid fetching left rooms and add back `newly_left` rooms

### DIFF
--- a/changelog.d/17725.misc
+++ b/changelog.d/17725.misc
@@ -1,0 +1,1 @@
+More efficiently fetch rooms for Sliding Sync.

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -261,13 +261,6 @@ class SlidingSyncHandler:
                 is_dm=room_id in interested_rooms.dm_room_ids,
             )
 
-            logger.info(
-                "asdf handle_room room_sync_result %s %s %s",
-                room_id,
-                bool(room_sync_result),
-                room_sync_result,
-            )
-
             # Filter out empty room results during incremental sync
             if room_sync_result or not from_token:
                 rooms[room_id] = room_sync_result

--- a/synapse/handlers/sliding_sync/room_lists.py
+++ b/synapse/handlers/sliding_sync/room_lists.py
@@ -219,7 +219,7 @@ class SlidingSyncRoomLists:
         # include rooms that are outside the list ranges.
         all_rooms: Set[str] = set()
 
-        # Note: this won't include rooms the user have left themselves. We add back
+        # Note: this won't include rooms the user has left themselves. We add back
         # `newly_left` rooms below. This is more efficient than fetching all rooms and
         # then filtering out the old left rooms.
         room_membership_for_user_map = await self.store.get_sliding_sync_rooms_for_user(

--- a/synapse/handlers/sliding_sync/room_lists.py
+++ b/synapse/handlers/sliding_sync/room_lists.py
@@ -512,7 +512,7 @@ class SlidingSyncRoomLists:
 
         # Filtered subset of `relevant_room_map` for rooms that may have updates
         # (in the event stream)
-        relevant_rooms_to_send_map = await self._filter_relevant_room_to_send(
+        relevant_rooms_to_send_map = await self._filter_relevant_rooms_to_send(
             previous_connection_state, from_token, relevant_room_map
         )
 
@@ -520,6 +520,7 @@ class SlidingSyncRoomLists:
             "asdf room_membership_for_user_map: %s", room_membership_for_user_map
         )
 
+        logger.info("asdf relevant_rooms_to_send_map: %s", relevant_rooms_to_send_map)
         return SlidingSyncInterestedRooms(
             lists=lists,
             relevant_room_map=relevant_room_map,
@@ -703,7 +704,7 @@ class SlidingSyncRoomLists:
 
         # Filtered subset of `relevant_room_map` for rooms that may have updates
         # (in the event stream)
-        relevant_rooms_to_send_map = await self._filter_relevant_room_to_send(
+        relevant_rooms_to_send_map = await self._filter_relevant_rooms_to_send(
             previous_connection_state, from_token, relevant_room_map
         )
 
@@ -718,7 +719,7 @@ class SlidingSyncRoomLists:
             dm_room_ids=dm_room_ids,
         )
 
-    async def _filter_relevant_room_to_send(
+    async def _filter_relevant_rooms_to_send(
         self,
         previous_connection_state: PerConnectionState,
         from_token: Optional[StreamToken],

--- a/synapse/handlers/sliding_sync/room_lists.py
+++ b/synapse/handlers/sliding_sync/room_lists.py
@@ -271,16 +271,11 @@ class SlidingSyncRoomLists:
         missing_newly_left_rooms = (
             newly_left_room_map.keys() - room_membership_for_user_map.keys()
         )
-        logger.info("asdf newly_left_room_map: %s", newly_left_room_map.keys())
-        logger.info("asdf missing_newly_left_rooms: %s", missing_newly_left_rooms)
         if missing_newly_left_rooms:
             # TODO: It would be nice to avoid these copies
             room_membership_for_user_map = dict(room_membership_for_user_map)
             for room_id in missing_newly_left_rooms:
                 newly_left_room_for_user = newly_left_room_map[room_id]
-                logger.info(
-                    "asdf newly_left_room_for_user: %s", newly_left_room_for_user
-                )
                 # This should be a given
                 assert newly_left_room_for_user.membership == Membership.LEAVE
 
@@ -357,7 +352,6 @@ class SlidingSyncRoomLists:
                     newly_left=room_id in newly_left_room_map,
                 )
             }
-            logger.info("asdf sync_room_map: %s", sync_room_map)
             with start_active_span("assemble_sliding_window_lists"):
                 for list_key, list_config in sync_config.lists.items():
                     # Apply filters
@@ -370,9 +364,6 @@ class SlidingSyncRoomLists:
                             list_config.filters,
                             to_token,
                             dm_room_ids,
-                        )
-                        logger.info(
-                            "asdf filtered_sync_room_map: %s", filtered_sync_room_map
                         )
 
                     # Find which rooms are partially stated and may need to be filtered out
@@ -515,11 +506,6 @@ class SlidingSyncRoomLists:
             previous_connection_state, from_token, relevant_room_map
         )
 
-        logger.info(
-            "asdf room_membership_for_user_map: %s", room_membership_for_user_map
-        )
-
-        logger.info("asdf relevant_rooms_to_send_map: %s", relevant_rooms_to_send_map)
         return SlidingSyncInterestedRooms(
             lists=lists,
             relevant_room_map=relevant_room_map,
@@ -546,10 +532,6 @@ class SlidingSyncRoomLists:
             newly_left_room_ids,
         ) = await self.get_room_membership_for_user_at_to_token(
             sync_config.user, to_token, from_token
-        )
-        logger.info(
-            "asdf _compute_interested_rooms_fallback room_membership_for_user_map: %s",
-            room_membership_for_user_map,
         )
 
         dm_room_ids = await self._get_dm_rooms_for_user(sync_config.user.to_string())
@@ -993,7 +975,6 @@ class SlidingSyncRoomLists:
         ) = await self._get_newly_joined_and_left_rooms(
             user_id, to_token=to_token, from_token=from_token
         )
-        logger.info("asdf newly_left_room_map: %s", newly_left_room_map.keys())
 
         # If the user has never joined any rooms before, we can just return an empty
         # list. We also have to check the `newly_left_room_map` in case someone was

--- a/synapse/handlers/sliding_sync/room_lists.py
+++ b/synapse/handlers/sliding_sync/room_lists.py
@@ -342,16 +342,7 @@ class SlidingSyncRoomLists:
                     )
 
         if sync_config.lists:
-            sync_room_map = {
-                room_id: room_membership_for_user
-                for room_id, room_membership_for_user in room_membership_for_user_map.items()
-                # TODO: Do we need to do this anymore?
-                if filter_membership_for_sync(
-                    user_id=user_id,
-                    room_membership_for_user=room_membership_for_user,
-                    newly_left=room_id in newly_left_room_map,
-                )
-            }
+            sync_room_map = room_membership_for_user_map
             with start_active_span("assemble_sliding_window_lists"):
                 for list_key, list_config in sync_config.lists.items():
                     # Apply filters

--- a/synapse/handlers/sliding_sync/room_lists.py
+++ b/synapse/handlers/sliding_sync/room_lists.py
@@ -271,6 +271,8 @@ class SlidingSyncRoomLists:
         missing_newly_left_rooms = (
             newly_left_room_map.keys() - room_membership_for_user_map.keys()
         )
+        logger.info("asdf newly_left_room_map: %s", newly_left_room_map.keys())
+        logger.info("asdf missing_newly_left_rooms: %s", missing_newly_left_rooms)
         if missing_newly_left_rooms:
             # TODO: It would be nice to avoid these copies
             room_membership_for_user_map = dict(room_membership_for_user_map)
@@ -512,6 +514,10 @@ class SlidingSyncRoomLists:
         # (in the event stream)
         relevant_rooms_to_send_map = await self._filter_relevant_room_to_send(
             previous_connection_state, from_token, relevant_room_map
+        )
+
+        logger.info(
+            "asdf room_membership_for_user_map: %s", room_membership_for_user_map
         )
 
         return SlidingSyncInterestedRooms(
@@ -1097,10 +1103,6 @@ class SlidingSyncRoomLists:
             if membership_change.membership != Membership.JOIN:
                 has_non_join_event_by_room_id_in_from_to_range[room_id] = True
 
-        logger.info(
-            "asdf last_membership_change_by_room_id_in_from_to_range %s",
-            last_membership_change_by_room_id_in_from_to_range,
-        )
         # 1) Fixup
         #
         # 2) We also want to assemble a list of possibly newly joined rooms. Someone

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -1403,7 +1403,7 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
     ) -> Mapping[str, RoomsForUserSlidingSync]:
         """Get all the rooms for a user to handle a sliding sync request.
 
-        Ignores forgotten rooms and rooms that the user has been kicked from.
+        Ignores forgotten rooms and rooms that the user has left themselves.
 
         Returns:
             Map from room ID to membership info
@@ -1428,6 +1428,7 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
                 LEFT JOIN sliding_sync_joined_rooms AS j ON (j.room_id = m.room_id AND m.membership = 'join')
                 WHERE user_id = ?
                     AND m.forgotten = 0
+                    AND (m.membership != 'leave' OR m.user_id != m.sender)
             """
             txn.execute(sql, (user_id,))
             return {
@@ -1448,6 +1449,49 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
         return await self.db_pool.runInteraction(
             "get_sliding_sync_rooms_for_user",
             get_sliding_sync_rooms_for_user_txn,
+        )
+
+    async def get_sliding_sync_room_for_user(
+        self, user_id: str, room_id: str
+    ) -> Optional[RoomsForUserSlidingSync]:
+        """Get the sliding sync room entry for the given user and room."""
+
+        def get_sliding_sync_room_for_user_txn(
+            txn: LoggingTransaction,
+        ) -> Optional[RoomsForUserSlidingSync]:
+            sql = """
+                SELECT m.room_id, m.sender, m.membership, m.membership_event_id,
+                    r.room_version,
+                    m.event_instance_name, m.event_stream_ordering,
+                    m.has_known_state,
+                    COALESCE(j.room_type, m.room_type),
+                    COALESCE(j.is_encrypted, m.is_encrypted)
+                FROM sliding_sync_membership_snapshots AS m
+                INNER JOIN rooms AS r USING (room_id)
+                LEFT JOIN sliding_sync_joined_rooms AS j ON (j.room_id = m.room_id AND m.membership = 'join')
+                WHERE user_id = ?
+                    AND m.forgotten = 0
+                    AND m.room_id = ?
+            """
+            txn.execute(sql, (user_id, room_id))
+            row = txn.fetchone()
+            if not row:
+                return None
+
+            return RoomsForUserSlidingSync(
+                room_id=row[0],
+                sender=row[1],
+                membership=row[2],
+                event_id=row[3],
+                room_version_id=row[4],
+                event_pos=PersistedEventPosition(row[5], row[6]),
+                has_known_state=bool(row[7]),
+                room_type=row[8],
+                is_encrypted=row[9],
+            )
+
+        return await self.db_pool.runInteraction(
+            "get_sliding_sync_room_for_user", get_sliding_sync_room_for_user_txn
         )
 
 

--- a/synapse/storage/databases/main/stream.py
+++ b/synapse/storage/databases/main/stream.py
@@ -941,6 +941,11 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
         Returns:
             All membership changes to the current state in the token range. Events are
             sorted by `stream_ordering` ascending.
+
+            `event_id`/`sender` can be `None` when the server leaves a room (meaning
+            everyone locally left) or a state reset which removed the person from the
+            room. We can't tell the difference between the two cases with what's
+            availabe in the `current_state_delta_stream` table.
         """
         # Start by ruling out cases where a DB query is not necessary.
         if from_key == to_key:
@@ -1052,6 +1057,7 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
                         membership=(
                             membership if membership is not None else Membership.LEAVE
                         ),
+                        # This will also be null for the same reasons if `s.event_id = null`
                         sender=sender,
                         # Prev event
                         prev_event_id=prev_event_id,

--- a/synapse/storage/databases/main/stream.py
+++ b/synapse/storage/databases/main/stream.py
@@ -945,7 +945,8 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
             `event_id`/`sender` can be `None` when the server leaves a room (meaning
             everyone locally left) or a state reset which removed the person from the
             room. We can't tell the difference between the two cases with what's
-            availabe in the `current_state_delta_stream` table.
+            available in the `current_state_delta_stream` table. To actually check for a
+            state reset, you need to check if a membership still exists in the room.
         """
         # Start by ruling out cases where a DB query is not necessary.
         if from_key == to_key:

--- a/tests/rest/client/sliding_sync/test_sliding_sync.py
+++ b/tests/rest/client/sliding_sync/test_sliding_sync.py
@@ -889,6 +889,8 @@ class SlidingSyncTestCase(SlidingSyncBase):
 
         # Make the Sliding Sync request
         response_body, from_token = self.do_sync(sync_body, tok=user1_tok)
+        # Make sure we see room1
+        self.assertIncludes(set(response_body["rooms"].keys()), {room_id1}, exact=True)
         self.assertEqual(response_body["rooms"][room_id1]["initial"], True)
 
         # Trigger a state reset
@@ -1017,6 +1019,8 @@ class SlidingSyncTestCase(SlidingSyncBase):
 
         # Make the Sliding Sync request
         response_body, from_token = self.do_sync(sync_body, tok=user1_tok)
+        # Make sure we see room1
+        self.assertIncludes(set(response_body["rooms"].keys()), {room_id1}, exact=True)
         self.assertEqual(response_body["rooms"][space_room_id]["initial"], True)
 
         # Trigger a state reset

--- a/tests/rest/client/sliding_sync/test_sliding_sync.py
+++ b/tests/rest/client/sliding_sync/test_sliding_sync.py
@@ -1020,7 +1020,9 @@ class SlidingSyncTestCase(SlidingSyncBase):
         # Make the Sliding Sync request
         response_body, from_token = self.do_sync(sync_body, tok=user1_tok)
         # Make sure we see room1
-        self.assertIncludes(set(response_body["rooms"].keys()), {room_id1}, exact=True)
+        self.assertIncludes(
+            set(response_body["rooms"].keys()), {space_room_id}, exact=True
+        )
         self.assertEqual(response_body["rooms"][space_room_id]["initial"], True)
 
         # Trigger a state reset

--- a/tests/storage/test_stream.py
+++ b/tests/storage/test_stream.py
@@ -30,8 +30,8 @@ from twisted.test.proto_helpers import MemoryReactor
 from synapse.api.constants import (
     Direction,
     EventTypes,
-    Membership,
     JoinRules,
+    Membership,
     RelationTypes,
 )
 from synapse.api.filtering import Filter
@@ -1206,9 +1206,7 @@ class GetCurrentStateDeltaMembershipChangesForUserTestCase(HomeserverTestCase):
             )
         )
         _, join_rule_event_pos, _ = self.get_success(
-            self.hs.get_storage_controllers().persistence.persist_event(
-                join_rule_event, join_rule_context
-            )
+            self.persistence.persist_event(join_rule_event, join_rule_context)
         )
 
         # FIXME: We're manually busting the cache since

--- a/tests/storage/test_stream.py
+++ b/tests/storage/test_stream.py
@@ -27,7 +27,13 @@ from immutabledict import immutabledict
 
 from twisted.test.proto_helpers import MemoryReactor
 
-from synapse.api.constants import Direction, EventTypes, Membership, RelationTypes
+from synapse.api.constants import (
+    Direction,
+    EventTypes,
+    Membership,
+    JoinRules,
+    RelationTypes,
+)
 from synapse.api.filtering import Filter
 from synapse.crypto.event_signing import add_hashes_and_signatures
 from synapse.events import FrozenEventV3
@@ -1154,10 +1160,87 @@ class GetCurrentStateDeltaMembershipChangesForUserTestCase(HomeserverTestCase):
                     room_id=room_id1,
                     event_id=None,
                     event_pos=dummy_state_pos,
-                    membership="leave",
+                    membership=Membership.LEAVE,
                     sender=None,  # user1_id,
                     prev_event_id=join_response1["event_id"],
                     prev_event_pos=join_pos1,
+                    prev_membership="join",
+                    prev_sender=user1_id,
+                ),
+            ],
+        )
+
+    def test_state_reset2(self) -> None:
+        """
+        Test a state reset scenario where the user gets removed from the room (when
+        there is no corresponding leave event)
+        """
+        user1_id = self.register_user("user1", "pass")
+        user1_tok = self.login(user1_id, "pass")
+        user2_id = self.register_user("user2", "pass")
+        user2_tok = self.login(user2_id, "pass")
+
+        room_id1 = self.helper.create_room_as(user2_id, is_public=True, tok=user2_tok)
+
+        event_response = self.helper.send(room_id1, "test", tok=user2_tok)
+        event_id = event_response["event_id"]
+
+        user1_join_response = self.helper.join(room_id1, user1_id, tok=user1_tok)
+        user1_join_pos = self.get_success(
+            self.store.get_position_for_event(user1_join_response["event_id"])
+        )
+
+        before_reset_token = self.event_sources.get_current_token()
+
+        # Trigger a state reset
+        join_rule_event, join_rule_context = self.get_success(
+            create_event(
+                self.hs,
+                prev_event_ids=[event_id],
+                type=EventTypes.JoinRules,
+                state_key="",
+                content={"join_rule": JoinRules.INVITE},
+                sender=user2_id,
+                room_id=room_id1,
+                room_version=self.get_success(self.store.get_room_version_id(room_id1)),
+            )
+        )
+        _, join_rule_event_pos, _ = self.get_success(
+            self.hs.get_storage_controllers().persistence.persist_event(
+                join_rule_event, join_rule_context
+            )
+        )
+
+        # FIXME: We're manually busting the cache since
+        # https://github.com/element-hq/synapse/issues/17368 is not solved yet
+        self.store._membership_stream_cache.entity_has_changed(
+            user1_id, join_rule_event_pos.stream
+        )
+
+        after_reset_token = self.event_sources.get_current_token()
+
+        membership_changes = self.get_success(
+            self.store.get_current_state_delta_membership_changes_for_user(
+                user1_id,
+                from_key=before_reset_token.room_key,
+                to_key=after_reset_token.room_key,
+            )
+        )
+
+        # Let the whole diff show on failure
+        self.maxDiff = None
+        self.assertEqual(
+            membership_changes,
+            [
+                CurrentStateDeltaMembership(
+                    room_id=room_id1,
+                    event_id=None,
+                    # The position where the state reset happened
+                    event_pos=join_rule_event_pos,
+                    membership=Membership.LEAVE,
+                    sender=None,
+                    prev_event_id=user1_join_response["event_id"],
+                    prev_event_pos=user1_join_pos,
                     prev_membership="join",
                     prev_sender=user1_id,
                 ),


### PR DESCRIPTION
Performance optimization: We can avoid fetching rooms that the user has left themselves (which could be a significant amount), then only add back rooms that the user has `newly_left` (left in the token range of an incremental sync). It's a lot faster to fetch less rooms than fetch them all and throw them away in most cases. Since the user only leaves a room (or is state reset out) once in a blue moon, we can avoid a lot of work.

Based on @erikjohnston's branch, https://github.com/element-hq/synapse/compare/develop...erikj/ss_perf


### Todo

 - [x] Add tests
 - [ ] Maybe add in `SoftDeleteChainMap`, https://github.com/element-hq/synapse/pull/17725#discussion_r1764394991

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
