### PR TITLE
Sliding sync: omit bump stamp when it is unchanged

### DIFF
--- a/changelog.d/17788.misc
+++ b/changelog.d/17788.misc
@@ -1,0 +1,1 @@
+Sliding sync minor performance improvement by omitting unchanged data from incremental responses.

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -1178,9 +1178,10 @@ class SlidingSyncHandler:
         changed.
 
         Args:
-            room_id to_token: The upper bound of token to return timeline: The
-                list of events we have fetched. limited: If the timeline was
-                limited.
+            room_id
+            to_token: The upper bound of token to return
+            timeline: The list of events we have fetched.
+            limited: If the timeline was limited.
             check_non_timeline: Whether we need to check for bump stamp for
                 events before the timeline if we didn't find a bump stamp in
                 the timeline events.

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -1066,7 +1066,7 @@ class SlidingSyncHandler:
                 room_id,
                 to_token,
                 timeline_events,
-                check_non_timeline=always_return_bump_stamp,
+                check_outside_timeline=always_return_bump_stamp,
             )
             if new_bump_stamp is not None:
                 bump_stamp = new_bump_stamp
@@ -1172,7 +1172,7 @@ class SlidingSyncHandler:
         room_id: str,
         to_token: StreamToken,
         timeline: List[EventBase],
-        check_non_timeline: bool,
+        check_outside_timeline: bool,
     ) -> Optional[int]:
         """Get a bump stamp for the room, if we have a bump event and it has
         changed.
@@ -1182,7 +1182,7 @@ class SlidingSyncHandler:
             to_token: The upper bound of token to return
             timeline: The list of events we have fetched.
             limited: If the timeline was limited.
-            check_non_timeline: Whether we need to check for bump stamp for
+            check_outside_timeline: Whether we need to check for bump stamp for
                 events before the timeline if we didn't find a bump stamp in
                 the timeline events.
         """
@@ -1204,7 +1204,7 @@ class SlidingSyncHandler:
                 if new_bump_stamp > 0:
                     return new_bump_stamp
 
-        if not check_non_timeline:
+        if not check_outside_timeline:
             # If we are not a limited sync, then we know the bump stamp can't
             # have changed.
             return None

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -1053,8 +1053,16 @@ class SlidingSyncHandler:
         bump_stamp = None
 
         always_return_bump_stamp = (
+            # We use the membership event position for any non-join
             room_membership_for_user_at_to_token.membership != Membership.JOIN
-            or limited is not False
+            # We didn't fetch any timeline events but we should still check for
+            # a bump_stamp that might be somewhere
+            or limited is None
+            # There might be a bump event somewhere before the timeline events
+            # that we fetched, that we didn't previously send down
+            or limited is True
+            # Always give the client some frame of reference if this is the
+            # first time they are seeing the room down the connection
             or initial
         )
 

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -1010,10 +1010,12 @@ class SlidingSyncRestServlet(RestServlet):
         serialized_rooms: Dict[str, JsonDict] = {}
         for room_id, room_result in rooms.items():
             serialized_rooms[room_id] = {
-                "bump_stamp": room_result.bump_stamp,
                 "notification_count": room_result.notification_count,
                 "highlight_count": room_result.highlight_count,
             }
+
+            if room_result.bump_stamp is not None:
+                serialized_rooms[room_id]["bump_stamp"] = room_result.bump_stamp
 
             if room_result.joined_count is not None:
                 serialized_rooms[room_id]["joined_count"] = room_result.joined_count

--- a/synapse/types/handlers/sliding_sync.py
+++ b/synapse/types/handlers/sliding_sync.py
@@ -158,7 +158,7 @@ class SlidingSyncResult:
                 name changes to mark the room as unread and bump it to the top. For
                 encrypted rooms, we just have to consider any activity as a bump because we
                 can't see the content and the client has to figure it out for themselves.
-                This is only included if there has been a change.
+                This may not be included if there hasn't been a change.
             joined_count: The number of users with membership of join, including the client's
                 own user ID. (same as sync `v2 m.joined_member_count`)
             invited_count: The number of users with membership of invite. (same as sync v2

--- a/synapse/types/handlers/sliding_sync.py
+++ b/synapse/types/handlers/sliding_sync.py
@@ -158,6 +158,7 @@ class SlidingSyncResult:
                 name changes to mark the room as unread and bump it to the top. For
                 encrypted rooms, we just have to consider any activity as a bump because we
                 can't see the content and the client has to figure it out for themselves.
+                This is only included if there has been a change.
             joined_count: The number of users with membership of join, including the client's
                 own user ID. (same as sync `v2 m.joined_member_count`)
             invited_count: The number of users with membership of invite. (same as sync v2
@@ -193,7 +194,7 @@ class SlidingSyncResult:
         limited: Optional[bool]
         # Only optional because it won't be included for invite/knock rooms with `stripped_state`
         num_live: Optional[int]
-        bump_stamp: int
+        bump_stamp: Optional[int]
         joined_count: Optional[int]
         invited_count: Optional[int]
         notification_count: int


### PR DESCRIPTION
This saves some DB lookups in rooms