### PR TITLE
Add admin handler to list of handlers used for background tasks

### DIFF
--- a/changelog.d/17847.bugfix
+++ b/changelog.d/17847.bugfix
@@ -1,0 +1,2 @@
+Fix a bug in the admin redact endpoint where the background task would not run if a worker was specified in
+ the config option `run_background_tasks_on`.

--- a/changelog.d/17847.bugfix
+++ b/changelog.d/17847.bugfix
@@ -1,2 +1,2 @@
 Fix a bug in the admin redact endpoint where the background task would not run if a worker was specified in
- the config option `run_background_tasks_on`.
+the config option `run_background_tasks_on`.

--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -1366,7 +1366,7 @@ _Added in Synapse 1.72.0._
 ## Redact all the events of a user
 
 This endpoint allows an admin to redact the events of a given user. There are no restrictions on redactions for a 
-local user. Redactions for non-local users are issued using the admin user, and will fail in rooms where the admin user is not admin/does not have the specified power level to issue redactions. 
+local user. By default, we puppet the user who sent the message to redact it themselves. Redactions for non-local users are issued using the admin user, and will fail in rooms where the admin user is not admin/does not have the specified power level to issue redactions. 
 
 The API is 
 ```

--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -1365,6 +1365,9 @@ _Added in Synapse 1.72.0._
 
 ## Redact all the events of a user
 
+This endpoint allows an admin to redact the events of a given user. There are no restrictions on redactions for a 
+local user. Redactions for non-local users are issued using the admin user, and will fail in rooms where the admin user is not admin/does not have the specified power level to issue redactions. 
+
 The API is 
 ```
 POST /_synapse/admin/v1/user/$user_id/redact

--- a/synapse/handlers/admin.py
+++ b/synapse/handlers/admin.py
@@ -73,6 +73,8 @@ class AdminHandler:
             self._redact_all_events, REDACT_ALL_EVENTS_ACTION_NAME
         )
 
+        self.hs = hs
+
     async def get_redact_task(self, redact_id: str) -> Optional[ScheduledTask]:
         """Get the current status of an active redaction process
 
@@ -423,8 +425,10 @@ class AdminHandler:
         user_id = task.params.get("user_id")
         assert user_id is not None
 
+        # puppet the user if they're ours, otherwise use admin to redact
         requester = create_requester(
-            user_id, authenticated_entity=admin.user.to_string()
+            user_id if self.hs.is_mine_id(user_id) else admin.user.to_string(),
+            authenticated_entity=admin.user.to_string(),
         )
 
         reason = task.params.get("reason")

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -249,6 +249,7 @@ class HomeServer(metaclass=abc.ABCMeta):
     """
 
     REQUIRED_ON_BACKGROUND_TASK_STARTUP = [
+        "admin",
         "account_validity",
         "auth",
         "deactivate_account",

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -5469,11 +5469,11 @@ class UserRedactionBackgroundTaskTestCase(BaseMultiWorkerStreamTestCase):
         self.assertEqual(channel.code, 200)
         id = channel.json_body.get("redact_id")
 
-        timeout = 10
+        timeout_s = 10
         start_time = time.time()
         redact_result = ""
         while redact_result != "complete":
-            if start_time + timeout < time.time():
+            if start_time + timeout_s < time.time():
                 self.fail("Timed out waiting for redactions.")
 
             channel2 = self.make_request(


### PR DESCRIPTION
Fixes #17823

While we're at it, makes a change where the redactions are sent as the admin if the user is not a member of the server (otherwise these fail with a "User must be our own" message).


### Dev notes

Keywords:

 - `TaskScheduler`
 - `run_as_background_process(...)`
 -  `wait_for_background_processes(...)`
 - `reactor`