### PR TITLE
Introducing Synapse Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 
 **Element Synapse - Matrix homeserver implementation**
 
-|support| |development| |documentation| |license| |pypi| |python|
+|support| |development| |documentation| |license| |pypi| |python| |gurubase|
 
 Synapse is an open source `Matrix <https://matrix.org>`__ homeserver
 implementation, written and maintained by `Element <https://element.io>`_.
@@ -273,3 +273,7 @@ Alongside all that, join our developer community on Matrix:
 .. |python| image:: https://img.shields.io/pypi/pyversions/matrix-synapse
   :alt: (supported python versions)
   :target: https://pypi.org/project/matrix-synapse
+
+.. |gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20Synapse%20Guru-006BFF
+  :alt: (Synapse Guru on Gurubase.io)
+  :target: https://gurubase.io/g/synapse


### PR DESCRIPTION
Hello Synapse team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Synapse Guru](https://gurubase.io/g/synapse) to Gurubase. Synapse Guru uses the data from this repo and data from the [docs](https://element-hq.github.io/synapse/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Synapse Guru" badge, which highlights that Synapse now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Synapse Guru in Gurubase, just let me know that's totally fine.