### PR TITLE
Support both import names of PyPI package `python-multipart`.

### DIFF
--- a/changelog.d/17932.misc
+++ b/changelog.d/17932.misc
@@ -1,0 +1,1 @@
+Support new package name of PyPI package `python-multipart` 0.0.13 so that distro packagers do not need to work around name conflict with PyPI package `multipart`.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -36,7 +36,7 @@ from typing import (
 )
 
 import attr
-import multipart
+import python_multipart
 import treq
 from canonicaljson import encode_canonical_json
 from netaddr import AddrFormatError, IPAddress, IPSet

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -105,9 +105,6 @@ try:
 except ImportError:
     from multipart import MultipartParser
 
-    if TYPE_CHECKING:
-        from multipart import multipart
-
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -103,7 +103,7 @@ try:
     if TYPE_CHECKING:
         from python_multipart import multipart
 except ImportError:
-    from multipart import MultipartParser
+    from multipart import MultipartParser  # type: ignore[no-redef]
 
 
 logger = logging.getLogger(__name__)

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -36,7 +36,6 @@ from typing import (
 )
 
 import attr
-import python_multipart
 import treq
 from canonicaljson import encode_canonical_json
 from netaddr import AddrFormatError, IPAddress, IPSet
@@ -92,6 +91,23 @@ from synapse.util.async_helpers import timeout_deferred
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
+
+# Support both import names for the `python-multipart` (PyPI) library,
+# which renamed its package name from `multipart` to `python_multipart`
+# in 0.0.13 (though supports the old import name for compatibility).
+# Note that the `multipart` package name conflicts with `multipart` (PyPI)
+# so we should prefer importing from `python_multipart` when possible.
+try:
+    from python_multipart import MultipartParser
+
+    if TYPE_CHECKING:
+        from python_multipart import multipart
+except ImportError:
+    from multipart import MultipartParser
+
+    if TYPE_CHECKING:
+        from multipart import multipart
+
 
 logger = logging.getLogger(__name__)
 
@@ -1039,7 +1055,7 @@ class _MultipartParserProtocol(protocol.Protocol):
         self.deferred = deferred
         self.boundary = boundary
         self.max_length = max_length
-        self.parser: Optional[multipart.MultipartParser] = None
+        self.parser: Optional[MultipartParser] = None
         self.multipart_response = MultipartResponse()
         self.has_redirect = False
         self.in_json = False
@@ -1097,12 +1113,12 @@ class _MultipartParserProtocol(protocol.Protocol):
                         self.deferred.errback()
                     self.file_length += end - start
 
-            callbacks: "multipart.multipart.MultipartCallbacks" = {
+            callbacks: "multipart.MultipartCallbacks" = {
                 "on_header_field": on_header_field,
                 "on_header_value": on_header_value,
                 "on_part_data": on_part_data,
             }
-            self.parser = multipart.MultipartParser(self.boundary, callbacks)
+            self.parser = MultipartParser(self.boundary, callbacks)
 
         self.total_length += len(incoming_data)
         if self.max_length is not None and self.total_length >= self.max_length:


### PR DESCRIPTION
This allows synapse to run with python multipart >=0.0.13 without any tricky fallback. There is a conflict between 2 packages called multipart, so this should be modified.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
