### PR TITLE
Bust `_membership_stream_cache` cache when current state changes

### DIFF
--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -86,7 +86,9 @@ class SQLBaseStore(metaclass=ABCMeta):
         """
 
     def _invalidate_state_caches(
-        self, room_id: str, members_changed: Collection[str]
+        self,
+        room_id: str,
+        members_changed: Collection[str],
     ) -> None:
         """Invalidates caches that are based on the current state, but does
         not stream invalidations down replication.

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -314,6 +314,17 @@ class StreamChangeCache:
         self._entity_to_key[entity] = stream_pos
         self._evict()
 
+    def all_entities_changed(self, stream_pos: int) -> None:
+        """
+        Mark all entities as changed. This is useful when the cache is invalidated and
+        there may be some potential change for all of the entities.
+        """
+        # All entities are at the same stream position now.
+        self._cache = SortedDict({stream_pos: set(self._entity_to_key.keys())})
+        self._entity_to_key = {
+            entity: stream_pos for entity in self._entity_to_key.keys()
+        }
+
     def _evict(self) -> None:
         """
         Ensure the cache has not exceeded the maximum size.

--- a/tests/util/test_stream_change_cache.py
+++ b/tests/util/test_stream_change_cache.py
@@ -251,3 +251,19 @@ class StreamChangeCacheTests(unittest.HomeserverTestCase):
 
         # Unknown entities will return None
         self.assertEqual(cache.get_max_pos_of_last_change("not@here.website"), None)
+
+    def test_all_entities_changed(self) -> None:
+        """
+        `StreamChangeCache.all_entities_changed(...)` will mark all entites as changed.
+        """
+        cache = StreamChangeCache("#test", 1, max_size=10)
+
+        cache.entity_has_changed("user@foo.com", 2)
+        cache.entity_has_changed("bar@baz.net", 3)
+        cache.entity_has_changed("user@elsewhere.org", 4)
+
+        cache.all_entities_changed(5)
+
+        self.assertEqual(cache.get_max_pos_of_last_change("user@foo.com"), 5)
+        self.assertEqual(cache.get_max_pos_of_last_change("bar@baz.net"), 5)
+        self.assertEqual(cache.get_max_pos_of_last_change("user@elsewhere.org"), 5)


### PR DESCRIPTION
Bust `_membership_stream_cache` cache when current state changes. This is a general Synapse thing so by it's nature it helps out Sliding Sync.

Fix https://github.com/element-hq/synapse/issues/17368

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
