### PR TITLE
Switch portdb CI to python 3.13, pg 17

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -583,8 +583,8 @@ jobs:
           - python-version: "3.8"
             postgres-version: "11"
 
-          - python-version: "3.11"
-            postgres-version: "15"
+          - python-version: "3.13"
+            postgres-version: "17"
 
     services:
       postgres:

--- a/changelog.d/17909.misc
+++ b/changelog.d/17909.misc
@@ -1,0 +1,1 @@
+Update the portdb CI to use Python 3.13 and Postgres 17 as latest dependencies.


### PR DESCRIPTION
...as those are the latest versions of Python and Postgres that Synapse supports. Technically missed in https://github.com/element-hq/synapse/pull/17752

Noticed in https://github.com/element-hq/synapse/pull/17908#discussion_r1831457002