### PR TITLE
Use more correct changelog entries for refactoring `Generator` usage

### DIFF
--- a/changelog.d/17813.bugfix
+++ b/changelog.d/17813.bugfix
@@ -1,1 +1,0 @@
-Avoid lost data on some database query retries.

--- a/changelog.d/17813.misc
+++ b/changelog.d/17813.misc
@@ -1,0 +1,1 @@
+Refactor database calls to remove `Generator` usage.

--- a/changelog.d/17814.bugfix
+++ b/changelog.d/17814.bugfix
@@ -1,1 +1,0 @@
-Avoid lost data on some database query retries.

--- a/changelog.d/17814.misc
+++ b/changelog.d/17814.misc
@@ -1,0 +1,1 @@
+Refactor database calls to remove `Generator` usage.

--- a/changelog.d/17815.bugfix
+++ b/changelog.d/17815.bugfix
@@ -1,1 +1,0 @@
-Avoid lost data on some database query retries.

--- a/changelog.d/17815.misc
+++ b/changelog.d/17815.misc
@@ -1,0 +1,1 @@
+Refactor database calls to remove `Generator` usage.

--- a/changelog.d/17816.bugfix
+++ b/changelog.d/17816.bugfix
@@ -1,1 +1,0 @@
-Avoid lost data on some database query retries.

--- a/changelog.d/17816.misc
+++ b/changelog.d/17816.misc
@@ -1,0 +1,1 @@
+Refactor database calls to remove `Generator` usage.

--- a/changelog.d/17817.bugfix
+++ b/changelog.d/17817.bugfix
@@ -1,1 +1,0 @@
-Avoid lost data on some database query retries.

--- a/changelog.d/17817.misc
+++ b/changelog.d/17817.misc
@@ -1,0 +1,1 @@
+Refactor database calls to remove `Generator` usage.

--- a/changelog.d/17818.bugfix
+++ b/changelog.d/17818.bugfix
@@ -1,1 +1,0 @@
-Avoid lost data on some database query retries.

--- a/changelog.d/17818.misc
+++ b/changelog.d/17818.misc
@@ -1,0 +1,1 @@
+Refactor database calls to remove `Generator` usage.

--- a/changelog.d/17890.misc
+++ b/changelog.d/17890.misc
@@ -1,0 +1,1 @@
+Refactor database calls to remove `Generator` usage.


### PR DESCRIPTION
Use more correct changelog entries for refactoring `Generator` usage

 - https://github.com/element-hq/synapse/pull/17813
 - https://github.com/element-hq/synapse/pull/17814
 - https://github.com/element-hq/synapse/pull/17815
 - https://github.com/element-hq/synapse/pull/17816
 - https://github.com/element-hq/synapse/pull/17817

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
