### PR TITLE
Add ETag header support to /state

### DIFF
--- a/changelog.d/17974.feature
+++ b/changelog.d/17974.feature
@@ -1,0 +1,1 @@
+Add ETag header to the /rooms/$room_id/state endpoint, and return no content on cache hit.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -175,7 +175,7 @@ class MessageHandler:
         state_filter: Optional[StateFilter] = None,
         at_token: Optional[StreamToken] = None,
         last_hash: Optional[str] = None,
-    ) -> Tuple[List[dict], str]:
+    ) -> Tuple[List[dict], Optional[str]]:
         """Retrieve all state events for a given room. If the user is
         joined to the room then return the current state. If the user has
         left the room return the state events from when they left. If an explicit
@@ -192,7 +192,8 @@ class MessageHandler:
                 state based on the current_state_events table.
         Returns:
             A list of dicts representing state events. [{}, {}, {}]
-            A hash of the state IDs representing the state events.
+            A hash of the state IDs representing the state events. This is only calculated if
+            no at_token is given and the user is joined to the room.
         Raises:
             NotFoundError (404) if the at token does not yield an event
 
@@ -250,7 +251,7 @@ class MessageHandler:
                 # If the requester's hash matches ours, their cache is up to date and we can skip
                 # fetching events.
                 if last_hash == hash:
-                    return None, hash
+                    return [], hash
                 room_state = await self.store.get_events(state_ids.values())
             elif membership == Membership.LEAVE:
                 # If the membership is not JOIN, then the event ID should exist.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -19,9 +19,9 @@
 # [This file includes modifications made by New Vector Limited]
 #
 #
+import hashlib
 import logging
 import random
-import hashlib
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple
 
@@ -244,7 +244,9 @@ class MessageHandler:
                     room_id, state_filter=state_filter
                 )
 
-                hash = hashlib.sha1(','.join(state_ids.values()).encode("utf-8")).hexdigest()
+                hash = hashlib.sha1(
+                    ",".join(state_ids.values()).encode("utf-8")
+                ).hexdigest()
                 # If the requester's hash matches ours, their cache is up to date and we can skip
                 # fetching events.
                 if last_hash == hash:

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -844,9 +844,9 @@ class RoomStateRestServlet(RestServlet):
             room_id=room_id,
             requester=requester,
             # Trim quotes from hash.
-            last_hash=existing_hash.decode('ascii')[1:-1] if existing_hash else None
+            last_hash=existing_hash.decode("ascii")[1:-1] if existing_hash else None,
         )
-        request.setHeader(b"ETag", f"\"{hash}\"".encode("ascii"))
+        request.setHeader(b"ETag", f'"{hash}"'.encode("ascii"))
 
         if events is None:
             return 304, None

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -835,7 +835,7 @@ class RoomStateRestServlet(RestServlet):
     @cancellable
     async def on_GET(
         self, request: SynapseRequest, room_id: str
-    ) -> Tuple[int, List[JsonDict]]:
+    ) -> Tuple[int, Optional[List[JsonDict]]]:
         requester = await self.auth.get_user_by_req(request, allow_guest=True)
         existing_hash = request.getHeader(b"If-None-Match")
 
@@ -848,7 +848,7 @@ class RoomStateRestServlet(RestServlet):
         )
         request.setHeader(b"ETag", f'"{hash}"'.encode("ascii"))
 
-        if events is None:
+        if len(events) == 0:
             return 304, None
 
         return 200, events

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -560,21 +560,18 @@ class RoomStateTestCase(RoomBase):
             "/rooms/%s/state" % room_id,
         )
 
-        etag = channel.headers.getRawHeaders(b"ETag")[0]
+        etagheader = channel.headers.getRawHeaders(b"ETag")
         self.assertEqual(HTTPStatus.OK, channel.code, msg=channel.result["body"])
-        self.assertIsNotNone(
-            etag,
-            "has a ETag header",
-        )
+        assert etagheader
         channel2 = self.make_request(
             "GET",
             "/rooms/%s/state" % room_id,
-            custom_headers=(
+            custom_headers=[
                 (
                     b"If-None-Match",
-                    etag,
+                    etagheader[0],
                 ),
-            ),
+            ],
         )
         self.assertEqual(
             HTTPStatus.NOT_MODIFIED,
@@ -582,8 +579,8 @@ class RoomStateTestCase(RoomBase):
             "Responds with not modified when provided with the correct ETag",
         )
         self.assertEqual(
-            etag,
-            channel2.headers.getRawHeaders(b"ETag")[0],
+            etagheader,
+            channel2.headers.getRawHeaders(b"ETag"),
             "returns the same etag",
         )
 


### PR DESCRIPTION
We talked about this in the Backend internal room. It's not the most ideal solution but I'd like to test the waters on what should be something that we can just do, as it's already part of the HTTP specification.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
