### PR TITLE
Add RoomID & EventID rust types

### DIFF
--- a/changelog.d/17996.misc
+++ b/changelog.d/17996.misc
@@ -1,0 +1,1 @@
+Add `RoomID` & `EventID` rust types.

--- a/rust/src/identifier.rs
+++ b/rust/src/identifier.rs
@@ -71,6 +71,34 @@ impl TryFrom<&str> for UserID {
     }
 }
 
+impl TryFrom<String> for UserID {
+    type Error = IdentifierError;
+
+    /// Will try creating a `UserID` from the provided `&str`.
+    /// Can fail if the user_id is incorrectly formatted.
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        if !s.starts_with('@') {
+            return Err(IdentifierError::IncorrectSigil);
+        }
+
+        if s.find(':').is_none() {
+            return Err(IdentifierError::MissingColon);
+        }
+
+        Ok(UserID(s.to_string()))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for UserID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: String = serde::Deserialize::deserialize(deserializer)?;
+        UserID::try_from(s).map_err(serde::de::Error::custom)
+    }
+}
+
 impl Deref for UserID {
     type Target = str;
 
@@ -80,6 +108,144 @@ impl Deref for UserID {
 }
 
 impl fmt::Display for UserID {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A Matrix room_id.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RoomID(String);
+
+impl RoomID {
+    /// Returns the `localpart` of the room_id.
+    pub fn localpart(&self) -> &str {
+        &self[1..self.colon_pos()]
+    }
+
+    /// Returns the `server_name` / `domain` of the room_id.
+    pub fn server_name(&self) -> &str {
+        &self[self.colon_pos() + 1..]
+    }
+
+    /// Returns the position of the ':' inside of the room_id.
+    /// Used when splitting the room_id into it's respective parts.
+    fn colon_pos(&self) -> usize {
+        self.find(':').unwrap()
+    }
+}
+
+impl TryFrom<&str> for RoomID {
+    type Error = IdentifierError;
+
+    /// Will try creating a `RoomID` from the provided `&str`.
+    /// Can fail if the room_id is incorrectly formatted.
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        if !s.starts_with('!') {
+            return Err(IdentifierError::IncorrectSigil);
+        }
+
+        if s.find(':').is_none() {
+            return Err(IdentifierError::MissingColon);
+        }
+
+        Ok(RoomID(s.to_string()))
+    }
+}
+
+impl TryFrom<String> for RoomID {
+    type Error = IdentifierError;
+
+    /// Will try creating a `RoomID` from the provided `String`.
+    /// Can fail if the event_id is incorrectly formatted.
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        if !s.starts_with('!') {
+            return Err(IdentifierError::IncorrectSigil);
+        }
+
+        if s.find(':').is_none() {
+            return Err(IdentifierError::MissingColon);
+        }
+
+        Ok(RoomID(s))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for RoomID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: String = serde::Deserialize::deserialize(deserializer)?;
+        RoomID::try_from(s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Deref for RoomID {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Display for RoomID {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A Matrix event_id.
+#[derive(Clone, Debug, PartialEq)]
+pub struct EventID(String);
+
+impl TryFrom<&str> for EventID {
+    type Error = IdentifierError;
+
+    /// Will try creating a `EventID` from the provided `&str`.
+    /// Can fail if the event_id is incorrectly formatted.
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        if !s.starts_with('$') {
+            return Err(IdentifierError::IncorrectSigil);
+        }
+
+        Ok(EventID(s.to_string()))
+    }
+}
+
+impl TryFrom<String> for EventID {
+    type Error = IdentifierError;
+
+    /// Will try creating a `EventID` from the provided `String`.
+    /// Can fail if the event_id is incorrectly formatted.
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        if !s.starts_with('$') {
+            return Err(IdentifierError::IncorrectSigil);
+        }
+
+        Ok(EventID(s))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for EventID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: String = serde::Deserialize::deserialize(deserializer)?;
+        EventID::try_from(s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Deref for EventID {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Display for EventID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }

--- a/rust/src/identifier.rs
+++ b/rust/src/identifier.rs
@@ -85,7 +85,7 @@ impl TryFrom<String> for UserID {
             return Err(IdentifierError::MissingColon);
         }
 
-        Ok(UserID(s.to_string()))
+        Ok(UserID(s))
     }
 }
 

--- a/rust/src/identifier.rs
+++ b/rust/src/identifier.rs
@@ -157,7 +157,7 @@ impl TryFrom<String> for RoomID {
     type Error = IdentifierError;
 
     /// Will try creating a `RoomID` from the provided `String`.
-    /// Can fail if the event_id is incorrectly formatted.
+    /// Can fail if the room_id is incorrectly formatted.
     fn try_from(s: String) -> Result<Self, Self::Error> {
         if !s.starts_with('!') {
             return Err(IdentifierError::IncorrectSigil);


### PR DESCRIPTION
Adds the RoomID & EventID rust types to the rust lib.
Also adds a Deserialize impl to the existing UserID type.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [X] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
