### PR TITLE
Don't ratelimit server-sent delayed events

### DIFF
--- a/changelog.d/18018.bugfix
+++ b/changelog.d/18018.bugfix
@@ -1,0 +1,1 @@
+Don't apply ratelimiting on the sending of delayed events by the server.

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -467,6 +467,7 @@ class DelayedEventsHandler:
                     requester,
                     event_dict,
                     txn_id=txn_id,
+                    ratelimit=False,
                 )
                 event_id = sent_event.event_id
         except ShadowBanError:


### PR DESCRIPTION
Fixes https://github.com/element-hq/synapse/issues/18021

When the server sends a delayed event upon timeout / on-demand sending, don't apply ratelimiting to the event create+send attempt, because it is a send that the server expects to be able to send.

What should (and does) get rate-limited are client requests to manage delayed events.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
