### PR TITLE
Remove support for PostgreSQL 11 and 12

### DIFF
--- a/.ci/scripts/calculate_jobs.py
+++ b/.ci/scripts/calculate_jobs.py
@@ -60,7 +60,7 @@ trial_postgres_tests = [
     {
         "python-version": "3.9",
         "database": "postgres",
-        "postgres-version": "11",
+        "postgres-version": "13",
         "extras": "all",
     }
 ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -581,7 +581,7 @@ jobs:
       matrix:
         include:
           - python-version: "3.9"
-            postgres-version: "11"
+            postgres-version: "13"
 
           - python-version: "3.13"
             postgres-version: "17"

--- a/changelog.d/18034.removal
+++ b/changelog.d/18034.removal
@@ -1,0 +1,1 @@
+Remove support for PostgreSQL 11 and 12. Contributed by @clokep.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -117,6 +117,14 @@ each upgrade are complete before moving on to the next upgrade, to avoid
 stacking them up. You can monitor the currently running background updates with
 [the Admin API](usage/administration/admin_api/background_updates.html#status).
 
+# Upgrading to v1.122.0
+
+## Dropping support for PostgreSQL 11 and 12
+
+In line with our [deprecation policy](deprecation_policy.md), we've dropped
+support for PostgreSQL 11 and 12, as they are no longer supported upstream.
+This release of Synapse requires PostgreSQL 13+.
+
 # Upgrading to v1.120.0
 
 ## Removal of experimental MSC3886 feature

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -99,8 +99,8 @@ class PostgresEngine(
         allow_unsafe_locale = self.config.get("allow_unsafe_locale", False)
 
         # Are we on a supported PostgreSQL version?
-        if not allow_outdated_version and self._version < 110000:
-            raise RuntimeError("Synapse requires PostgreSQL 11 or above.")
+        if not allow_outdated_version and self._version < 130000:
+            raise RuntimeError("Synapse requires PostgreSQL 13 or above.")
 
         with db_conn.cursor() as txn:
             txn.execute("SHOW SERVER_ENCODING")


### PR DESCRIPTION
This is essentially matrix-org/synapse#14392. I didn't see anything in there about updating sytest or complement.

The main driver of this is so that I can use `jsonb_path_exists` in #17488. 😄 

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
