### PR TITLE
Bump pypy to 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -458,7 +458,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["pypy-3.9"]
+        python-version: ["pypy-3.10"]
         extras: ["all"]
 
     steps:

--- a/changelog.d/18032.misc
+++ b/changelog.d/18032.misc
@@ -1,0 +1,1 @@
+Bump pypy version in our test CI to 3.10.


### PR DESCRIPTION
pypy 3.9 is EOL according to https://pypy.org/posts/2024/08/pypy-v7317-release.html#pypy-versions-and-speed-pypy-org.

---

Q: Shouldn't we bump this to the *latest* pypy version, rather than the oldest supported?