### PR TITLE
Optimise notifier

### DIFF
--- a/changelog.d/17765.misc
+++ b/changelog.d/17765.misc
@@ -1,0 +1,1 @@
+Increase performance of the notifier when there are many syncing users.

--- a/synapse/notifier.py
+++ b/synapse/notifier.py
@@ -142,8 +142,7 @@ class _NotifierUserStream:
         """Notify any listeners for this user of a new event from an
         event source.
         Args:
-            stream_key: The stream the event came from.
-            stream_id: The new id for the stream the event came from.
+            current_token: The new current token.
             time_now_ms: The current time in milliseconds.
         """
         self.current_token = current_token


### PR DESCRIPTION
The notifier is quite inefficient when it has to wake up many user streams all at once

From a silly benchmark this takes the time to notify 1M user streams from ~30s to ~5s