### PR TITLE
Limit event fetches to prevent stack size from growing too large

### DIFF
--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -452,7 +452,9 @@ class DatabaseOutageTestCase(unittest.HomeserverTestCase):
         with self._outage():
             # Kick off a bunch of event fetches but do not pump the reactor
             event_deferreds = []
-            for event_id in self.event_ids:
+            # Limit the number of event_ids otherwise the total stack size grows too
+            # large for our custom twisted patch.
+            for event_id in self.event_ids[0:17]:
                 event_deferreds.append(ensureDeferred(self.store.get_event(event_id)))
 
             # We should have maxed out on event fetcher threads


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [X] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
