### PR TITLE
Reduce overhead of sliding sync E2EE loops

### DIFF
--- a/changelog.d/17771.misc
+++ b/changelog.d/17771.misc
@@ -1,0 +1,1 @@
+Reduce overhead of sliding sync E2EE loops.

--- a/synapse/api/auth/msc3861_delegated.py
+++ b/synapse/api/auth/msc3861_delegated.py
@@ -338,7 +338,7 @@ class MSC3861DelegatedAuth(BaseAuth):
             logger.exception("Failed to introspect token")
             raise SynapseError(503, "Unable to introspect the access token")
 
-        logger.info(f"Introspection result: {introspection_result!r}")
+        logger.debug("Introspection result: %r", introspection_result)
 
         # TODO: introspection verification should be more extensive, especially:
         #   - verify the audience


### PR DESCRIPTION
Mainly toning down logging and only calling `get_membership_from_event_ids` if something has changed.