### PR TITLE
Drop unstable MSC4151 implementation

### DIFF
--- a/changelog.d/18052.removal
+++ b/changelog.d/18052.removal
@@ -1,0 +1,1 @@
+Remove the unstable [MSC4151](https://github.com/matrix-org/matrix-spec-proposals/pull/4151) implementation. The stable support remains, per [Matrix 1.13](https://spec.matrix.org/v1.13/client-server-api/#post_matrixclientv3roomsroomidreport).

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -436,9 +436,6 @@ class ExperimentalConfig(Config):
                 ("experimental", "msc4108_delegation_endpoint"),
             )
 
-        # MSC4151: Report room API (Client-Server API)
-        self.msc4151_enabled: bool = experimental.get("msc4151_enabled", False)
-
         # MSC4210: Remove legacy mentions
         self.msc4210_enabled: bool = experimental.get("msc4210_enabled", False)
 

--- a/synapse/rest/client/reporting.py
+++ b/synapse/rest/client/reporting.py
@@ -127,16 +127,6 @@ class ReportRoomRestServlet(RestServlet):
         self.clock = hs.get_clock()
         self.store = hs.get_datastores().main
 
-        # TODO: Remove the unstable variant after 2-3 releases
-        # https://github.com/element-hq/synapse/issues/17373
-        if hs.config.experimental.msc4151_enabled:
-            self.PATTERNS.append(
-                re.compile(
-                    f"^{CLIENT_API_PREFIX}/unstable/org.matrix.msc4151"
-                    "/rooms/(?P<room_id>[^/]*)/report$"
-                )
-            )
-
     class PostBody(RequestBodyModel):
         reason: StrictStr
 

--- a/synapse/rest/client/reporting.py
+++ b/synapse/rest/client/reporting.py
@@ -20,13 +20,11 @@
 #
 
 import logging
-import re
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Tuple
 
 from synapse._pydantic_compat import StrictStr
 from synapse.api.errors import AuthError, Codes, NotFoundError, SynapseError
-from synapse.api.urls import CLIENT_API_PREFIX
 from synapse.http.server import HttpServer
 from synapse.http.servlet import (
     RestServlet,

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -170,8 +170,6 @@ class VersionsRestServlet(RestServlet):
                     ),
                     # MSC4140: Delayed events
                     "org.matrix.msc4140": bool(self.config.server.max_event_delay_ms),
-                    # MSC4151: Report room API (Client-Server API)
-                    "org.matrix.msc4151": self.config.experimental.msc4151_enabled,
                     # Simplified sliding sync
                     "org.matrix.simplified_msc3575": msc3575_enabled,
                 },


### PR DESCRIPTION
It's been rotated out of known clients, and should be safe for removal now.

Fixes https://github.com/element-hq/synapse/issues/17373

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
