### PR TITLE
Create one-off scheduled task to delete old OTKs

### DIFF
--- a/changelog.d/17934.feature
+++ b/changelog.d/17934.feature
@@ -1,0 +1,1 @@
+Add a one-off task to delete old one-time-keys, to guard against us having old OTKs in the database that the client has long forgotten about.

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -1453,7 +1453,9 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
             impl,
         )
 
-    async def delete_old_otks_for_one_user(self, after_user_id: str) -> Tuple[Optional[str], int]:
+    async def delete_old_otks_for_one_user(
+        self, after_user_id: str
+    ) -> Tuple[Optional[str], int]:
         """Deletes old OTKs belonging to one user.
 
         Returns:
@@ -1461,6 +1463,7 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
              * `user` is the user ID of the updated user, or None if we are don
              * `rows` is the number of deleted rows
         """
+
         def impl(txn: LoggingTransaction) -> Tuple[Optional[str], int]:
             # Find the next user
             txn.execute(

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -1485,7 +1485,9 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
             # keys were likely made by libolm rather than Vodozemac; libolm only kept
             # 100 private OTKs, so was far more vulnerable than Vodozemac to throwing
             # away keys prematurely.
-            clause, args = make_in_list_sql_clause(txn.database_engine, 'user_id', users)
+            clause, args = make_in_list_sql_clause(
+                txn.database_engine, "user_id", users
+            )
             sql = f"""
                 DELETE FROM e2e_one_time_keys_json
                 WHERE {clause} AND ts_added_ms < ? AND length(key_id) = 6
@@ -1495,7 +1497,9 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
 
             return users, txn.rowcount
 
-        return await self.db_pool.runInteraction("delete_old_otks_for_next_user_batch", impl)
+        return await self.db_pool.runInteraction(
+            "delete_old_otks_for_next_user_batch", impl
+        )
 
 
 class EndToEndKeyStore(EndToEndKeyWorkerStore, SQLBaseStore):

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -1453,48 +1453,49 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
             impl,
         )
 
-    async def delete_old_otks_for_one_user(
-        self, after_user_id: str
-    ) -> Tuple[Optional[str], int]:
-        """Deletes old OTKs belonging to one user.
+    async def delete_old_otks_for_next_user_batch(
+        self, after_user_id: str, number_of_users: int
+    ) -> Tuple[List[str], int]:
+        """Deletes old OTKs belonging to the next batch of users
 
         Returns:
-            `(user, rows)`, where:
-             * `user` is the user ID of the updated user, or None if we are don
+            `(users, rows)`, where:
+             * `users` is the user IDs of the updated users. An empty list if we are done.
              * `rows` is the number of deleted rows
         """
 
-        def impl(txn: LoggingTransaction) -> Tuple[Optional[str], int]:
-            # Find the next user
+        def impl(txn: LoggingTransaction) -> Tuple[List[str], int]:
+            # Find a batch of users
             txn.execute(
                 """
-                SELECT user_id FROM e2e_one_time_keys_json WHERE user_id > ? LIMIT 1
+                SELECT DISTINCT(user_id) FROM e2e_one_time_keys_json
+                    WHERE user_id > ?
+                    ORDER BY user_id
+                    LIMIT ?
                 """,
-                (after_user_id,),
+                (after_user_id, number_of_users),
             )
-            row = txn.fetchone()
-            if not row:
-                # We're done!
-                return None, 0
-            (user_id,) = row
+            users = [row[0] for row in txn.fetchall()]
+            if len(users) == 0:
+                return users, 0
 
-            # Delete any old OTKs belonging to that user.
+            # Delete any old OTKs belonging to those users.
             #
             # We only actually consider OTKs whose key ID is 6 characters long. These
             # keys were likely made by libolm rather than Vodozemac; libolm only kept
             # 100 private OTKs, so was far more vulnerable than Vodozemac to throwing
             # away keys prematurely.
-            txn.execute(
-                """
+            clause, args = make_in_list_sql_clause(txn.database_engine, 'user_id', users)
+            sql = f"""
                 DELETE FROM e2e_one_time_keys_json
-                WHERE user_id = ? AND ts_added_ms < ? AND length(key_id) = 6
-                """,
-                (user_id, self._clock.time_msec() - (7 * 24 * 3600 * 1000)),
-            )
+                WHERE {clause} AND ts_added_ms < ? AND length(key_id) = 6
+                """
+            args.append(self._clock.time_msec() - (7 * 24 * 3600 * 1000))
+            txn.execute(sql, args)
 
-            return user_id, txn.rowcount
+            return users, txn.rowcount
 
-        return await self.db_pool.runInteraction("delete_old_otks_for_one_user", impl)
+        return await self.db_pool.runInteraction("delete_old_otks_for_next_user_batch", impl)
 
 
 class EndToEndKeyStore(EndToEndKeyWorkerStore, SQLBaseStore):

--- a/synapse/storage/schema/main/delta/88/05_drop_old_otks.sql.postgres
+++ b/synapse/storage/schema/main/delta/88/05_drop_old_otks.sql.postgres
@@ -1,0 +1,19 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2024 New Vector, Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+-- Until Synapse 1.119, Synapse used to issue one-time-keys in a random order, leading to the possibility
+-- that it could still have old OTKs that the client has dropped.
+--
+-- We create a scheduled task which will drop old OTKs, to flush them out.
+INSERT INTO scheduled_tasks(id, action, status, timestamp)
+    VALUES ('delete_old_otks_task', 'delete_old_otks', 'scheduled', extract(epoch from current_timestamp) * 1000);

--- a/synapse/storage/schema/main/delta/88/05_drop_old_otks.sql.sqlite
+++ b/synapse/storage/schema/main/delta/88/05_drop_old_otks.sql.sqlite
@@ -1,0 +1,19 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2024 New Vector, Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+-- Until Synapse 1.119, Synapse used to issue one-time-keys in a random order, leading to the possibility
+-- that it could still have old OTKs that the client has dropped.
+--
+-- We create a scheduled task which will drop old OTKs, to flush them out.
+INSERT INTO scheduled_tasks(id, action, status, timestamp)
+    VALUES ('delete_old_otks_task', 'delete_old_otks', 'scheduled', strftime('%s', 'now') * 1000);

--- a/tests/handlers/test_e2e_keys.py
+++ b/tests/handlers/test_e2e_keys.py
@@ -1828,7 +1828,7 @@ class E2eKeysHandlerTestCase(unittest.HomeserverTestCase):
         self.assertIs(exists, True)
         self.assertIs(replaceable_without_uia, False)
 
-    def test_delete_old_one_time_keys(self):
+    def test_delete_old_one_time_keys(self) -> None:
         """Test the db migration that clears out old OTKs"""
 
         # We upload two sets of keys, one just over a week ago, and one just less than


### PR DESCRIPTION
To work around the fact that, pre-https://github.com/element-hq/synapse/pull/17903, our database may have old one-time-keys that the clients have long thrown away the private keys for, we want to delete OTKs that look like they came from libolm.

To spread the load a bit, without holding up other background database updates, we use a scheduled task to do the work.