### PR TITLE
Remove the deprecated cgi module

### DIFF
--- a/changelog.d/17741.misc
+++ b/changelog.d/17741.misc
@@ -1,0 +1,1 @@
+Remove the deprecated cgi module.

--- a/changelog.d/17741.misc
+++ b/changelog.d/17741.misc
@@ -1,1 +1,1 @@
-Remove the deprecated cgi module.
+Remove usage of the deprecated cgi module.

--- a/contrib/graph/graph.py
+++ b/contrib/graph/graph.py
@@ -20,8 +20,8 @@
 #
 
 import argparse
-import cgi
 import datetime
+import html
 import json
 import urllib.request
 from typing import List
@@ -85,7 +85,7 @@ def make_graph(pdus: List[dict], filename_prefix: str) -> None:
             "name": name,
             "type": pdu.get("pdu_type"),
             "state_key": pdu.get("state_key"),
-            "content": cgi.escape(json.dumps(pdu.get("content")), quote=True),
+            "content": html.escape(json.dumps(pdu.get("content")), quote=True),
             "time": t,
             "depth": pdu.get("depth"),
         }

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -887,7 +887,7 @@ def _check_power_levels(
                     raise SynapseError(400, f"{v!r} must be an integer.")
             if k in {"events", "notifications", "users"}:
                 if not isinstance(v, collections.abc.Mapping) or not all(
-                    isinstance(v, int)
+                    type(v) is int
                     for v in v.values()  # noqa: E721
                 ):
                     raise SynapseError(

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -887,7 +887,7 @@ def _check_power_levels(
                     raise SynapseError(400, f"{v!r} must be an integer.")
             if k in {"events", "notifications", "users"}:
                 if not isinstance(v, collections.abc.Mapping) or not all(
-                    type(v) is int
+                    isinstance(v, int)
                     for v in v.values()  # noqa: E721
                 ):
                     raise SynapseError(

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -24,7 +24,6 @@ import logging
 import random
 import sys
 import urllib.parse
-from email.message import EmailMessage
 from http import HTTPStatus
 from io import BytesIO, StringIO
 from typing import (

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -1813,11 +1813,8 @@ def check_content_type_is(headers: Headers, expected_content_type: str) -> None:
         )
 
     c_type = content_type_headers[0].decode("ascii")  # only the first header
-
-    msg = EmailMessage()
-    msg["content-type"] = c_type
-    c_type_parsed = msg.get_content_type()
-
+    # Extract the 'essence' of the mimetype, removing any parameter
+    c_type_parsed = c_type.split(";", 1)[0].strip()
     if c_type_parsed != expected_content_type:
         raise RequestSendFailed(
             RuntimeError(

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -19,12 +19,12 @@
 #
 #
 import abc
-import cgi
 import codecs
 import logging
 import random
 import sys
 import urllib.parse
+from email.message import EmailMessage
 from http import HTTPStatus
 from io import BytesIO, StringIO
 from typing import (
@@ -1813,8 +1813,12 @@ def check_content_type_is(headers: Headers, expected_content_type: str) -> None:
         )
 
     c_type = content_type_headers[0].decode("ascii")  # only the first header
-    val, options = cgi.parse_header(c_type)
-    if val != expected_content_type:
+
+    msg = EmailMessage()
+    msg["content-type"] = c_type
+    c_type_parsed = msg.get_content_type()
+
+    if c_type_parsed != expected_content_type:
         raise RequestSendFailed(
             RuntimeError(
                 f"Remote server sent Content-Type header of '{c_type}', not '{expected_content_type}'",


### PR DESCRIPTION
Removes all uses of the `cgi` module from Synapse. It was deprecated in Python version 3.11 and removed in version 3.13 ([“dead battery”](https://docs.python.org/3.13/whatsnew/3.13.html#pep-594-remove-dead-batteries-from-the-standard-library)). 

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
