### PR TITLE
Disable statement timeout during room purge

### DIFF
--- a/changelog.d/18017.misc
+++ b/changelog.d/18017.misc
@@ -1,0 +1,1 @@
+Disable DB statement timeout when doing a purge room since it can be quite long.

--- a/synapse/storage/databases/main/purge_events.py
+++ b/synapse/storage/databases/main/purge_events.py
@@ -376,6 +376,11 @@ class PurgeEventsStore(StateGroupWorkerStore, CacheInvalidationWorkerStore):
                 (room_id,),
             )
 
+        if isinstance(self.database_engine, PostgresEngine):
+            # Disable statement timeouts for this transaction; purging rooms can
+            # take a while!
+            txn.execute("SET LOCAL statement_timeout = 0")
+
         # First, fetch all the state groups that should be deleted, before
         # we delete that information.
         txn.execute(


### PR DESCRIPTION
This is already done for `purge_history` but seems to have been forgotten for `purge_room`.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
