### PR TITLE
Fix incorrect port mapping in docker-compose.yml

### DIFF
--- a/changelog.d/18047.docker
+++ b/changelog.d/18047.docker
@@ -1,1 +1,0 @@
-Fix incorrect port mapping in `docker-compose.yml`. Contributed by @Kuan-Lun.

--- a/changelog.d/18047.docker
+++ b/changelog.d/18047.docker
@@ -1,0 +1,1 @@
+Fix incorrect port mapping in `docker-compose.yml`. Contributed by @Kuan-Lun.

--- a/changelog.d/18051.docker
+++ b/changelog.d/18051.docker
@@ -1,0 +1,1 @@
+Fix incorrect port mapping in `docker-compose.yml`. Contributed by @Kuan-Lun.

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     # In order to expose Synapse, remove one of the following, you might for
     # instance expose the TLS port directly:
     ports:
-      - 8448:8448/tcp
+      - 8448:8008/tcp
     # ... or use a reverse proxy, here is an example for traefik:
     labels:
       # The following lines are valid for Traefik version 1.x:


### PR DESCRIPTION
The port mapping for the Synapse service was incorrectly set to `8448:8448/tcp`. This has been corrected to `8448:8008/tcp` to match the Traefik configuration, which specifies the backend service port as `8008` using the `traefik.http.services.synapse.loadbalancer.server.port`.
