### PR TITLE
Add `last_seen_ts` to query user example

### DIFF
--- a/changelog.d/17976.doc
+++ b/changelog.d/17976.doc
@@ -1,0 +1,1 @@
+Add previously-undocumented `last_seen_ts` to query user admin API.

--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -40,6 +40,7 @@ It returns a JSON body like the following:
     "erased": false,
     "shadow_banned": 0,
     "creation_ts": 1560432506,
+    "last_seen_ts": 1732919539393,
     "appservice_id": null,
     "consent_server_notice_sent": null,
     "consent_version": null,


### PR DESCRIPTION
This section could probably do with a lot more editorial attention, but for now this is all there is in terms of documentation. The field is already returned by Synapse: https://github.com/element-hq/synapse/blob/4587decd678300217969f1d2f69b226421a33ced/synapse/handlers/admin.py#L150

`last_seen_ts` was introduced in https://github.com/matrix-org/synapse/pull/16218

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
