### PR TITLE
Unpin the upload release GHA action

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -212,7 +212,7 @@ jobs:
           mv debs*/* debs/
           tar -cvJf debs.tar.xz debs
       - name: Attach to release
-        uses: softprops/action-gh-release@a929a66f232c1b11af63782948aa2210f981808a  # PR#109
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -220,7 +220,3 @@ jobs:
             Sdist/*
             Wheel*/*
             debs.tar.xz
-          # if it's not already published, keep the release as a draft.
-          draft: true
-          # mark it as a prerelease if the tag contains 'rc'.
-          prerelease: ${{ contains(github.ref, 'rc') }}

--- a/changelog.d/17923.misc
+++ b/changelog.d/17923.misc
@@ -1,0 +1,1 @@
+Unpin the upload release GHA action.


### PR DESCRIPTION
We were pinned to an old version that had deprecation warnings.

In new versions of the action leaving off properties (i.e. `draft` and `prerelease`) tells the action to not modify those properties of the release.