### PR TITLE
Fix bug when rejecting withdrew invite with a third_party_rules module

### DIFF
--- a/changelog.d/17930.bugfix
+++ b/changelog.d/17930.bugfix
@@ -1,0 +1,1 @@
+Fix bug when rejecting withdrew invite with a third_party_rules module, where the invite would be stuck for the client.

--- a/synapse/events/snapshot.py
+++ b/synapse/events/snapshot.py
@@ -248,7 +248,7 @@ class EventContext(UnpersistedEventContextBase):
     @tag_args
     async def get_current_state_ids(
         self, state_filter: Optional["StateFilter"] = None
-    ) -> Optional[StateMap[str]]:
+    ) -> StateMap[str]:
         """
         Gets the room state map, including this event - ie, the state in ``state_group``
 
@@ -256,21 +256,19 @@ class EventContext(UnpersistedEventContextBase):
         not make it into the room state. This method will raise an exception if
         ``rejected`` is set.
 
+        It is also an error to access this for an outlier event.
+
         Arg:
            state_filter: specifies the type of state event to fetch from DB, example: EventTypes.JoinRules
 
         Returns:
-            Returns None if state_group is None, which happens when the associated
-            event is an outlier.
-
             Maps a (type, state_key) to the event ID of the state event matching
             this tuple.
         """
         if self.rejected:
             raise RuntimeError("Attempt to access state_ids of rejected event")
 
-        if self._state_delta_due_to_event is None:
-            return None
+        assert self._state_delta_due_to_event is not None
 
         prev_state_ids = await self.get_prev_state_ids(state_filter)
 

--- a/synapse/events/snapshot.py
+++ b/synapse/events/snapshot.py
@@ -269,7 +269,8 @@ class EventContext(UnpersistedEventContextBase):
         if self.rejected:
             raise RuntimeError("Attempt to access state_ids of rejected event")
 
-        assert self._state_delta_due_to_event is not None
+        if self._state_delta_due_to_event is None:
+            return None
 
         prev_state_ids = await self.get_prev_state_ids(state_filter)
 
@@ -300,7 +301,8 @@ class EventContext(UnpersistedEventContextBase):
             this tuple.
         """
 
-        assert self.state_group_before_event is not None
+        if self.state_group_before_event is None:
+            return {}
         return await self._storage.state.get_state_ids_for_group(
             self.state_group_before_event, state_filter
         )


### PR DESCRIPTION
When rejecting a withdrew invite through federation, an out of band event needs to be created.

When doing so with a third_party_rules module installed, `get_prev_state_ids` [is called](https://github.com/element-hq/synapse/blob/e0fdb862cbbddc920a30233024eb99038ee2fb28/synapse/module_api/callbacks/third_party_event_rules_callbacks.py#L285) on the context to calculate the state to pass at `check_event_allowed` callbacks.

The context for outliers is defined [here](https://github.com/element-hq/synapse/blob/e0fdb862cbbddc920a30233024eb99038ee2fb28/synapse/events/snapshot.py#L168), and `state_group_before_event` is None.

This change makes the behavior of `get_prev_state_ids` and `get_current_state_ids` match the one presented in the docstring regarding null state_group.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
