### PR TITLE
Add --no-secrets-in-config command line option

### DIFF
--- a/changelog.d/18092.feature
+++ b/changelog.d/18092.feature
@@ -1,0 +1,1 @@
+Add the `--no-secrets-in-config` command line option.

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -574,6 +574,14 @@ class RootConfig:
             " Defaults to the directory containing the last config file",
         )
 
+        config_parser.add_argument(
+            "--no-secrets-in-config",
+            dest="secrets_in_config",
+            action="store_false",
+            default=True,
+            help="Reject config options that expect an in-line secret as value.",
+        )
+
         cls.invoke_all_static("add_arguments", config_parser)
 
     @classmethod
@@ -611,7 +619,10 @@ class RootConfig:
 
         config_dict = read_config_files(config_files)
         obj.parse_config_dict(
-            config_dict, config_dir_path=config_dir_path, data_dir_path=data_dir_path
+            config_dict,
+            config_dir_path=config_dir_path,
+            data_dir_path=data_dir_path,
+            allow_secrets_in_config=config_args.secrets_in_config,
         )
 
         obj.invoke_all("read_arguments", config_args)
@@ -637,6 +648,13 @@ class RootConfig:
             metavar="CONFIG_FILE",
             help="Specify config file. Can be given multiple times and"
             " may specify directories containing *.yaml files.",
+        )
+        parser.add_argument(
+            "--no-secrets-in-config",
+            dest="secrets_in_config",
+            action="store_false",
+            default=True,
+            help="Reject config options that expect an in-line secret as value.",
         )
 
         # we nest the mutually-exclusive group inside another group so that the help
