### PR TITLE
MSC4076: Add disable_badge_count to pusher configuration

### DIFF
--- a/changelog.d/17975.feature
+++ b/changelog.d/17975.feature
@@ -1,1 +1,1 @@
-[MSC4076](https://github.com/matrix-org/matrix-spec-proposals/pull/4076): Add `disable_badge_count` to pusher configuration
+[MSC4076](https://github.com/matrix-org/matrix-spec-proposals/pull/4076): Add `disable_badge_count` to pusher configuration.

--- a/changelog.d/17975.feature
+++ b/changelog.d/17975.feature
@@ -1,0 +1,1 @@
+[MSC4076](https://github.com/matrix-org/matrix-spec-proposals/pull/4076): Add `disable_badge_count` to pusher configuration

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -448,3 +448,6 @@ class ExperimentalConfig(Config):
 
         # MSC4222: Adding `state_after` to sync v2
         self.msc4222_enabled: bool = experimental.get("msc4222_enabled", False)
+
+        # MSC4076: Add `disable_badge_count`` to pusher configuration
+        self.msc4076_enabled: bool = experimental.get("msc4076_enabled", False)

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -128,7 +128,7 @@ class HttpPusher(Pusher):
             raise PusherConfigException("'data' key can not be null for HTTP pusher")
 
         # Check if badge counts should be disabled for this push gateway
-        self.disable_badge_count = bool(
+        self.disable_badge_count = self.hs.config.experimental.msc4076_enabled and bool(
             self.data.get("org.matrix.msc4076.disable_badge_count", False)
         )
 

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -488,7 +488,6 @@ class HttpPusher(Pusher):
             if not self.disable_badge_count:
                 content["counts"] = {
                     "unread": badge,
-                    # 'missed_calls': 2
                 }
             if event.type == "m.room.member" and event.is_state():
                 content["membership"] = event.content["membership"]

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -128,7 +128,9 @@ class HttpPusher(Pusher):
             raise PusherConfigException("'data' key can not be null for HTTP pusher")
 
         # Check if badge counts should be disabled for this push gateway
-        self.disable_badge_count = bool(self.data.get("org.matrix.msc4076.disable_badge_count", False))
+        self.disable_badge_count = bool(
+            self.data.get("org.matrix.msc4076.disable_badge_count", False)
+        )
 
         self.name = "%s/%s/%s" % (
             pusher_config.user_name,

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -127,6 +127,9 @@ class HttpPusher(Pusher):
         if self.data is None:
             raise PusherConfigException("'data' key can not be null for HTTP pusher")
 
+        # Check if badge counts should be disabled for this push gateway
+        self.disable_badge_count = bool(self.data.get("org.matrix.msc4076.disable_badge_count", False))
+
         self.name = "%s/%s/%s" % (
             pusher_config.user_name,
             pusher_config.app_id,
@@ -461,9 +464,10 @@ class HttpPusher(Pusher):
             content: JsonDict = {
                 "event_id": event.event_id,
                 "room_id": event.room_id,
-                "counts": {"unread": badge},
                 "prio": priority,
             }
+            if not self.disable_badge_count:
+                content["counts"] = {"unread": badge}
             # event_id_only doesn't include the tweaks, so override them.
             tweaks = {}
         else:
@@ -478,11 +482,12 @@ class HttpPusher(Pusher):
                 "type": event.type,
                 "sender": event.user_id,
                 "prio": priority,
-                "counts": {
+            }
+            if not self.disable_badge_count:
+                content["counts"] = {
                     "unread": badge,
                     # 'missed_calls': 2
-                },
-            }
+                }
             if event.type == "m.room.member" and event.is_state():
                 content["membership"] = event.content["membership"]
                 content["user_is_target"] = event.state_key == self.user_id

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -1088,15 +1088,19 @@ class HTTPPusherTests(HomeserverTestCase):
 
         self.assertEqual(len(self.push_attempts), 11)
 
-    @parameterized.expand([
-        # Badge count disabled
-        (True, True),
-        (True, False),
-        # Badge count enabled
-        (False, True),
-        (False, False),
-    ])
-    def test_msc4076_badge_count(self, disable_badge_count: bool, event_id_only: bool) -> None:
+    @parameterized.expand(
+        [
+            # Badge count disabled
+            (True, True),
+            (True, False),
+            # Badge count enabled
+            (False, True),
+            (False, False),
+        ]
+    )
+    def test_msc4076_badge_count(
+        self, disable_badge_count: bool, event_id_only: bool
+    ) -> None:
         # Register the user who gets notified
         user_id = self.register_user("user", "pass")
         access_token = self.login("user", "pass")

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -17,7 +17,7 @@
 # [This file includes modifications made by New Vector Limited]
 #
 #
-from typing import Any, List, Tuple
+from typing import Any, Dict, List, Tuple
 from unittest.mock import Mock
 
 from parameterized import parameterized
@@ -1097,68 +1097,68 @@ class HTTPPusherTests(HomeserverTestCase):
         (False, False),
     ])
     def test_msc4076_badge_count(self, disable_badge_count: bool, event_id_only: bool) -> None:
-            # Register the user who gets notified
-            user_id = self.register_user("user", "pass")
-            access_token = self.login("user", "pass")
+        # Register the user who gets notified
+        user_id = self.register_user("user", "pass")
+        access_token = self.login("user", "pass")
 
-            # Register the user who sends the message
-            other_user_id = self.register_user("otheruser", "pass")
-            other_access_token = self.login("otheruser", "pass")
+        # Register the user who sends the message
+        other_user_id = self.register_user("otheruser", "pass")
+        other_access_token = self.login("otheruser", "pass")
 
-            # Register the pusher with disable_badge_count set to True
-            user_tuple = self.get_success(
-                self.hs.get_datastores().main.get_user_by_access_token(access_token)
+        # Register the pusher with disable_badge_count set to True
+        user_tuple = self.get_success(
+            self.hs.get_datastores().main.get_user_by_access_token(access_token)
+        )
+        assert user_tuple is not None
+        device_id = user_tuple.device_id
+
+        # Set the push data dict based on test input parameters
+        push_data: Dict[str, Any] = {
+            "url": "http://example.com/_matrix/push/v1/notify",
+        }
+        if disable_badge_count:
+            push_data["org.matrix.msc4076.disable_badge_count"] = True
+        if event_id_only:
+            push_data["format"] = "event_id_only"
+
+        self.get_success(
+            self.hs.get_pusherpool().add_or_update_pusher(
+                user_id=user_id,
+                device_id=device_id,
+                kind="http",
+                app_id="m.http",
+                app_display_name="HTTP Push Notifications",
+                device_display_name="pushy push",
+                pushkey="a@example.com",
+                lang=None,
+                data=push_data,
             )
-            assert user_tuple is not None
-            device_id = user_tuple.device_id
+        )
 
-            # Set the push data dict based on test input parameters
-            push_data = {
-                "url": "http://example.com/_matrix/push/v1/notify",
-            }
-            if disable_badge_count:
-                push_data["org.matrix.msc4076.disable_badge_count"] = True
-            if event_id_only:
-                push_data["format"] = "event_id_only"
+        # Create a room
+        room = self.helper.create_room_as(user_id, tok=access_token)
 
-            self.get_success(
-                self.hs.get_pusherpool().add_or_update_pusher(
-                    user_id=user_id,
-                    device_id=device_id,
-                    kind="http",
-                    app_id="m.http",
-                    app_display_name="HTTP Push Notifications",
-                    device_display_name="pushy push",
-                    pushkey="a@example.com",
-                    lang=None,
-                    data=push_data,
-                )
-            )
+        # The other user joins
+        self.helper.join(room=room, user=other_user_id, tok=other_access_token)
 
-            # Create a room
-            room = self.helper.create_room_as(user_id, tok=access_token)
+        # The other user sends a message
+        self.helper.send(room, body="Hi!", tok=other_access_token)
 
-            # The other user joins
-            self.helper.join(room=room, user=other_user_id, tok=other_access_token)
+        # Advance time a bit, so the pusher will register something has happened
+        self.pump()
 
-            # The other user sends a message
-            self.helper.send(room, body="Hi!", tok=other_access_token)
+        # One push was attempted to be sent
+        self.assertEqual(len(self.push_attempts), 1)
+        self.assertEqual(
+            self.push_attempts[0][1], "http://example.com/_matrix/push/v1/notify"
+        )
 
-            # Advance time a bit, so the pusher will register something has happened
-            self.pump()
-
-            # One push was attempted to be sent
-            self.assertEqual(len(self.push_attempts), 1)
+        if disable_badge_count:
+            # Verify that the notification DOESN'T contain a counts field
+            self.assertNotIn("counts", self.push_attempts[0][2]["notification"])
+        else:
+            # Ensure that the notification DOES contain a counts field
+            self.assertIn("counts", self.push_attempts[0][2]["notification"])
             self.assertEqual(
-                self.push_attempts[0][1], "http://example.com/_matrix/push/v1/notify"
+                self.push_attempts[0][2]["notification"]["counts"]["unread"], 1
             )
-
-            if disable_badge_count:
-                # Verify that the notification DOESN'T contain a counts field
-                self.assertNotIn("counts", self.push_attempts[0][2]["notification"])
-            else:
-                # Ensure that the notification DOES contain a counts field
-                self.assertIn("counts", self.push_attempts[0][2]["notification"])
-                self.assertEqual(
-                    self.push_attempts[0][2]["notification"]["counts"]["unread"], 1
-                )

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -1140,7 +1140,7 @@ class HTTPPusherTests(HomeserverTestCase):
         self.assertEqual(
             self.push_attempts[0][1], "http://example.com/_matrix/push/v1/notify"
         )
-        
+
         # Verify that the notification doesn't contain a counts field
         self.assertNotIn("counts", self.push_attempts[0][2]["notification"])
 
@@ -1199,7 +1199,7 @@ class HTTPPusherTests(HomeserverTestCase):
         self.assertEqual(
             self.push_attempts[0][1], "http://example.com/_matrix/push/v1/notify"
         )
-        
+
         # Verify that the notification doesn't contain a counts field
         self.assertNotIn("counts", self.push_attempts[0][2]["notification"])
 
@@ -1256,7 +1256,7 @@ class HTTPPusherTests(HomeserverTestCase):
         self.assertEqual(
             self.push_attempts[0][1], "http://example.com/_matrix/push/v1/notify"
         )
-        
+
         # Verify that the notification contains a counts field
         self.assertIn("counts", self.push_attempts[0][2]["notification"])
         self.assertEqual(

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -20,6 +20,8 @@
 from typing import Any, List, Tuple
 from unittest.mock import Mock
 
+from parameterized import parameterized
+
 from twisted.internet.defer import Deferred
 from twisted.test.proto_helpers import MemoryReactor
 
@@ -1086,179 +1088,77 @@ class HTTPPusherTests(HomeserverTestCase):
 
         self.assertEqual(len(self.push_attempts), 11)
 
-    def test_badge_count_disabled(self) -> None:
-        """
-        Test that when disable_badge_count is set to True, the counts field is omitted
-        from the notification.
-        """
-        # Register the user who gets notified
-        user_id = self.register_user("user", "pass")
-        access_token = self.login("user", "pass")
+    @parameterized.expand([
+        # Badge count disabled
+        (True, True),
+        (True, False),
+        # Badge count enabled
+        (False, True),
+        (False, False),
+    ])
+    def test_msc4076_badge_count(self, disable_badge_count: bool, event_id_only: bool) -> None:
+            # Register the user who gets notified
+            user_id = self.register_user("user", "pass")
+            access_token = self.login("user", "pass")
 
-        # Register the user who sends the message
-        other_user_id = self.register_user("otheruser", "pass")
-        other_access_token = self.login("otheruser", "pass")
+            # Register the user who sends the message
+            other_user_id = self.register_user("otheruser", "pass")
+            other_access_token = self.login("otheruser", "pass")
 
-        # Register the pusher with disable_badge_count set to True
-        user_tuple = self.get_success(
-            self.hs.get_datastores().main.get_user_by_access_token(access_token)
-        )
-        assert user_tuple is not None
-        device_id = user_tuple.device_id
-
-        self.get_success(
-            self.hs.get_pusherpool().add_or_update_pusher(
-                user_id=user_id,
-                device_id=device_id,
-                kind="http",
-                app_id="m.http",
-                app_display_name="HTTP Push Notifications",
-                device_display_name="pushy push",
-                pushkey="a@example.com",
-                lang=None,
-                data={
-                    "url": "http://example.com/_matrix/push/v1/notify",
-                    "org.matrix.msc4076.disable_badge_count": True,
-                },
+            # Register the pusher with disable_badge_count set to True
+            user_tuple = self.get_success(
+                self.hs.get_datastores().main.get_user_by_access_token(access_token)
             )
-        )
+            assert user_tuple is not None
+            device_id = user_tuple.device_id
 
-        # Create a room
-        room = self.helper.create_room_as(user_id, tok=access_token)
+            # Set the push data dict based on test input parameters
+            push_data = {
+                "url": "http://example.com/_matrix/push/v1/notify",
+            }
+            if disable_badge_count:
+                push_data["org.matrix.msc4076.disable_badge_count"] = True
+            if event_id_only:
+                push_data["format"] = "event_id_only"
 
-        # The other user joins
-        self.helper.join(room=room, user=other_user_id, tok=other_access_token)
-
-        # The other user sends a message
-        self.helper.send(room, body="Hi!", tok=other_access_token)
-
-        # Advance time a bit, so the pusher will register something has happened
-        self.pump()
-
-        # One push was attempted to be sent
-        self.assertEqual(len(self.push_attempts), 1)
-        self.assertEqual(
-            self.push_attempts[0][1], "http://example.com/_matrix/push/v1/notify"
-        )
-
-        # Verify that the notification doesn't contain a counts field
-        self.assertNotIn("counts", self.push_attempts[0][2]["notification"])
-
-    def test_badge_count_disabled_event_id_only(self) -> None:
-        """
-        Test that when disable_badge_count is set to True and format is event_id_only,
-        the counts field is omitted from the notification.
-        """
-        # Register the user who gets notified
-        user_id = self.register_user("user", "pass")
-        access_token = self.login("user", "pass")
-
-        # Register the user who sends the message
-        other_user_id = self.register_user("otheruser", "pass")
-        other_access_token = self.login("otheruser", "pass")
-
-        # Register the pusher with disable_badge_count set to True and format set to event_id_only
-        user_tuple = self.get_success(
-            self.hs.get_datastores().main.get_user_by_access_token(access_token)
-        )
-        assert user_tuple is not None
-        device_id = user_tuple.device_id
-
-        self.get_success(
-            self.hs.get_pusherpool().add_or_update_pusher(
-                user_id=user_id,
-                device_id=device_id,
-                kind="http",
-                app_id="m.http",
-                app_display_name="HTTP Push Notifications",
-                device_display_name="pushy push",
-                pushkey="a@example.com",
-                lang=None,
-                data={
-                    "url": "http://example.com/_matrix/push/v1/notify",
-                    "format": "event_id_only",
-                    "org.matrix.msc4076.disable_badge_count": True,
-                },
+            self.get_success(
+                self.hs.get_pusherpool().add_or_update_pusher(
+                    user_id=user_id,
+                    device_id=device_id,
+                    kind="http",
+                    app_id="m.http",
+                    app_display_name="HTTP Push Notifications",
+                    device_display_name="pushy push",
+                    pushkey="a@example.com",
+                    lang=None,
+                    data=push_data,
+                )
             )
-        )
 
-        # Create a room
-        room = self.helper.create_room_as(user_id, tok=access_token)
+            # Create a room
+            room = self.helper.create_room_as(user_id, tok=access_token)
 
-        # The other user joins
-        self.helper.join(room=room, user=other_user_id, tok=other_access_token)
+            # The other user joins
+            self.helper.join(room=room, user=other_user_id, tok=other_access_token)
 
-        # The other user sends a message
-        self.helper.send(room, body="Hi!", tok=other_access_token)
+            # The other user sends a message
+            self.helper.send(room, body="Hi!", tok=other_access_token)
 
-        # Advance time a bit, so the pusher will register something has happened
-        self.pump()
+            # Advance time a bit, so the pusher will register something has happened
+            self.pump()
 
-        # One push was attempted to be sent
-        self.assertEqual(len(self.push_attempts), 1)
-        self.assertEqual(
-            self.push_attempts[0][1], "http://example.com/_matrix/push/v1/notify"
-        )
-
-        # Verify that the notification doesn't contain a counts field
-        self.assertNotIn("counts", self.push_attempts[0][2]["notification"])
-
-    def test_badge_count_enabled(self) -> None:
-        """
-        Test that when disable_badge_count is set to False, the counts field is included
-        in the notification.
-        """
-        # Register the user who gets notified
-        user_id = self.register_user("user", "pass")
-        access_token = self.login("user", "pass")
-
-        # Register the user who sends the message
-        other_user_id = self.register_user("otheruser", "pass")
-        other_access_token = self.login("otheruser", "pass")
-
-        # Register the pusher with disable_badge_count set to False
-        user_tuple = self.get_success(
-            self.hs.get_datastores().main.get_user_by_access_token(access_token)
-        )
-        assert user_tuple is not None
-        device_id = user_tuple.device_id
-
-        self.get_success(
-            self.hs.get_pusherpool().add_or_update_pusher(
-                user_id=user_id,
-                device_id=device_id,
-                kind="http",
-                app_id="m.http",
-                app_display_name="HTTP Push Notifications",
-                device_display_name="pushy push",
-                pushkey="a@example.com",
-                lang=None,
-                data={
-                    "url": "http://example.com/_matrix/push/v1/notify",
-                },
+            # One push was attempted to be sent
+            self.assertEqual(len(self.push_attempts), 1)
+            self.assertEqual(
+                self.push_attempts[0][1], "http://example.com/_matrix/push/v1/notify"
             )
-        )
 
-        # Create a room
-        room = self.helper.create_room_as(user_id, tok=access_token)
-
-        # The other user joins
-        self.helper.join(room=room, user=other_user_id, tok=other_access_token)
-
-        # The other user sends a message
-        self.helper.send(room, body="Hi!", tok=other_access_token)
-
-        # Advance time a bit, so the pusher will register something has happened
-        self.pump()
-
-        # One push was attempted to be sent
-        self.assertEqual(len(self.push_attempts), 1)
-        self.assertEqual(
-            self.push_attempts[0][1], "http://example.com/_matrix/push/v1/notify"
-        )
-
-        # Verify that the notification contains a counts field
-        self.assertIn("counts", self.push_attempts[0][2]["notification"])
-        self.assertEqual(
-            self.push_attempts[0][2]["notification"]["counts"]["unread"], 1
-        )
+            if disable_badge_count:
+                # Verify that the notification DOESN'T contain a counts field
+                self.assertNotIn("counts", self.push_attempts[0][2]["notification"])
+            else:
+                # Ensure that the notification DOES contain a counts field
+                self.assertIn("counts", self.push_attempts[0][2]["notification"])
+                self.assertEqual(
+                    self.push_attempts[0][2]["notification"]["counts"]["unread"], 1
+                )

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -1098,6 +1098,7 @@ class HTTPPusherTests(HomeserverTestCase):
             (False, False),
         ]
     )
+    @override_config({"experimental_features": {"msc4076_enabled": True}})
     def test_msc4076_badge_count(
         self, disable_badge_count: bool, event_id_only: bool
     ) -> None:

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -1085,3 +1085,180 @@ class HTTPPusherTests(HomeserverTestCase):
             self.pump()
 
         self.assertEqual(len(self.push_attempts), 11)
+
+    def test_badge_count_disabled(self) -> None:
+        """
+        Test that when disable_badge_count is set to True, the counts field is omitted
+        from the notification.
+        """
+        # Register the user who gets notified
+        user_id = self.register_user("user", "pass")
+        access_token = self.login("user", "pass")
+
+        # Register the user who sends the message
+        other_user_id = self.register_user("otheruser", "pass")
+        other_access_token = self.login("otheruser", "pass")
+
+        # Register the pusher with disable_badge_count set to True
+        user_tuple = self.get_success(
+            self.hs.get_datastores().main.get_user_by_access_token(access_token)
+        )
+        assert user_tuple is not None
+        device_id = user_tuple.device_id
+
+        self.get_success(
+            self.hs.get_pusherpool().add_or_update_pusher(
+                user_id=user_id,
+                device_id=device_id,
+                kind="http",
+                app_id="m.http",
+                app_display_name="HTTP Push Notifications",
+                device_display_name="pushy push",
+                pushkey="a@example.com",
+                lang=None,
+                data={
+                    "url": "http://example.com/_matrix/push/v1/notify",
+                    "org.matrix.msc4076.disable_badge_count": True,
+                },
+            )
+        )
+
+        # Create a room
+        room = self.helper.create_room_as(user_id, tok=access_token)
+
+        # The other user joins
+        self.helper.join(room=room, user=other_user_id, tok=other_access_token)
+
+        # The other user sends a message
+        self.helper.send(room, body="Hi!", tok=other_access_token)
+
+        # Advance time a bit, so the pusher will register something has happened
+        self.pump()
+
+        # One push was attempted to be sent
+        self.assertEqual(len(self.push_attempts), 1)
+        self.assertEqual(
+            self.push_attempts[0][1], "http://example.com/_matrix/push/v1/notify"
+        )
+        
+        # Verify that the notification doesn't contain a counts field
+        self.assertNotIn("counts", self.push_attempts[0][2]["notification"])
+
+    def test_badge_count_disabled_event_id_only(self) -> None:
+        """
+        Test that when disable_badge_count is set to True and format is event_id_only,
+        the counts field is omitted from the notification.
+        """
+        # Register the user who gets notified
+        user_id = self.register_user("user", "pass")
+        access_token = self.login("user", "pass")
+
+        # Register the user who sends the message
+        other_user_id = self.register_user("otheruser", "pass")
+        other_access_token = self.login("otheruser", "pass")
+
+        # Register the pusher with disable_badge_count set to True and format set to event_id_only
+        user_tuple = self.get_success(
+            self.hs.get_datastores().main.get_user_by_access_token(access_token)
+        )
+        assert user_tuple is not None
+        device_id = user_tuple.device_id
+
+        self.get_success(
+            self.hs.get_pusherpool().add_or_update_pusher(
+                user_id=user_id,
+                device_id=device_id,
+                kind="http",
+                app_id="m.http",
+                app_display_name="HTTP Push Notifications",
+                device_display_name="pushy push",
+                pushkey="a@example.com",
+                lang=None,
+                data={
+                    "url": "http://example.com/_matrix/push/v1/notify",
+                    "format": "event_id_only",
+                    "org.matrix.msc4076.disable_badge_count": True,
+                },
+            )
+        )
+
+        # Create a room
+        room = self.helper.create_room_as(user_id, tok=access_token)
+
+        # The other user joins
+        self.helper.join(room=room, user=other_user_id, tok=other_access_token)
+
+        # The other user sends a message
+        self.helper.send(room, body="Hi!", tok=other_access_token)
+
+        # Advance time a bit, so the pusher will register something has happened
+        self.pump()
+
+        # One push was attempted to be sent
+        self.assertEqual(len(self.push_attempts), 1)
+        self.assertEqual(
+            self.push_attempts[0][1], "http://example.com/_matrix/push/v1/notify"
+        )
+        
+        # Verify that the notification doesn't contain a counts field
+        self.assertNotIn("counts", self.push_attempts[0][2]["notification"])
+
+    def test_badge_count_enabled(self) -> None:
+        """
+        Test that when disable_badge_count is set to False, the counts field is included
+        in the notification.
+        """
+        # Register the user who gets notified
+        user_id = self.register_user("user", "pass")
+        access_token = self.login("user", "pass")
+
+        # Register the user who sends the message
+        other_user_id = self.register_user("otheruser", "pass")
+        other_access_token = self.login("otheruser", "pass")
+
+        # Register the pusher with disable_badge_count set to False
+        user_tuple = self.get_success(
+            self.hs.get_datastores().main.get_user_by_access_token(access_token)
+        )
+        assert user_tuple is not None
+        device_id = user_tuple.device_id
+
+        self.get_success(
+            self.hs.get_pusherpool().add_or_update_pusher(
+                user_id=user_id,
+                device_id=device_id,
+                kind="http",
+                app_id="m.http",
+                app_display_name="HTTP Push Notifications",
+                device_display_name="pushy push",
+                pushkey="a@example.com",
+                lang=None,
+                data={
+                    "url": "http://example.com/_matrix/push/v1/notify",
+                },
+            )
+        )
+
+        # Create a room
+        room = self.helper.create_room_as(user_id, tok=access_token)
+
+        # The other user joins
+        self.helper.join(room=room, user=other_user_id, tok=other_access_token)
+
+        # The other user sends a message
+        self.helper.send(room, body="Hi!", tok=other_access_token)
+
+        # Advance time a bit, so the pusher will register something has happened
+        self.pump()
+
+        # One push was attempted to be sent
+        self.assertEqual(len(self.push_attempts), 1)
+        self.assertEqual(
+            self.push_attempts[0][1], "http://example.com/_matrix/push/v1/notify"
+        )
+        
+        # Verify that the notification contains a counts field
+        self.assertIn("counts", self.push_attempts[0][2]["notification"])
+        self.assertEqual(
+            self.push_attempts[0][2]["notification"]["counts"]["unread"], 1
+        )


### PR DESCRIPTION
This PR implements [MSC4076: Let E2EE clients calculate app badge counts themselves (disable_badge_count)](https://github.com/matrix-org/matrix-spec-proposals/pull/4076).

The MSC is not merged yet but I have not put this new code under a experimental feature flag. The behavior change is very limited to the homerserver / client / push gateway interfaces. It can only happen if the client asks for it. 

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
