### PR TITLE
Add a column `participant` to `room_membership` table

### DIFF
--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1440,6 +1440,9 @@ class EventCreationHandler:
                     )
                     return prev_event
 
+            if event.type == "m.room.message":
+                await self.store.set_room_participation(event.room_id, event.user_id)
+
             if event.internal_metadata.is_out_of_band_membership():
                 # the only sort of out-of-band-membership events we expect to see here are
                 # invite rejections and rescinded knocks that we have generated ourselves.

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -1606,6 +1606,35 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
             from_ts,
         )
 
+    async def set_room_participation(self, room_id: str, user_id: str) -> None:
+        """
+        Record the provided user as participating in the given room
+
+        Args:
+            room_id: ID of the room to set the participant in
+            user_id: the user ID of the user
+        """
+        await self.db_pool.simple_update(
+            "room_memberships",
+            {"user_id": user_id, "room_id": room_id},
+            {"participant": True},
+            "update_room_participation",
+        )
+
+    async def get_room_participation(self, room_id: str, user_id: str) -> bool:
+        """
+        Check whether a user is listed as a participant in a room
+
+        Args:
+            room_id: ID of the room to check in
+            user_id: user ID of the user
+        """
+        return await self.db_pool.simple_select_one_onecol(
+            "room_memberships",
+            {"user_id": user_id, "room_id": room_id},
+            "participant",
+        )
+
 
 class RoomMemberBackgroundUpdateStore(SQLBaseStore):
     def __init__(

--- a/synapse/storage/schema/__init__.py
+++ b/synapse/storage/schema/__init__.py
@@ -19,7 +19,7 @@
 #
 #
 
-SCHEMA_VERSION = 88  # remember to update the list below when updating
+SCHEMA_VERSION = 89  # remember to update the list below when updating
 """Represents the expectations made by the codebase about the database schema
 
 This should be incremented whenever the codebase changes its requirements on the
@@ -155,6 +155,9 @@ Changes in SCHEMA_VERSION = 88
       be posted in response to a resettable timeout or an on-demand action.
     - Add background update to fix data integrity issue in the
       `sliding_sync_membership_snapshots` -> `forgotten` column
+
+Changes in SCHEMA_VERSION = 89
+    - Add a column `participant` to `room_memberships` table
 """
 
 

--- a/synapse/storage/schema/main/delta/89/01_add_column_participant_room_memberships_table.sql
+++ b/synapse/storage/schema/main/delta/89/01_add_column_participant_room_memberships_table.sql
@@ -1,0 +1,20 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2025 New Vector, Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+-- Add a column `participant` to `room_memberships` table to track whether a room member has sent
+-- a `m.room.message` event into a room they are a member of
+ALTER TABLE room_memberships ADD COLUMN participant BOOLEAN DEFAULT FALSE;
+
+-- Add a background update to populate `participant` column
+INSERT INTO background_updates (ordering, update_name, progress_json) VALUES
+  (8901, 'populate_participant_bg_update', '{}');


### PR DESCRIPTION
Adds a column `participant` to `room_memberships` table to track whether a user has participated in a room - participation is defined as having sent a `m.room.message` event into the room. 

Related to #18040, the approach there to determine room participation was deemed too inefficient and adding this column was the recommend remedy. 