### PR TITLE
Fix saving of non-RGB thumbnails as PNG

### DIFF
--- a/changelog.d/17736.bugfix
+++ b/changelog.d/17736.bugfix
@@ -1,0 +1,1 @@
+Fix saving of PNG thumbnails, when the original image is in the CMYK color space.

--- a/synapse/media/thumbnailer.py
+++ b/synapse/media/thumbnailer.py
@@ -206,7 +206,7 @@ class Thumbnailer:
     def _encode_image(self, output_image: Image.Image, output_type: str) -> BytesIO:
         output_bytes_io = BytesIO()
         fmt = self.FORMATS[output_type]
-        if fmt == "JPEG":
+        if fmt == "JPEG" or fmt == "PNG" and output_image.mode == "CMYK":
             output_image = output_image.convert("RGB")
         output_image.save(output_bytes_io, fmt, quality=80)
         return output_bytes_io


### PR DESCRIPTION
The PNG format does not support non-RGB color spaces, which makes pillow raise an exception when trying to save e.g. a CMYK image in PNG format.

Converting to RGB is recommended on the [upstream issue](https://github.com/python-pillow/Pillow/issues/1380), and as CMYK is a print format transparency does not need to be considered.

Closes: #10741

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
