### PR TITLE
Pass through `unsigned` data in `/keys/query`

### DIFF
--- a/changelog.d/17951.feature
+++ b/changelog.d/17951.feature
@@ -1,0 +1,1 @@
+Add experimental option to pass through unsigned data in `/keys/query` responses.

--- a/docker/complement/conf/workers-shared-extra.yaml.j2
+++ b/docker/complement/conf/workers-shared-extra.yaml.j2
@@ -114,6 +114,8 @@ experimental_features:
   msc3983_appservice_otk_claims: true
   # Proxy key queries to exclusive ASes
   msc3984_appservice_key_query: true
+  # Pass through unsigned device data in /keys/query
+  msc4229_enabled: true
 
 server_notices:
   system_mxid_localpart: _server

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -225,6 +225,7 @@ test_packages=(
     ./tests/msc3902
     ./tests/msc3967
     ./tests/msc4140
+    ./tests/msc4229
 )
 
 # Enable dirty runs, so tests will reuse the same container where possible.

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -448,3 +448,6 @@ class ExperimentalConfig(Config):
 
         # MSC4222: Adding `state_after` to sync v2
         self.msc4222_enabled: bool = experimental.get("msc4222_enabled", False)
+
+        # MSC4229: Pass through `unsigned` data from `/keys/upload` to `/keys/query`
+        self.msc4229_enabled: bool = experimental.get("msc4229_enabled", False)

--- a/synapse/handlers/e2e_keys.py
+++ b/synapse/handlers/e2e_keys.py
@@ -542,7 +542,9 @@ class E2eKeysHandler:
             result_dict[user_id] = {}
 
         results = await self.store.get_e2e_device_keys_for_cs_api(
-            local_query, include_displaynames
+            local_query,
+            include_displaynames,
+            include_uploaded_unsigned_data=self.config.experimental.msc4229_enabled,
         )
 
         # Check if the application services have any additional results.

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -220,12 +220,15 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
         self,
         query_list: Collection[Tuple[str, Optional[str]]],
         include_displaynames: bool = True,
+        include_uploaded_unsigned_data: bool = False,
     ) -> Dict[str, Dict[str, JsonDict]]:
         """Fetch a list of device keys, formatted suitably for the C/S API.
         Args:
             query_list: List of pairs of user_ids and device_ids.
             include_displaynames: Whether to include the displayname of returned devices
                 (if one exists).
+            include_uploaded_unsigned_data: Whether to include uploaded `unsigned` data
+                in the response
         Returns:
             Dict mapping from user-id to dict mapping from device_id to
             key data.  The key data will be a dict in the same format as the
@@ -247,7 +250,13 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
                 if r is None:
                     continue
 
-                r["unsigned"] = {}
+                # If there was already an `unsigned` dict in the uploaded key, keep it.
+                # Otherwise, create a new one.
+                if not include_uploaded_unsigned_data or not isinstance(
+                    r.get("unsigned"), dict
+                ):
+                    r["unsigned"] = {}
+
                 if include_displaynames:
                     # Include the device's display name in the "unsigned" dictionary
                     display_name = device_info.display_name


### PR DESCRIPTION
We'd like a mechanism by which a client can add "unsigned" data to their device keys, and have it be accessible by other clients involved in E2EE discussions.

Most of this actually already works; the bit that doesn't is that *client-side* `/keys/query` strips out any "unsigned" data from the `/keys/upload` body. (Server-side `/keys/query` follows a different codepath and is fine).

This PR adds an experimental option which modifies client-side `/keys/query` so that `unsigned` data is preserved.

An MSC for this behaviour is pending, but will be https://github.com/matrix-org/matrix-spec-proposals/pull/4229.

Fixes: https://github.com/element-hq/synapse/issues/17943
Part of https://github.com/element-hq/element-meta/issues/2467