### PR TITLE
Fix `delete_old_otks` job on worker deployments

### DIFF
--- a/changelog.d/17960.bugfix
+++ b/changelog.d/17960.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse v1.120rc1 which would cause the newly-introduced `delete_old_otks` job to fail in worker-mode deployments.

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -254,6 +254,7 @@ class HomeServer(metaclass=abc.ABCMeta):
         "auth",
         "deactivate_account",
         "delayed_events",
+        "e2e_keys",  # for the `delete_old_otks` scheduled-task handler
         "message",
         "pagination",
         "profile",


### PR DESCRIPTION
In a worker-mode deployment, the `E2eKeysHandler` is not necessarily loaded, which means the handler for the `delete_old_otks` task will not be registered. Make sure we load the handler.

Introduced in https://github.com/element-hq/synapse/pull/17934