### PR TITLE
MSC4171 Omit service members from room summary

### DIFF
--- a/changelog.d/17866.feature
+++ b/changelog.d/17866.feature
@@ -1,1 +1,1 @@
-Add support for filtering out "service members" from room summary responses, as described in MSC4171.
+Add experimental support for filtering out "service members" from room summary responses, as described in [MSC4171](https://github.com/matrix-org/matrix-spec-proposals/pull/4171).

--- a/changelog.d/17866.feature
+++ b/changelog.d/17866.feature
@@ -1,0 +1,1 @@
+Add support for filtering out "service members" from room summary responses, as described in MSC4171.

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -135,6 +135,8 @@ class EventTypes:
 
     PollStart: Final = "m.poll.start"
 
+    MSC4171FunctionalMembers: Final = "io.element.functional_members"
+
 
 class ToDeviceEventTypes:
     RoomKeyRequest: Final = "m.room_key_request"

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -448,5 +448,8 @@ class ExperimentalConfig(Config):
         # MSC4151: Report room API (Client-Server API)
         self.msc4151_enabled: bool = experimental.get("msc4151_enabled", False)
 
+        # MSC4171: Service members
+        self.msc4171_enabled: bool = experimental.get("msc4171_enabled", False)
+
         # MSC4210: Remove legacy mentions
         self.msc4210_enabled: bool = experimental.get("msc4210_enabled", False)

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -732,6 +732,8 @@ class FederationServer(FederationBase):
         state_event_ids: Collection[str]
         servers_in_room: Optional[Collection[str]]
         if caller_supports_partial_state:
+            # NOTE: We do not exclude service members from the federated
+            # room summary.
             summary = await self.store.get_room_summary(room_id)
             state_event_ids = _get_event_ids_for_partial_state_join(
                 event, prev_state_ids, summary

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -783,14 +783,20 @@ class SlidingSyncHandler:
             name_event_id = state_ids.get((EventTypes.Name, ""))
 
             if self.hide_service_members_from_heroes:
-                functional_members_id = state_ids.get((EventTypes.MSC4171FunctionalMembers, ""))
+                functional_members_id = state_ids.get(
+                    (EventTypes.MSC4171FunctionalMembers, "")
+                )
                 if functional_members_id:
                     functional_members = await self.store.get_event(
                         functional_members_id, allow_none=True
                     )
                     # If there is a functional members event, and the service_members is an array, then apply the filter.
-                    if functional_members and isinstance(functional_members.content.get("service_members"), list):
-                        ignore_members_for_heroes = functional_members.content.get("service_members")
+                    if functional_members and isinstance(
+                        functional_members.content.get("service_members"), list
+                    ):
+                        ignore_members_for_heroes = functional_members.content.get(
+                            "service_members"
+                        )
 
         else:
             assert from_bound is not None
@@ -851,7 +857,9 @@ class SlidingSyncHandler:
                 # TODO: Reverse/rewind back to the `to_token`
 
             hero_user_ids = extract_heroes_from_room_summary(
-                room_membership_summary, me=user.to_string(), skip_user_ids=ignore_members_for_heroes
+                room_membership_summary,
+                me=user.to_string(),
+                skip_user_ids=ignore_members_for_heroes,
             )
 
         # Fetch the membership counts for rooms we're joined to.

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -90,7 +90,6 @@ class SlidingSyncHandler:
         self.event_sources = hs.get_event_sources()
         self.relations_handler = hs.get_relations_handler()
         self.rooms_to_exclude_globally = hs.config.server.rooms_to_exclude_from_sync
-        self.hide_service_members_from_heroes = hs.config.experimental.msc4171_enabled
         self.is_mine_id = hs.is_mine_id
 
         self.connection_store = SlidingSyncConnectionStore(self.store)
@@ -766,38 +765,15 @@ class SlidingSyncHandler:
         membership_changed = False
         name_changed = False
         avatar_changed = False
-        ignore_members_for_heroes = []
         if initial:
-            state_filter_types = [(EventTypes.Name, "")]
-
-            if self.hide_service_members_from_heroes:
-                state_filter_types.append((EventTypes.MSC4171FunctionalMembers, ""))
-
-            # Check whether the room has a name set (and fetch the service members)
-            state_ids = await self.get_current_state_ids_at(
+            # Check whether the room has a name set
+            name_state_ids = await self.get_current_state_ids_at(
                 room_id=room_id,
                 room_membership_for_user_at_to_token=room_membership_for_user_at_to_token,
-                state_filter=StateFilter.from_types(state_filter_types),
+                state_filter=StateFilter.from_types([(EventTypes.Name, "")]),
                 to_token=to_token,
             )
-            name_event_id = state_ids.get((EventTypes.Name, ""))
-
-            if self.hide_service_members_from_heroes:
-                functional_members_id = state_ids.get(
-                    (EventTypes.MSC4171FunctionalMembers, "")
-                )
-                if functional_members_id:
-                    functional_members = await self.store.get_event(
-                        functional_members_id, allow_none=True
-                    )
-                    # If there is a functional members event, and the service_members is an array, then apply the filter.
-                    if functional_members and isinstance(
-                        functional_members.content.get("service_members"), list
-                    ):
-                        ignore_members_for_heroes = functional_members.content.get(
-                            "service_members"
-                        )
-
+            name_event_id = name_state_ids.get((EventTypes.Name, ""))
         else:
             assert from_bound is not None
 
@@ -857,9 +833,7 @@ class SlidingSyncHandler:
                 # TODO: Reverse/rewind back to the `to_token`
 
             hero_user_ids = extract_heroes_from_room_summary(
-                room_membership_summary,
-                me=user.to_string(),
-                skip_user_ids=ignore_members_for_heroes,
+                room_membership_summary, me=user.to_string()
             )
 
         # Fetch the membership counts for rooms we're joined to.

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -788,6 +788,7 @@ class SlidingSyncHandler:
                     functional_members = await self.store.get_event(
                         functional_members_id, allow_none=True
                     )
+                    # If there is a functional members event, and the service_members is an array, then apply the filter.
                     if functional_members and isinstance(functional_members.content.get("service_members"), list):
                         ignore_members_for_heroes = functional_members.content.get("service_members")
 

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -832,7 +832,9 @@ class SlidingSyncHandler:
                 room_membership_summary = {}
             else:
                 room_membership_summary = await self.store.get_room_summary(
-                    room_id, self.should_exclude_service_members
+                    room_id,
+                    self.should_exclude_service_members
+                    and sync_config.exclude_service_members_from_heroes,
                 )
                 # TODO: Reverse/rewind back to the `to_token`
 

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -90,6 +90,8 @@ class SlidingSyncHandler:
         self.event_sources = hs.get_event_sources()
         self.relations_handler = hs.get_relations_handler()
         self.rooms_to_exclude_globally = hs.config.server.rooms_to_exclude_from_sync
+        self.should_exclude_service_members = hs.config.experimental.msc4171_enabled
+
         self.is_mine_id = hs.is_mine_id
 
         self.connection_store = SlidingSyncConnectionStore(self.store)
@@ -829,7 +831,9 @@ class SlidingSyncHandler:
                 # For invite/knock rooms we don't include the information.
                 room_membership_summary = {}
             else:
-                room_membership_summary = await self.store.get_room_summary(room_id)
+                room_membership_summary = await self.store.get_room_summary(
+                    room_id, self.should_exclude_service_members
+                )
                 # TODO: Reverse/rewind back to the `to_token`
 
             hero_user_ids = extract_heroes_from_room_summary(

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1050,7 +1050,6 @@ class SyncHandler:
         name_id = state_ids.get((EventTypes.Name, ""))
         canonical_alias_id = state_ids.get((EventTypes.CanonicalAlias, ""))
 
-
         summary: JsonDict = {}
         empty_ms = MemberSummary([], 0)
 
@@ -1100,7 +1099,6 @@ class SyncHandler:
                 member_ids[user_id] = event_id
 
         me = sync_config.user.to_string()
-        # HERE:
         summary["m.heroes"] = extract_heroes_from_room_summary(details, me, ignore_members_for_heroes)
 
         if not sync_config.filter_collection.lazy_load_members():

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -343,6 +343,7 @@ class SyncHandler:
         self._task_scheduler = hs.get_task_scheduler()
 
         self.should_calculate_push_rules = hs.config.push.enable_push
+        self.should_exclude_service_members = hs.config.experimental.msc4171_enabled
 
         # TODO: flush cache entries on subsequent sync request.
         #    Once we get the next /sync request (ie, one with the same access token
@@ -1040,7 +1041,9 @@ class SyncHandler:
         )
 
         # this is heavily cached, thus: fast.
-        details = await self.store.get_room_summary(room_id)
+        details = await self.store.get_room_summary(
+            room_id, self.should_exclude_service_members
+        )
 
         name_id = state_ids.get((EventTypes.Name, ""))
         canonical_alias_id = state_ids.get((EventTypes.CanonicalAlias, ""))

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -143,6 +143,7 @@ class SyncConfig:
     filter_collection: FilterCollection
     is_guest: bool
     device_id: Optional[str]
+    exclude_service_members_from_heroes: bool
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
@@ -1042,7 +1043,9 @@ class SyncHandler:
 
         # this is heavily cached, thus: fast.
         details = await self.store.get_room_summary(
-            room_id, self.should_exclude_service_members
+            room_id,
+            self.should_exclude_service_members
+            and sync_config.exclude_service_members_from_heroes,
         )
 
         name_id = state_ids.get((EventTypes.Name, ""))

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1084,6 +1084,7 @@ class SyncHandler:
                 functional_members = await self.store.get_event(
                     functional_members_id, allow_none=True
                 )
+                # If there is a functional members event, and the service_members is an array, then apply the filter.
                 if functional_members and isinstance(functional_members.content.get("service_members"), list):
                     ignore_members_for_heroes = functional_members.content.get("service_members")
 

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1074,18 +1074,23 @@ class SyncHandler:
             if canonical_alias and canonical_alias.content.get("alias"):
                 return summary
 
-
         ignore_members_for_heroes = []
 
         if self.hide_service_members_from_heroes:
-            functional_members_id = state_ids.get((EventTypes.MSC4171FunctionalMembers, ""))
+            functional_members_id = state_ids.get(
+                (EventTypes.MSC4171FunctionalMembers, "")
+            )
             if functional_members_id:
                 functional_members = await self.store.get_event(
                     functional_members_id, allow_none=True
                 )
                 # If there is a functional members event, and the service_members is an array, then apply the filter.
-                if functional_members and isinstance(functional_members.content.get("service_members"), list):
-                    ignore_members_for_heroes = functional_members.content.get("service_members")
+                if functional_members and isinstance(
+                    functional_members.content.get("service_members"), list
+                ):
+                    ignore_members_for_heroes = functional_members.content.get(
+                        "service_members"
+                    )
 
         # FIXME: only build up a member_ids list for our heroes
         member_ids = {}
@@ -1099,7 +1104,9 @@ class SyncHandler:
                 member_ids[user_id] = event_id
 
         me = sync_config.user.to_string()
-        summary["m.heroes"] = extract_heroes_from_room_summary(details, me, ignore_members_for_heroes)
+        summary["m.heroes"] = extract_heroes_from_room_summary(
+            details, me, ignore_members_for_heroes
+        )
 
         if not sync_config.filter_collection.lazy_load_members():
             return summary

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -366,6 +366,7 @@ class SyncHandler:
         )
 
         self.rooms_to_exclude_globally = hs.config.server.rooms_to_exclude_from_sync
+        self.hide_service_members_from_heroes = hs.config.experimental.msc4171_enabled
 
     @overload
     async def wait_for_sync_for_user(
@@ -1032,11 +1033,15 @@ class SyncHandler:
             return None
 
         last_event = last_events[-1]
+
+        state_filter_types = [(EventTypes.Name, ""), (EventTypes.CanonicalAlias, "")]
+
+        if self.hide_service_members_from_heroes:
+            state_filter_types.append((EventTypes.MSC4171FunctionalMembers, ""))
+
         state_ids = await self._state_storage_controller.get_state_ids_for_event(
             last_event.event_id,
-            state_filter=StateFilter.from_types(
-                [(EventTypes.Name, ""), (EventTypes.CanonicalAlias, "")]
-            ),
+            state_filter=StateFilter.from_types(state_filter_types),
         )
 
         # this is heavily cached, thus: fast.
@@ -1044,6 +1049,7 @@ class SyncHandler:
 
         name_id = state_ids.get((EventTypes.Name, ""))
         canonical_alias_id = state_ids.get((EventTypes.CanonicalAlias, ""))
+
 
         summary: JsonDict = {}
         empty_ms = MemberSummary([], 0)
@@ -1069,6 +1075,18 @@ class SyncHandler:
             if canonical_alias and canonical_alias.content.get("alias"):
                 return summary
 
+
+        ignore_members_for_heroes = []
+
+        if self.hide_service_members_from_heroes:
+            functional_members_id = state_ids.get((EventTypes.MSC4171FunctionalMembers, ""))
+            if functional_members_id:
+                functional_members = await self.store.get_event(
+                    functional_members_id, allow_none=True
+                )
+                if functional_members and isinstance(functional_members.content.get("service_members"), list):
+                    ignore_members_for_heroes = functional_members.content.get("service_members")
+
         # FIXME: only build up a member_ids list for our heroes
         member_ids = {}
         for membership in (
@@ -1081,7 +1099,8 @@ class SyncHandler:
                 member_ids[user_id] = event_id
 
         me = sync_config.user.to_string()
-        summary["m.heroes"] = extract_heroes_from_room_summary(details, me)
+        # HERE:
+        summary["m.heroes"] = extract_heroes_from_room_summary(details, me, ignore_members_for_heroes)
 
         if not sync_config.filter_collection.lazy_load_members():
             return summary

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -151,16 +151,20 @@ class SyncRestServlet(RestServlet):
         )
         filter_id = parse_string(request, "filter")
         full_state = parse_boolean(request, "full_state", default=False)
+        exclude_service_members_from_heroes = parse_boolean(
+            request, "msc4171_exclude_service_members", default=False
+        )
 
         logger.debug(
             "/sync: user=%r, timeout=%r, since=%r, "
-            "set_presence=%r, filter_id=%r, device_id=%r",
+            "set_presence=%r, filter_id=%r, device_id=%r, exclude_service_members=%r",
             user,
             timeout,
             since,
             set_presence,
             filter_id,
             device_id,
+            exclude_service_members_from_heroes,
         )
 
         # Stream position of the last ignored users account data event for this user,
@@ -220,6 +224,7 @@ class SyncRestServlet(RestServlet):
             filter_collection=filter_collection,
             is_guest=requester.is_guest,
             device_id=device_id,
+            exclude_service_members_from_heroes=exclude_service_members_from_heroes,
         )
 
         since_token = None
@@ -682,12 +687,16 @@ class SlidingSyncE2eeRestServlet(RestServlet):
 
         timeout = parse_integer(request, "timeout", default=0)
         since = parse_string(request, "since")
+        exclude_service_members_from_heroes = parse_boolean(
+            request, "msc4171_exclude_service_members", default=False
+        )
 
         sync_config = SyncConfig(
             user=user,
             filter_collection=self.only_member_events_filter_collection,
             is_guest=requester.is_guest,
             device_id=device_id,
+            exclude_service_members_from_heroes=exclude_service_members_from_heroes,
         )
 
         since_token = None
@@ -886,6 +895,10 @@ class SlidingSyncRestServlet(RestServlet):
         # Position in the stream
         from_token_string = parse_string(request, "pos")
 
+        exclude_service_members_from_heroes = parse_boolean(
+            request, "msc4171_exclude_service_members", default=False
+        )
+
         from_token = None
         if from_token_string is not None:
             from_token = await SlidingSyncStreamToken.from_string(
@@ -935,6 +948,7 @@ class SlidingSyncRestServlet(RestServlet):
             lists=body.lists,
             room_subscriptions=body.room_subscriptions,
             extensions=body.extensions,
+            exclude_service_members_from_heroes=exclude_service_members_from_heroes,
         )
 
         sliding_sync_results = await self.sliding_sync_handler.wait_for_sync_for_user(

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -303,6 +303,7 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
 
         Args:
             room_id: The room ID to query
+            exclude_service_users: Should MSC4171 be used to exclude service members
         Returns:
             dict of membership states, pointing to a MemberSummary named tuple.
         """

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -377,10 +377,13 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
         exclude_members = []
         if functional_members_event_id:
             functional_members_event = await self.get_event(functional_members_event_id)
-            # TODO: Validate data
-            exclude_members = functional_members_event.content.get(
-                "service_members", []
+            functional_members_data = functional_members_event.content.get(
+                "service_members"
             )
+            # ONLY use this value if this looks like a valid list of strings. Otherwise, ignore.
+            if isinstance(functional_members_data, list) and all(isinstance(item, str) for item in functional_members_data):
+                exclude_members = functional_members_data
+
 
         return await self.db_pool.runInteraction(
             "get_room_summary", _get_room_summary_txn, exclude_members

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -337,12 +337,12 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
                 FROM current_state_events
                 WHERE type = 'm.room.member' AND room_id = ?
                     AND membership IS NOT NULL
-                    AND %s
+                    AND {}
                 ORDER BY
                     CASE membership WHEN ? THEN 1 WHEN ? THEN 2 WHEN ? THEN 3 ELSE 4 END ASC,
                     event_stream_ordering ASC
                 LIMIT ?
-            """ % (exclude_users_clause)
+            """.format(exclude_users_clause)
 
             txn.execute(
                 sql,

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -1754,7 +1754,9 @@ class RoomMemberStore(
 
 
 def extract_heroes_from_room_summary(
-    details: Mapping[str, MemberSummary], me: str, skip_user_ids: List[str] = [],
+    details: Mapping[str, MemberSummary],
+    me: str,
+    skip_user_ids: List[str] = None,
 ) -> List[str]:
     """Determine the users that represent a room, from the perspective of the `me` user.
 
@@ -1775,16 +1777,27 @@ def extract_heroes_from_room_summary(
     Returns a list (possibly empty) of heroes' mxids.
     """
     empty_ms = MemberSummary([], 0)
+    skip_user_ids = skip_user_ids or []
 
     joined_user_ids = [
-        r[0] for r in details.get(Membership.JOIN, empty_ms).members if r[0] != me and r[0] not in skip_user_ids
+        r[0]
+        for r in details.get(Membership.JOIN, empty_ms).members
+        if r[0] != me and r[0] not in skip_user_ids
     ]
     invited_user_ids = [
-        r[0] for r in details.get(Membership.INVITE, empty_ms).members if r[0] != me and r[0] not in skip_user_ids
+        r[0]
+        for r in details.get(Membership.INVITE, empty_ms).members
+        if r[0] != me and r[0] not in skip_user_ids
     ]
     gone_user_ids = [
-        r[0] for r in details.get(Membership.LEAVE, empty_ms).members if r[0] != me and r[0] not in skip_user_ids
-    ] + [r[0] for r in details.get(Membership.BAN, empty_ms).members if r[0] != me and r[0] not in skip_user_ids]
+        r[0]
+        for r in details.get(Membership.LEAVE, empty_ms).members
+        if r[0] != me and r[0] not in skip_user_ids
+    ] + [
+        r[0]
+        for r in details.get(Membership.BAN, empty_ms).members
+        if r[0] != me and r[0] not in skip_user_ids
+    ]
 
     # We expect `MemberSummary.members` to already be sorted by `stream_ordering`
     if joined_user_ids or invited_user_ids:

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -1754,7 +1754,7 @@ class RoomMemberStore(
 
 
 def extract_heroes_from_room_summary(
-    details: Mapping[str, MemberSummary], me: str
+    details: Mapping[str, MemberSummary], me: str, skip_user_ids: List[str] = [],
 ) -> List[str]:
     """Determine the users that represent a room, from the perspective of the `me` user.
 
@@ -1770,20 +1770,21 @@ def extract_heroes_from_room_summary(
         details: Mapping from membership type to member summary. We expect
             `MemberSummary.members` to already be sorted by `stream_ordering`.
         me: The user for whom we are determining the heroes for.
+        skip_user_ids: Users to always ignore when building up a list of heros.
 
     Returns a list (possibly empty) of heroes' mxids.
     """
     empty_ms = MemberSummary([], 0)
 
     joined_user_ids = [
-        r[0] for r in details.get(Membership.JOIN, empty_ms).members if r[0] != me
+        r[0] for r in details.get(Membership.JOIN, empty_ms).members if r[0] != me and r[0] not in skip_user_ids
     ]
     invited_user_ids = [
-        r[0] for r in details.get(Membership.INVITE, empty_ms).members if r[0] != me
+        r[0] for r in details.get(Membership.INVITE, empty_ms).members if r[0] != me and r[0] not in skip_user_ids
     ]
     gone_user_ids = [
-        r[0] for r in details.get(Membership.LEAVE, empty_ms).members if r[0] != me
-    ] + [r[0] for r in details.get(Membership.BAN, empty_ms).members if r[0] != me]
+        r[0] for r in details.get(Membership.LEAVE, empty_ms).members if r[0] != me and r[0] not in skip_user_ids
+    ] + [r[0] for r in details.get(Membership.BAN, empty_ms).members if r[0] != me and r[0] not in skip_user_ids]
 
     # We expect `MemberSummary.members` to already be sorted by `stream_ordering`
     if joined_user_ids or invited_user_ids:

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -381,9 +381,10 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
                 "service_members"
             )
             # ONLY use this value if this looks like a valid list of strings. Otherwise, ignore.
-            if isinstance(functional_members_data, list) and all(isinstance(item, str) for item in functional_members_data):
+            if isinstance(functional_members_data, list) and all(
+                isinstance(item, str) for item in functional_members_data
+            ):
                 exclude_members = functional_members_data
-
 
         return await self.db_pool.runInteraction(
             "get_room_summary", _get_room_summary_txn, exclude_members

--- a/synapse/types/handlers/sliding_sync.py
+++ b/synapse/types/handlers/sliding_sync.py
@@ -68,6 +68,7 @@ class SlidingSyncConfig(SlidingSyncBody):
 
     user: UserID
     requester: Requester
+    exclude_service_members_from_heroes: bool
 
     # Pydantic config
     class Config:

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -1079,4 +1079,5 @@ def generate_sync_config(
         filter_collection=filter_collection,
         is_guest=False,
         device_id=device_id,
+        exclude_service_members_from_heroes=False,
     )

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -638,7 +638,8 @@ class RoomSummaryTestCase(unittest.HomeserverTestCase):
 
     def test_extract_heroes_from_room_summary_exclude_service_members(self) -> None:
         """
-        Test that `extract_heroes_from_room_summary(...)` returns the first 5 joins.
+        Test that `extract_heroes_from_room_summary(...)` returns the first 5 joins who are
+        not mentioned in the functional members state event.
         """
         user1_id = self.register_user("user1", "pass")
         user1_tok = self.login(user1_id, "pass")

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -688,7 +688,9 @@ class RoomSummaryTestCase(unittest.HomeserverTestCase):
             hero_user_ids, [user1_id, user4_id, user5_id, user6_id, user7_id]
         )
 
-    def test_extract_heroes_from_room_summary_exclude_service_members_with_empty_heroes(self) -> None:
+    def test_extract_heroes_from_room_summary_exclude_service_members_with_empty_heroes(
+        self,
+    ) -> None:
         """
         Test that `extract_heroes_from_room_summary(...)` will return an
         empty set of heroes if all users have been excluded.
@@ -723,9 +725,7 @@ class RoomSummaryTestCase(unittest.HomeserverTestCase):
         )
 
         # First 5 users to join the room, excluding service members.
-        self.assertListEqual(
-            hero_user_ids, []
-        )
+        self.assertListEqual(hero_user_ids, [])
 
     def test_extract_heroes_from_room_summary_membership_order(self) -> None:
         """

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -680,7 +680,7 @@ class RoomSummaryTestCase(unittest.HomeserverTestCase):
             room_membership_summary, me="@fakuser"
         )
 
-        # First 5 users to join the room
+        # First 5 users to join the room, excluding service members.
         self.assertListEqual(
             hero_user_ids, [user1_id, user4_id, user5_id, user6_id, user7_id]
         )

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -668,8 +668,6 @@ class RoomSummaryTestCase(unittest.HomeserverTestCase):
 
         room_membership_summary = self.get_success(self.store.get_room_summary(room_id))
 
-        print(room_membership_summary)
-
         hero_user_ids = extract_heroes_from_room_summary(
             room_membership_summary, me="@fakuser", skip_user_ids=[user2_id, user3_id]
         )

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -678,7 +678,7 @@ class RoomSummaryTestCase(unittest.HomeserverTestCase):
         room_membership_summary = self.get_success(self.store.get_room_summary(room_id))
 
         hero_user_ids = extract_heroes_from_room_summary(
-            room_membership_summary, me="@fakuser"
+            room_membership_summary, me="@fakeuser"
         )
 
         # First 5 users to join the room, excluding service members.

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -658,6 +658,14 @@ class RoomSummaryTestCase(unittest.HomeserverTestCase):
         # Setup the room (user1 is the creator and is joined to the room)
         room_id = self.helper.create_room_as(user1_id, tok=user1_tok)
 
+        # Exclude some users
+        self.helper.send_state(
+            room_id,
+            event_type=EventTypes.MSC4171FunctionalMembers,
+            body={"service_members": [user2_id, user3_id]},
+            tok=user1_tok,
+        )
+
         # User2 -> User7 joins
         self.helper.join(room_id, user2_id, tok=user2_tok)
         self.helper.join(room_id, user3_id, tok=user3_tok)
@@ -669,7 +677,7 @@ class RoomSummaryTestCase(unittest.HomeserverTestCase):
         room_membership_summary = self.get_success(self.store.get_room_summary(room_id))
 
         hero_user_ids = extract_heroes_from_room_summary(
-            room_membership_summary, me="@fakuser", skip_user_ids=[user2_id, user3_id]
+            room_membership_summary, me="@fakuser"
         )
 
         # First 5 users to join the room

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -675,7 +675,9 @@ class RoomSummaryTestCase(unittest.HomeserverTestCase):
         self.helper.join(room_id, user6_id, tok=user6_tok)
         self.helper.join(room_id, user7_id, tok=user7_tok)
 
-        room_membership_summary = self.get_success(self.store.get_room_summary(room_id))
+        room_membership_summary = self.get_success(
+            self.store.get_room_summary(room_id, True)
+        )
 
         hero_user_ids = extract_heroes_from_room_summary(
             room_membership_summary, me="@fakeuser"


### PR DESCRIPTION
For #17859 

This applies the rules for MSC4171 to the `m.heroes` response in sync. For clarity, this PR is needed to fix behaviors in some modern clients such as EX which use heroes to determine room names rather than local calculation.

MSC discussion for excluding service members from `m.heroes`: https://github.com/matrix-org/matrix-spec-proposals/pull/4171#discussion_r1688649042

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