@@ -806,14 +824,21 @@ class RootConfig:
             return None
 
         obj.parse_config_dict(
-            config_dict, config_dir_path=config_dir_path, data_dir_path=data_dir_path
+            config_dict,
+            config_dir_path=config_dir_path,
+            data_dir_path=data_dir_path,
+            allow_secrets_in_config=config_args.secrets_in_config,
         )
         obj.invoke_all("read_arguments", config_args)
 
         return obj
 
     def parse_config_dict(
-        self, config_dict: Dict[str, Any], config_dir_path: str, data_dir_path: str
+        self,
+        config_dict: Dict[str, Any],
+        config_dir_path: str,
+        data_dir_path: str,
+        allow_secrets_in_config: bool = True,
     ) -> None:
         """Read the information from the config dict into this Config object.
 
@@ -831,6 +856,7 @@ class RootConfig:
             config_dict,
             config_dir_path=config_dir_path,
             data_dir_path=data_dir_path,
+            allow_secrets_in_config=allow_secrets_in_config,
         )
 
     def generate_missing_files(

--- a/synapse/config/_base.pyi
+++ b/synapse/config/_base.pyi
@@ -132,7 +132,11 @@ class RootConfig:
     @classmethod
     def invoke_all_static(cls, func_name: str, *args: Any, **kwargs: Any) -> None: ...
     def parse_config_dict(
-        self, config_dict: Dict[str, Any], config_dir_path: str, data_dir_path: str
+        self,
+        config_dict: Dict[str, Any],
+        config_dir_path: str,
+        data_dir_path: str,
+        allow_secrets_in_config: bool = ...,
     ) -> None: ...
     def generate_config(
         self,

--- a/synapse/config/captcha.py
+++ b/synapse/config/captcha.py
@@ -29,8 +29,15 @@ from ._base import Config, ConfigError
 class CaptchaConfig(Config):
     section = "captcha"
 
-    def read_config(self, config: JsonDict, **kwargs: Any) -> None:
+    def read_config(
+        self, config: JsonDict, allow_secrets_in_config: bool, **kwargs: Any
+    ) -> None:
         recaptcha_private_key = config.get("recaptcha_private_key")
+        if recaptcha_private_key and not allow_secrets_in_config:
+            raise ConfigError(
+                "Config options that expect an in-line secret as value are disabled",
+                ("recaptcha_private_key",),
+            )
         if recaptcha_private_key is not None and not isinstance(
             recaptcha_private_key, str
         ):
@@ -38,6 +45,11 @@ class CaptchaConfig(Config):
         self.recaptcha_private_key = recaptcha_private_key
 
         recaptcha_public_key = config.get("recaptcha_public_key")
+        if recaptcha_public_key and not allow_secrets_in_config:
+            raise ConfigError(
+                "Config options that expect an in-line secret as value are disabled",
+                ("recaptcha_public_key",),
+            )
         if recaptcha_public_key is not None and not isinstance(
             recaptcha_public_key, str
         ):

--- a/synapse/config/key.py
+++ b/synapse/config/key.py
@@ -112,7 +112,11 @@ class KeyConfig(Config):
     section = "key"
 
     def read_config(
-        self, config: JsonDict, config_dir_path: str, **kwargs: Any
+        self,
+        config: JsonDict,
+        config_dir_path: str,
+        allow_secrets_in_config: bool,
+        **kwargs: Any,
     ) -> None:
         # the signing key can be specified inline or in a separate file
         if "signing_key" in config:
@@ -172,6 +176,11 @@ class KeyConfig(Config):
         )
 
         macaroon_secret_key = config.get("macaroon_secret_key")
+        if macaroon_secret_key and not allow_secrets_in_config:
+            raise ConfigError(
+                "Config options that expect an in-line secret as value are disabled",
+                ("macaroon_secret_key",),
+            )
         macaroon_secret_key_path = config.get("macaroon_secret_key_path")
         if macaroon_secret_key_path:
             if macaroon_secret_key:
@@ -193,6 +202,11 @@ class KeyConfig(Config):
         # a secret which is used to calculate HMACs for form values, to stop
         # falsification of values
         self.form_secret = config.get("form_secret", None)
+        if self.form_secret and not allow_secrets_in_config:
+            raise ConfigError(
+                "Config options that expect an in-line secret as value are disabled",
+                ("form_secret",),
+            )
 
     def generate_config_section(
         self,

--- a/synapse/config/redis.py
+++ b/synapse/config/redis.py
@@ -34,7 +34,9 @@ These are mutually incompatible.
 class RedisConfig(Config):
     section = "redis"
 
-    def read_config(self, config: JsonDict, **kwargs: Any) -> None:
+    def read_config(
+        self, config: JsonDict, allow_secrets_in_config: bool, **kwargs: Any
+    ) -> None:
         redis_config = config.get("redis") or {}
         self.redis_enabled = redis_config.get("enabled", False)
 
@@ -48,6 +50,11 @@ class RedisConfig(Config):
         self.redis_path = redis_config.get("path", None)
         self.redis_dbid = redis_config.get("dbid", None)
         self.redis_password = redis_config.get("password")
+        if self.redis_password and not allow_secrets_in_config:
+            raise ConfigError(
+                "Config options that expect an in-line secret as value are disabled",
+                ("redis", "password"),
+            )
         redis_password_path = redis_config.get("password_path")
         if redis_password_path:
             if self.redis_password:

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -43,7 +43,9 @@ You have configured both `registration_shared_secret` and
 class RegistrationConfig(Config):
     section = "registration"
 
-    def read_config(self, config: JsonDict, **kwargs: Any) -> None:
+    def read_config(
+        self, config: JsonDict, allow_secrets_in_config: bool, **kwargs: Any
+    ) -> None:
         self.enable_registration = strtobool(
             str(config.get("enable_registration", False))
         )
@@ -68,6 +70,11 @@ class RegistrationConfig(Config):
 
         # read the shared secret, either inline or from an external file
         self.registration_shared_secret = config.get("registration_shared_secret")
+        if self.registration_shared_secret and not allow_secrets_in_config:
+            raise ConfigError(
+                "Config options that expect an in-line secret as value are disabled",
+                ("registration_shared_secret",),
+            )
         registration_shared_secret_path = config.get("registration_shared_secret_path")
         if registration_shared_secret_path:
             if self.registration_shared_secret:

--- a/synapse/config/voip.py
+++ b/synapse/config/voip.py
@@ -34,9 +34,16 @@ These are mutually incompatible.
 class VoipConfig(Config):
     section = "voip"
 
-    def read_config(self, config: JsonDict, **kwargs: Any) -> None:
+    def read_config(
+        self, config: JsonDict, allow_secrets_in_config: bool, **kwargs: Any
+    ) -> None:
         self.turn_uris = config.get("turn_uris", [])
         self.turn_shared_secret = config.get("turn_shared_secret")
+        if self.turn_shared_secret and not allow_secrets_in_config:
+            raise ConfigError(
+                "Config options that expect an in-line secret as value are disabled",
+                ("turn_shared_secret",),
+            )
         turn_shared_secret_path = config.get("turn_shared_secret_path")
         if turn_shared_secret_path:
             if self.turn_shared_secret:


### PR DESCRIPTION
Adds the `--no-secrets-in-config` command line option that makes Synapse reject all configurations containing keys with in-line secret values. Currently this rejects

- `turn_shared_secret`
- `registration_shared_secret`
- `macaroon_secret_key`
- `recaptcha_private_key`
- `recaptcha_public_key`
- `experimental_features.client_secret`
- `experimental_features.jwk`
- `experimental_features.admin_token`
- `form_secret`
- `redis.password`

This PR complements my other PRs[^1] that add the corresponding `_path` variants for this class of config options. It enables admins to enforce a policy of no secrets in configuration files and guards against accident and malice.

Because I consider the flag `--no-secrets-in-config` to be security-relevant, I did not add a corresponding `--secrets-in-config` flag; this way, if Synapse command line options are appended at various places, there is no way to weaken the once-set setting with a succeeding flag.

[^1]: [#17690](https://github.com/element-hq/synapse/pull/17690), [#17717](https://github.com/element-hq/synapse/pull/17717), [#17983](https://github.com/element-hq/synapse/pull/17983), [#17984](https://github.com/element-hq/synapse/pull/17984), [#18004](https://github.com/element-hq/synapse/pull/18004), [#18090](https://github.com/element-hq/synapse/pull/18090)


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
