### PR TITLE
Build debian packages for new Ubuntu versions

### DIFF
--- a/changelog.d/17824.misc
+++ b/changelog.d/17824.misc
@@ -1,0 +1,1 @@
+Build debian packages for new Ubuntu versions, and stop building for no longer supported versions.

--- a/scripts-dev/build_debian_packages.py
+++ b/scripts-dev/build_debian_packages.py
@@ -32,8 +32,8 @@ DISTS = (
     "debian:sid",  # (EOL not specified yet) (our EOL forced by Python 3.11 is 2027-10-24)
     "ubuntu:focal",  # 20.04 LTS (EOL 2025-04) (our EOL forced by Python 3.8 is 2024-10-14)
     "ubuntu:jammy",  # 22.04 LTS (EOL 2027-04) (our EOL forced by Python 3.10 is 2026-10-04)
-    "ubuntu:lunar",  # 23.04 (EOL 2024-01) (our EOL forced by Python 3.11 is 2027-10-24)
-    "ubuntu:mantic",  # 23.10 (EOL 2024-07) (our EOL forced by Python 3.11 is 2027-10-24)
+    "ubuntu:noble",  # 24.04 LTS (EOL 2029-06)
+    "ubuntu:oracular",  # 24.10 (EOL 2025-07)
     "debian:trixie",  # (EOL not specified yet)
 )
 


### PR DESCRIPTION
c.f. https://wiki.ubuntu.com/Releases for the currently supported Ubuntu releases.

Note: this removes support for 23.04 and 23.10, which are EOL.

Fixes #17811