### PR TITLE
Prevent exception when remote media Content-Type header value is `None`

### DIFF
--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -912,7 +912,11 @@ class MediaRepository:
                 )
                 raise SynapseError(502, "Failed to fetch remote media")
 
-            if b"Content-Type" in headers:
+            if (
+                b"Content-Type" in headers
+                and len(headers[b"Content-Type"]) > 0
+                and headers[b"Content-Type"][0] is not None
+            ):
                 media_type = headers[b"Content-Type"][0].decode("ascii")
             else:
                 media_type = "application/octet-stream"


### PR DESCRIPTION
Fixes the following exception, which we were seeing around 30 times/day on matrix.org:

```
  File "synapse/http/server.py", line 332, in _async_render_wrapper
    callback_return = await self._async_render(request)
  File "synapse/http/server.py", line 544, in _async_render
    callback_return = await raw_callback_return
  File "synapse/rest/client/media.py", line 260, in on_GET
    await self.media_repo.get_remote_media(
  File "synapse/media/media_repository.py", line 531, in get_remote_media
    responder, media_info = await self._get_remote_media_impl(
  File "synapse/media/media_repository.py", line 691, in _get_remote_media_impl
    raise e
  File "synapse/media/media_repository.py", line 676, in _get_remote_media_impl
    media_info = await self._federation_download_remote_file(
  File "synapse/media/media_repository.py", line 916, in _federation_download_remote_file
    media_type = headers[b"Content-Type"][0].decode("ascii")
AttributeError: 'NoneType' object has no attribute 'decode'
```