### PR TITLE
Include the destination in the error of 'Destination mismatch'

### DIFF
--- a/changelog.d/17830.misc
+++ b/changelog.d/17830.misc
@@ -1,0 +1,1 @@
+Include the destination in the error of 'Destination mismatch' on federation requests.

--- a/synapse/federation/transport/server/_base.py
+++ b/synapse/federation/transport/server/_base.py
@@ -113,7 +113,7 @@ class Authenticator:
                 ):
                     raise AuthenticationError(
                         HTTPStatus.UNAUTHORIZED,
-                        "Destination mismatch in auth header",
+                        f"Destination mismatch in auth header, received: {destination!r}",
                         Codes.UNAUTHORIZED,
                     )
         if (


### PR DESCRIPTION
To help debug problems such as https://github.com/element-hq/synapse/issues/17822