### PR TITLE
Bump Synapse Dockerfile default to Python 3.12

### DIFF
--- a/changelog.d/17887.misc
+++ b/changelog.d/17887.misc
@@ -1,0 +1,1 @@
+Bump the default Python version in the Synapse Dockerfile from 3.11 -> 3.12.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@
 # `poetry export | pip install -r /dev/stdin`, but beware: we have experienced bugs in
 # in `poetry export` in the past.
 
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.12
 
 ###
 ### Stage 0: generate requirements.txt


### PR DESCRIPTION
As 3.13 has now been released, recent 3.12 releases should be stable enough.