### PR TITLE
Allow Admin API delete room v2 actions to be run on worker

### DIFF
--- a/docker/complement/conf/start_for_complement.sh
+++ b/docker/complement/conf/start_for_complement.sh
@@ -65,7 +65,8 @@ if [[ -n "$SYNAPSE_COMPLEMENT_USE_WORKERS" ]]; then
       client_reader, \
       appservice, \
       pusher, \
-      stream_writers=account_data+presence+receipts+to_device+typing"
+      stream_writers=account_data+presence+receipts+to_device+typing, \
+      admin"
 
   fi
   log "Workers requested: $SYNAPSE_WORKER_TYPES"

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -135,6 +135,14 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
         },
         "worker_extra_conf": "enable_media_repo: true",
     },
+    "admin": {
+      "app": "synapse.app.generic_worker",
+      "listener_resources": ["replication", "admin"],
+      "endpoint_patterns": ["^/_synapse/admin/v2/rooms/.*$"],
+      "shared_extra_conf": {},
+      "worker_extra_conf": "",
+
+    },
     "appservice": {
         "app": "synapse.app.generic_worker",
         "listener_resources": [],
@@ -574,6 +582,7 @@ def is_sharding_allowed_for_worker_type(worker_type: str) -> bool:
         "receipts",
         "typing",
         "to_device",
+        "admin"
     ]
 
 
@@ -1076,6 +1085,7 @@ def main(args: List[str], environ: MutableMapping[str, str]) -> None:
             # Split type names by comma, ignoring whitespace.
             worker_types = split_and_strip_string(worker_types_env, ",")
             requested_worker_types = parse_worker_types(worker_types)
+            log(f"requested_worker_types {requested_worker_types}")
 
         # Always regenerate all other config files
         log("Generating worker config files")

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -534,6 +534,8 @@ Valid resource names are:
   for [workers](../../workers.md) and containers without listener e.g.
   [application services](../../workers.md#notifying-application-services).
 
+* `admin`: the admin API (/_synapse/admin)
+
 Example configuration #1:
 ```yaml
 listeners:

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -329,6 +329,16 @@ with `client` and `federation` `resources` must be configured in the
 [`worker_listeners`](usage/configuration/config_documentation.md#worker_listeners)
 option in the worker config.
 
+The following admin APIs are now available to be handled by workers, with more forthcoming:
+
+    # Admin APIs
+    "^/_synapse/admin/v2/rooms/.*$"
+
+Note that a [HTTP listener](usage/configuration/config_documentation.md#listeners)
+with `admin` and `replication `resources` must be configured in the
+[`worker_listeners`](usage/configuration/config_documentation.md#worker_listeners)
+option in the worker config.
+
 #### Load balancing
 
 It is possible to run multiple instances of this worker app, with incoming requests

--- a/synapse/api/urls.py
+++ b/synapse/api/urls.py
@@ -39,6 +39,7 @@ SERVER_KEY_PREFIX = "/_matrix/key"
 MEDIA_R0_PREFIX = "/_matrix/media/r0"
 MEDIA_V3_PREFIX = "/_matrix/media/v3"
 LEGACY_MEDIA_PREFIX = "/_matrix/media/v1"
+ADMIN_PREFIX = "/_synapse/admin"
 
 
 class ConsentURIBuilder:

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -33,7 +33,7 @@ from synapse.api.urls import (
     LEGACY_MEDIA_PREFIX,
     MEDIA_R0_PREFIX,
     MEDIA_V3_PREFIX,
-    SERVER_KEY_PREFIX,
+    SERVER_KEY_PREFIX, ADMIN_PREFIX,
 )
 from synapse.app import _base
 from synapse.app._base import (
@@ -52,7 +52,7 @@ from synapse.logging.context import LoggingContext
 from synapse.metrics import METRICS_PREFIX, MetricsResource, RegistryProxy
 from synapse.replication.http import REPLICATION_PREFIX, ReplicationRestResource
 from synapse.rest import ClientRestResource
-from synapse.rest.admin import register_servlets_for_media_repo
+from synapse.rest.admin import register_servlets_for_media_repo, AdminRestResource
 from synapse.rest.health import HealthResource
 from synapse.rest.key.v2 import KeyResource
 from synapse.rest.synapse.client import build_synapse_client_resource_tree
@@ -207,7 +207,7 @@ class GenericWorkerServer(HomeServer):
                                 MEDIA_R0_PREFIX: media_repo,
                                 MEDIA_V3_PREFIX: media_repo,
                                 LEGACY_MEDIA_PREFIX: media_repo,
-                                "/_synapse/admin": admin_resource,
+                                ADMIN_PREFIX: admin_resource,
                             }
                         )
 
@@ -247,6 +247,9 @@ class GenericWorkerServer(HomeServer):
 
                 if name == "replication":
                     resources[REPLICATION_PREFIX] = ReplicationRestResource(self)
+
+                if name == "admin":
+                    resources[ADMIN_PREFIX] = AdminRestResource(self)
 
         # Attach additional resources registered by modules.
         resources.update(self._module_web_resources)

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -191,6 +191,7 @@ KNOWN_RESOURCES = {
     "openid",
     "replication",
     "static",
+    "admin"
 }
 
 

--- a/synapse/rest/admin/__init__.py
+++ b/synapse/rest/admin/__init__.py
@@ -273,8 +273,11 @@ def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:
     """
     Register all the admin servlets.
     """
-    # Admin servlets aren't registered on workers.
+    # Only handle certain endpoints on workers.
     if hs.config.worker.worker_app is not None:
+        RoomRestV2Servlet(hs).register(http_server)
+        DeleteRoomStatusByDeleteIdRestServlet(hs).register(http_server)
+        DeleteRoomStatusByRoomIdRestServlet(hs).register(http_server)
         return
 
     register_servlets_for_client_rest_resource(hs, http_server)


### PR DESCRIPTION
As the title states - support shifting the admin api delete room v2 actions to a generic worker. Also adds support for testing this in complement. 

I'm new to working with workers, so there may be things that I have missed/done ineptly. Eagle eyes appreciated. In particular, one question I had was whether a worker handling these admin requests needs a replication listener - since the code requires invalidating the cache and streaming, I guessed that the answer is yes, but would like to know if that is correct.

Should be reviewable commit-by-commit.