### PR TITLE
Stop using twisted.internet.defer.returnValue

### DIFF
--- a/changelog.d/18020.misc
+++ b/changelog.d/18020.misc
@@ -1,0 +1,1 @@
+Remove some remaining uses of `twisted.internet.defer.returnValue`. Contributed by Colin Watson.

--- a/contrib/cmdclient/console.py
+++ b/contrib/cmdclient/console.py
@@ -245,7 +245,7 @@ class SynapseCmd(cmd.Cmd):
 
         if "flows" not in json_res:
             print("Failed to find any login flows.")
-            defer.returnValue(False)
+            return False
 
         flow = json_res["flows"][0]  # assume first is the one we want.
         if "type" not in flow or "m.login.password" != flow["type"] or "stages" in flow:
@@ -254,8 +254,8 @@ class SynapseCmd(cmd.Cmd):
                 "Unable to login via the command line client. Please visit "
                 "%s to login." % fallback_url
             )
-            defer.returnValue(False)
-        defer.returnValue(True)
+            return False
+        return True
 
     def do_emailrequest(self, line):
         """Requests the association of a third party identifier

--- a/contrib/cmdclient/http.py
+++ b/contrib/cmdclient/http.py
@@ -78,7 +78,7 @@ class TwistedHttpClient(HttpClient):
             url, data, headers_dict={"Content-Type": ["application/json"]}
         )
         body = yield readBody(response)
-        defer.returnValue((response.code, body))
+        return response.code, body
 
     @defer.inlineCallbacks
     def get_json(self, url, args=None):
@@ -88,7 +88,7 @@ class TwistedHttpClient(HttpClient):
             url = "%s?%s" % (url, qs)
         response = yield self._create_get_request(url)
         body = yield readBody(response)
-        defer.returnValue(json.loads(body))
+        return json.loads(body)
 
     def _create_put_request(self, url, json_data, headers_dict: Optional[dict] = None):
         """Wrapper of _create_request to issue a PUT request"""
@@ -134,7 +134,7 @@ class TwistedHttpClient(HttpClient):
             response = yield self._create_request(method, url)
 
         body = yield readBody(response)
-        defer.returnValue(json.loads(body))
+        return json.loads(body)
 
     @defer.inlineCallbacks
     def _create_request(
@@ -173,7 +173,7 @@ class TwistedHttpClient(HttpClient):
         if self.verbose:
             print("Status %s %s" % (response.code, response.phrase))
             print(pformat(list(response.headers.getAllRawHeaders())))
-        defer.returnValue(response)
+        return response
 
     def sleep(self, seconds):
         d = defer.Deferred()

--- a/synapse/util/patch_inline_callbacks.py
+++ b/synapse/util/patch_inline_callbacks.py
@@ -162,7 +162,7 @@ def _check_yield_points(
                     d = result.throwExceptionIntoGenerator(gen)
                 else:
                     d = gen.send(result)
-            except (StopIteration, defer._DefGen_Return) as e:
+            except StopIteration as e:
                 if current_context() != expected_context:
                     # This happens when the context is lost sometime *after* the
                     # final yield and returning. E.g. we forgot to yield on a
@@ -183,7 +183,7 @@ def _check_yield_points(
                         )
                     )
                     changes.append(err)
-                # The `StopIteration` or `_DefGen_Return` contains the return value from the
+                # The `StopIteration` contains the return value from the
                 # generator.
                 return cast(T, e.value)
 


### PR DESCRIPTION
`defer.returnValue` was only needed in Python 2; in Python 3, a simple `return` is fine.

`twisted.internet.defer.returnValue` is deprecated as of Twisted 24.7.0.

Most uses of `returnValue` in synapse were removed a while back; this cleans up some remaining bits.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
