### PR TITLE
Add the ability to filter by state event type on admin room state endpoint

### DIFF
--- a/changelog.d/18035.feature
+++ b/changelog.d/18035.feature
@@ -1,2 +1,1 @@
-Add a query param `type` to the [Room State Admin API](https://element-hq.github.io/synapse/develop/admin_api/rooms.html#room-state-api)
-that filters the state event.
+Add a unit test for the `type` parameter of the [Room State Admin API](https://element-hq.github.io/synapse/develop/admin_api/rooms.html#room-state-api).

--- a/changelog.d/18035.feature
+++ b/changelog.d/18035.feature
@@ -1,2 +1,2 @@
-Adds a query param `type` to `/_synapse/admin/v1/rooms/{room_id}/state` that filters the state event
-query by state event type.
+Add a query param `type` to the [Room State Admin API](https://element-hq.github.io/synapse/develop/admin_api/rooms.html#room-state-api)
+that filters the state event.

--- a/changelog.d/18035.feature
+++ b/changelog.d/18035.feature
@@ -1,0 +1,2 @@
+Adds a query param `type` to `/_synapse/admin/v1/rooms/{room_id}/state` that filters the state event
+query by state event type.

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -390,7 +390,7 @@ GET /_synapse/admin/v1/rooms/<room_id>/state
 The following query parameter is available:
 
 * `type` - The type of room state event to filter by, eg "m.room.create". If provided, only state events
-    of this type will be returned. 
+    of this type will be returned (regardless of their `state_key` value).
 
 A response body like the following is returned:
 

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -385,6 +385,13 @@ The API is:
 GET /_synapse/admin/v1/rooms/<room_id>/state
 ```
 
+**Parameters**
+
+The following query parameter is available:
+
+* `type` - The type of room state event to filter by, eg "m.room.create". If provided, only state events
+    of this type will be returned. 
+
 A response body like the following is returned:
 
 ```json

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -468,11 +468,6 @@ class RoomStateRestServlet(RestServlet):
         type = parse_string(request, "type")
 
         if type:
-            if not type.startswith("m.room."):
-                raise SynapseError(
-                    HTTPStatus.BAD_REQUEST,
-                    "Type must be a room state event.",
-                )
             state_filter = StateFilter(
                 types=immutabledict({type: None}),
                 include_others=False,

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -23,6 +23,7 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, List, Optional, Tuple, cast
 
 import attr
+from immutabledict import immutabledict
 
 from synapse.api.constants import Direction, EventTypes, JoinRules, Membership
 from synapse.api.errors import AuthError, Codes, NotFoundError, SynapseError
@@ -463,7 +464,23 @@ class RoomStateRestServlet(RestServlet):
         if not room:
             raise NotFoundError("Room not found")
 
-        event_ids = await self._storage_controllers.state.get_current_state_ids(room_id)
+        state_filter = None
+        type = parse_string(request, "type")
+
+        if type:
+            if not type.startswith("m.room."):
+                raise SynapseError(
+                    HTTPStatus.BAD_REQUEST,
+                    "Type must be a room state event.",
+                )
+            state_filter = StateFilter(
+                types=immutabledict({type: None}),
+                include_others=False,
+            )
+
+        event_ids = await self._storage_controllers.state.get_current_state_ids(
+            room_id, state_filter
+        )
         events = await self.store.get_events(event_ids.values())
         now = self.clock.time_msec()
         room_state = await self._event_serializer.serialize_events(events.values(), now)

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -2058,12 +2058,12 @@ class RoomTestCase(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            f"/_synapse/admin/v1/rooms/{room_id}/state?type=''",
+            f"/_synapse/admin/v1/rooms/{room_id}/state?type=",
             access_token=self.admin_user_tok,
         )
         self.assertEqual(200, channel.code)
         state = channel.json_body["state"]
-        self.assertEqual(0, len(state))
+        self.assertEqual(5, len(state))
 
     def test_room_state_param_not_in_room(self) -> None:
         """


### PR DESCRIPTION
Adds a query param `type` to `/_synapse/admin/v1/rooms/{room_id}/state` that filters the state event query by state event type. 
