### PR TITLE
Return suspended status when querying user account 

### DIFF
--- a/changelog.d/17952.misc
+++ b/changelog.d/17952.misc
@@ -1,0 +1,1 @@
+Return whether the user is suspended when querying the user account in the Admin API.

--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -55,7 +55,8 @@ It returns a JSON body like the following:
         }
     ],
     "user_type": null,
-    "locked": false
+    "locked": false,
+    "suspended": false
 }
 ```
 

--- a/synapse/handlers/admin.py
+++ b/synapse/handlers/admin.py
@@ -124,6 +124,7 @@ class AdminHandler:
             "consent_ts": user_info.consent_ts,
             "user_type": user_info.user_type,
             "is_guest": user_info.is_guest,
+            "suspended": user_info.suspended,
         }
 
         if self._msc3866_enabled:

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -3221,6 +3221,7 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertIn("consent_ts", content)
         self.assertIn("external_ids", content)
         self.assertIn("last_seen_ts", content)
+        self.assertIn("suspended", content)
 
         # This key was removed intentionally. Ensure it is not accidentally re-included.
         self.assertNotIn("password_hash", content)


### PR DESCRIPTION
As the title states - return whether the user is suspended when querying the user account in the Admin API.