### PR TITLE
Fix overly restrictive typeguards in get_rooms_that_allow_join

### DIFF
--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -21,6 +21,8 @@
 import logging
 from typing import TYPE_CHECKING, List, Mapping, Optional, Union
 
+from immutabledict import immutabledict
+
 from synapse import event_auth
 from synapse.api.constants import (
     EventTypes,
@@ -326,13 +328,13 @@ class EventAuthHandler:
 
         # If allowed is of the wrong form, then only allow invited users.
         allow_list = join_rules_event.content.get("allow", [])
-        if not isinstance(allow_list, list):
+        if not isinstance(allow_list, (list, tuple)):
             return ()
 
         # Pull out the other room IDs, invalid data gets filtered.
         result = []
         for allow in allow_list:
-            if not isinstance(allow, dict):
+            if not isinstance(allow, (immutabledict, dict)):
                 continue
 
             # If the type is unexpected, skip it.


### PR DESCRIPTION
This was causing a bug that was only occuring when the server had modules loaded and there were unjoined space-visible rooms in a hierarchy.

This fix is a result of the following investigation: Symptom: new 'space-visible' rooms are not showing up in /hierarchy Reason: because get_rooms_that_allow_join is checking that the allow key is a list, and it's coming back as a tuple https://github.com/element-hq/synapse/blob/develop/synapse/handlers/event_auth.py#L329

-> Reason: when the room is created, the join_rules event calls check_event_allowed - https://github.com/element-hq/synapse/blob/develop/synapse/handlers/message.py#L1289 - which calls event.freeze() which seems to be changing lists to tuples - https://github.com/element-hq/synapse/blob/develop/synapse/module_api/callbacks/third_party_event_rules_callbacks.py#L294 --> so that when the event is being pulled from cache, the allow list is a tuple. But when I restart the server, it gets pulled from the DB and deserialized as a list.

### Pull Request Checklist

* [X] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
