### PR TITLE
Add an admin endpoint to fetch the participants in a room

### DIFF
--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -371,6 +371,30 @@ A response body like the following is returned:
 }
 ```
 
+# Room Participants
+
+The room participants API allows the admin to get a list of current room members who have
+also posted to the room.
+
+The API is:
+
+```
+GET /_synapse/admin/v1/rooms/<room_id>/participants
+```
+
+A response body like the following is returned:
+
+```json
+{
+  "participants": [
+    "@foo:matrix.org",
+    "@bar:matrix.org",
+    "@foobar:matrix.org"
+  ]
+}
+```
+
+
 # Room State API
 
 The Room State admin API allows server admins to get a list of all state events in a room.

--- a/synapse/rest/admin/__init__.py
+++ b/synapse/rest/admin/__init__.py
@@ -81,6 +81,7 @@ from synapse.rest.admin.rooms import (
     RoomEventContextServlet,
     RoomMembersRestServlet,
     RoomMessagesRestServlet,
+    RoomParticipantsRestServlet,
     RoomRestServlet,
     RoomRestV2Servlet,
     RoomStateRestServlet,
@@ -320,6 +321,7 @@ def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:
     ListDestinationsRestServlet(hs).register(http_server)
     RoomMessagesRestServlet(hs).register(http_server)
     RoomTimestampToEventRestServlet(hs).register(http_server)
+    RoomParticipantsRestServlet(hs).register(http_server)
     UserReplaceMasterCrossSigningKeyRestServlet(hs).register(http_server)
     UserByExternalId(hs).register(http_server)
     UserByThreePid(hs).register(http_server)


### PR DESCRIPTION
Adds an admin endpoint `GET /_synapse/admin/v1/rooms/{room_id}/participants` which returns a list of all currently joined room members who have also posted to the room. 