### PR TITLE
WIP: Speed up filtering of events with new history visibility index

### DIFF
--- a/synapse/storage/databases/main/sliding_sync.py
+++ b/synapse/storage/databases/main/sliding_sync.py
@@ -23,6 +23,7 @@ from synapse.events import EventBase
 from synapse.logging.opentracing import log_kv
 from synapse.storage._base import SQLBaseStore, db_to_json
 from synapse.storage.database import LoggingTransaction
+from synapse.storage.engines import PostgresEngine
 from synapse.types import MultiWriterStreamToken, RoomStreamToken
 from synapse.types.handlers.sliding_sync import (
     HaveSentRoom,
@@ -458,27 +459,58 @@ class SlidingSyncStore(SQLBaseStore):
         def get_visibility_for_events_txn(
             txn: LoggingTransaction,
         ) -> Mapping[str, Optional[str]]:
-            sql = """
-                SELECT visibility FROM history_visibility_ranges
-                WHERE start_range <= ? AND (? < end_range OR end_range IS NULL)
-                    AND room_id = ?
-            """
+            if isinstance(txn.database_engine, PostgresEngine):
+                sql = """
+                    SELECT start_range, end_range, visibility FROM history_visibility_ranges
+                    WHERE int8range(start_range, end_range, '[)') @> ANY(?::bigint[])
+                        AND room_id = ?
+                """
+                stream_orderings = [
+                    event.internal_metadata.stream_ordering for event in events
+                ]
+                txn.execute(sql, (stream_orderings, room_id))
 
-            results = {}
-            for event in events:
-                txn.execute(
-                    sql,
-                    (
-                        event.internal_metadata.stream_ordering,
-                        event.internal_metadata.stream_ordering,
-                        room_id,
-                    ),
-                )
-                row = txn.fetchone()
-                if row is not None:
-                    results[event.event_id] = row[0]
+                ranges = [
+                    ((start_range, end_range), visibility)
+                    for start_range, end_range, visibility in txn
+                ]
 
-            return results
+                results: Dict[str, Optional[str]] = {}
+                for event in events:
+                    stream_ordering = event.internal_metadata.stream_ordering
+                    for (start_range, end_range), visibility in ranges:
+                        if stream_ordering < start_range:
+                            continue
+                        if end_range is not None and end_range <= stream_ordering:
+                            continue
+
+                        results[event.event_id] = visibility
+                        break
+
+                return results
+
+            else:
+                sql = """
+                    SELECT visibility FROM history_visibility_ranges
+                    WHERE start_range <= ? AND (? < end_range OR end_range IS NULL)
+                        AND room_id = ?
+                """
+
+                results = {}
+                for event in events:
+                    txn.execute(
+                        sql,
+                        (
+                            event.internal_metadata.stream_ordering,
+                            event.internal_metadata.stream_ordering,
+                            room_id,
+                        ),
+                    )
+                    row = txn.fetchone()
+                    if row is not None:
+                        results[event.event_id] = row[0]
+
+                return results
 
         return await self.db_pool.runInteraction(
             "get_visibility_for_events", get_visibility_for_events_txn

--- a/synapse/storage/schema/main/delta/87/04_visibility.sql
+++ b/synapse/storage/schema/main/delta/87/04_visibility.sql
@@ -1,0 +1,25 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2024 New Vector, Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+CREATE TABLE IF NOT EXISTS history_visibility_ranges (
+    room_id TEXT NOT NULL,
+    visibility TEXT NOT NULL,
+    start_range BIGINT NOT NULL,
+    end_range BIGINT
+);
+
+CREATE INDEX history_visibility_ranges_idx ON history_visibility_ranges(room_id, start_range, end_range DESC);
+CREATE UNIQUE INDEX history_visibility_ranges_uniq_idx ON history_visibility_ranges(room_id, start_range);
+
+-- CREATE EXTENSION IF NOT EXISTS btree_gist;
+-- CREATE INDEX history_visibility_ranges_idx_gist ON history_visibility_ranges USING gist(room_id, int8range(start_range, end_range, '[)]'));

--- a/synapse/storage/schema/main/delta/87/05_visibility_index.sql.postgres
+++ b/synapse/storage/schema/main/delta/87/05_visibility_index.sql.postgres
@@ -1,0 +1,15 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2024 New Vector, Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+CREATE INDEX history_visibility_ranges_idx_gist ON history_visibility_ranges USING gist(room_id, int8range(start_range, end_range, '[)'));

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -105,8 +105,6 @@ async def filter_events_for_client(
         The filtered events. The `unsigned` data is annotated with the membership state
         of `user_id` at each event.
     """
-    if not events:
-        return []
 
     # Filter out events that have been soft failed so that we don't relay them
     # to clients.
@@ -124,6 +122,9 @@ async def filter_events_for_client(
         _HISTORY_VIS_KEY,
         (EventTypes.Member, user_id),
     )
+
+    if not events:
+        return []
 
     room_id = events[0].room_id
     assert all(event.room_id == room_id for event in events)


### PR DESCRIPTION
This is a WIP to try out a new approach for speeding up filtering of events. That is quite an expensive and hot path, since it is called on every event we return to the clients, and it involves looking up the state at each of the events.

This PR adds a new table that for each room records the history visibility for a given range of stream orderings. This is updated when we update the current state. On postgres, this allows efficient queries along the lines of "return all rows whose range includes any of these stream orderings".

A lot of large rooms have history visibility set to "shared", which means that we can skip checking historic membership entirely. We could also use this same approach to index room membership, though that is a bigger ask.