### PR TITLE
appservice: Add {as,hs}_token_path config options

### DIFF
--- a/changelog.d/18071.feature
+++ b/changelog.d/18071.feature
@@ -1,0 +1,1 @@
+Add appservice config options `as_token_path` and `hs_token_path`.

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -27,6 +27,7 @@ from parameterized import parameterized
 
 from synapse.config import ConfigError
 from synapse.config._base import RootConfig
+from synapse.config.appservice import _load_appservice
 from synapse.config.homeserver import HomeServerConfig
 
 from tests.config.utils import ConfigFileTestCase
@@ -179,3 +180,39 @@ class ConfigLoadingFileTestCase(ConfigFileTestCase):
             config = HomeServerConfig.load_config("", ["-c", self.config_file])
 
             self.assertEqual(get_secret(config), b"53C237")
+
+    def test_secret_files_appservice(self) -> None:
+        with tempfile.NamedTemporaryFile(buffering=0) as token_file:
+            token_file.write(b"53C237")
+
+            as_info = {
+                "id": "fake-as-id",
+                "url": "example.org",
+                "as_token_path": token_file.name,
+                "hs_token_path": token_file.name,
+                "sender_localpart": "not-real-part",
+                "namespaces": {},
+            }
+
+            appservice = _load_appservice(
+                hostname="example.org",
+                as_info=as_info,
+                config_filename="mock-config-file.name",
+            )
+
+            self.assertEqual(appservice.token, "53C237")
+            self.assertEqual(appservice.hs_token, "53C237")
+
+            with self.assertRaises(ConfigError):
+                _load_appservice(
+                    hostname="example.org",
+                    as_info={**as_info, "as_token_path": "/does/not/exist"},
+                    config_filename="mock-config-file.name",
+                )
+
+            with self.assertRaises(ConfigError):
+                _load_appservice(
+                    hostname="example.org",
+                    as_info={**as_info, "hs_token_path": "/does/not/exist"},
+                    config_filename="mock-config-file.name",
+                )


### PR DESCRIPTION
Adds the config options `as_token_path` and `hs_token_path` to the application service configuration. A gratis unit test is part of the deal!

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
