### PR TITLE
Fix mypy errors on Twisted 24.11.0

### DIFF
--- a/changelog.d/17998.misc
+++ b/changelog.d/17998.misc
@@ -1,0 +1,1 @@
+Fix various type errors across the codebase.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -41,7 +41,7 @@ from canonicaljson import encode_canonical_json
 from netaddr import AddrFormatError, IPAddress, IPSet
 from prometheus_client import Counter
 from typing_extensions import Protocol
-from zope.interface import implementer, provider
+from zope.interface import implementer
 
 from OpenSSL import SSL
 from OpenSSL.SSL import VERIFY_NONE
@@ -225,7 +225,7 @@ class _IPBlockingResolver:
                     recv.addressResolved(address)
             recv.resolutionComplete()
 
-        @provider(IResolutionReceiver)
+        @implementer(IResolutionReceiver)
         class EndpointReceiver:
             @staticmethod
             def resolutionBegan(resolutionInProgress: IHostResolution) -> None:
@@ -239,8 +239,9 @@ class _IPBlockingResolver:
             def resolutionComplete() -> None:
                 _callback()
 
+        endpoint_receiver_wrapper = EndpointReceiver()
         self._reactor.nameResolver.resolveHostName(
-            EndpointReceiver, hostname, portNumber=portNumber
+            endpoint_receiver_wrapper, hostname, portNumber=portNumber
         )
 
         return recv

--- a/synapse/http/proxyagent.py
+++ b/synapse/http/proxyagent.py
@@ -21,7 +21,7 @@
 import logging
 import random
 import re
-from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple, Union
 from urllib.parse import urlparse
 from urllib.request import (  # type: ignore[attr-defined]
     getproxies_environment,
@@ -351,7 +351,9 @@ def http_proxy_endpoint(
     proxy: Optional[bytes],
     reactor: IReactorCore,
     tls_options_factory: Optional[IPolicyForHTTPS],
-    **kwargs: object,
+    timeout: float = 30,
+    bindAddress: Optional[Union[bytes, str, tuple[Union[bytes, str], int]]] = None,
+    attemptDelay: Optional[float] = None,
 ) -> Tuple[Optional[IStreamClientEndpoint], Optional[ProxyCredentials]]:
     """Parses an http proxy setting and returns an endpoint for the proxy
 
@@ -382,7 +384,9 @@ def http_proxy_endpoint(
     # 3.9+) on scheme-less proxies, e.g. host:port.
     scheme, host, port, credentials = parse_proxy(proxy)
 
-    proxy_endpoint = HostnameEndpoint(reactor, host, port, **kwargs)
+    proxy_endpoint = HostnameEndpoint(
+        reactor, host, port, timeout, bindAddress, attemptDelay
+    )
 
     if scheme == b"https":
         if tls_options_factory:

--- a/synapse/http/proxyagent.py
+++ b/synapse/http/proxyagent.py
@@ -391,7 +391,8 @@ def http_proxy_endpoint(
     if scheme == b"https":
         if tls_options_factory:
             tls_options = tls_options_factory.creatorForNetloc(host, port)
-            proxy_endpoint = wrapClientTLS(tls_options, proxy_endpoint)
+            wrapped_proxy_endpoint = wrapClientTLS(tls_options, proxy_endpoint)
+            return wrapped_proxy_endpoint, credentials
         else:
             raise RuntimeError(
                 f"No TLS options for a https connection via proxy {proxy!s}"

--- a/synapse/http/replicationagent.py
+++ b/synapse/http/replicationagent.py
@@ -89,7 +89,7 @@ class ReplicationEndpointFactory:
                 location_config.port,
             )
             if scheme == "https":
-                endpoint = wrapClientTLS(
+                wrapped_endpoint = wrapClientTLS(
                     # The 'port' argument below isn't actually used by the function
                     self.context_factory.creatorForNetloc(
                         location_config.host.encode("utf-8"),
@@ -97,6 +97,8 @@ class ReplicationEndpointFactory:
                     ),
                     endpoint,
                 )
+                return wrapped_endpoint
+
             return endpoint
         elif isinstance(location_config, InstanceUnixLocationConfig):
             return UNIXClientEndpoint(self.reactor, location_config.path)

--- a/tests/http/test_proxyagent.py
+++ b/tests/http/test_proxyagent.py
@@ -854,7 +854,7 @@ class MatrixFederationAgentTests(TestCase):
     def test_proxy_with_no_scheme(self) -> None:
         http_proxy_agent = ProxyAgent(self.reactor, use_proxy=True)
         proxy_ep = checked_cast(HostnameEndpoint, http_proxy_agent.http_proxy_endpoint)
-        self.assertEqual(proxy_ep._hostStr, "proxy.com")
+        self.assertEqual(proxy_ep._hostText, "proxy.com")
         self.assertEqual(proxy_ep._port, 8888)
 
     @patch.dict(os.environ, {"http_proxy": "socks://proxy.com:8888"})
@@ -866,14 +866,14 @@ class MatrixFederationAgentTests(TestCase):
     def test_proxy_with_http_scheme(self) -> None:
         http_proxy_agent = ProxyAgent(self.reactor, use_proxy=True)
         proxy_ep = checked_cast(HostnameEndpoint, http_proxy_agent.http_proxy_endpoint)
-        self.assertEqual(proxy_ep._hostStr, "proxy.com")
+        self.assertEqual(proxy_ep._hostText, "proxy.com")
         self.assertEqual(proxy_ep._port, 8888)
 
     @patch.dict(os.environ, {"http_proxy": "https://proxy.com:8888"})
     def test_proxy_with_https_scheme(self) -> None:
         https_proxy_agent = ProxyAgent(self.reactor, use_proxy=True)
         proxy_ep = checked_cast(_WrapperEndpoint, https_proxy_agent.http_proxy_endpoint)
-        self.assertEqual(proxy_ep._wrappedEndpoint._hostStr, "proxy.com")
+        self.assertEqual(proxy_ep._wrappedEndpoint._hostText, "proxy.com")
         self.assertEqual(proxy_ep._wrappedEndpoint._port, 8888)
 
 


### PR DESCRIPTION
Fixes various `mypy` errors associated with Twisted `24.11.0`.

Hopefully addresses https://github.com/element-hq/synapse/issues/17075, though I've yet to test against `trunk`.

Changes should be compatible with our currently pinned Twisted version of `24.7.0`.
