### PR TITLE
Fix NAME attribute of `ReplicationRemovePusherRestServlet`

### DIFF
--- a/changelog.d/17779.bugfix
+++ b/changelog.d/17779.bugfix
@@ -1,0 +1,1 @@
+Fix a rare bug introduced in v1.29.0 where invalidating a user's access token from a worker could raise an error.

--- a/synapse/replication/http/push.py
+++ b/synapse/replication/http/push.py
@@ -48,7 +48,7 @@ class ReplicationRemovePusherRestServlet(ReplicationEndpoint):
 
     """
 
-    NAME = "add_user_account_data"
+    NAME = "remove_pusher"
     PATH_ARGS = ("user_id",)
     CACHE = False
 


### PR DESCRIPTION
Looks like a copy-paste error. One way to prevent this in the future is having a test that checks that no two replication endpoints have the same `NAME`. Or generating `NAME` based on the class name.

---

The PR that originally [introduced this replication endpoint](https://github.com/matrix-org/synapse/pull/9465) mentioned that there were currently no users of it. Indeed, I could only find one (very rare) codepath that called `PusherPool.remove_pusher` from a worker, which was:

https://github.com/element-hq/synapse/blob/5acd8d258c6b93fe8d7e9c082d10cf52c5efc9b2/synapse/module_api/__init__.py#L912-L915

https://github.com/element-hq/synapse/blob/d4e3ad04cd722e3c98c85685d47a6d86029ffe0c/synapse/handlers/auth.py#L1514-L1516

So only if a Synapse module called `invalidate_access_token` while running on a worker, would this bug have surfaced.