### PR TITLE
OIDC: increase length of generated `nonce` parameter from 30->32 chars

### DIFF
--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -1002,7 +1002,7 @@ class OidcProvider:
         """
 
         state = generate_token()
-        nonce = generate_token()
+        nonce = generate_token(length=32)
         code_verifier = ""
 
         if not client_redirect_url:


### PR DESCRIPTION
This PR slightly increases the character length (and thus the entropy) of the `nonce` value (from the default 30 characters -> 32 characters) that Synapse generates when performing an OIDC login.

This is so that Synapse's OIDC implementation complies with [the relevant portion of the TI-Messenger spec](https://gemspec.gematik.de/docs/gemSpec/gemSpec_IDP_FD/gemSpec_IDP_FD_V1.7.3/#A_24833) - which aims to standardise Matrix as the communication layer for healthcare in Germany.

The spec requires (translation via Google Translate):

> The Authorization Server service MUST generate a nonce (random value) at runtime in accordance with [ [RFC7636 # section-4.1](https://tools.ietf.org/html/rfc7636#section-4.1) ]. The `nonce` MUST contain an entropy of at least 43 and a maximum of 128 characters.

We clarified with Gematik (the German government body in charge of writing this spec) what they meant exactly by "an entropy of at least 43". They replied that they meant to write "43 characters".

When sent to the Identity Provider, the `nonce` value is encoded using [base64url](https://datatracker.ietf.org/doc/html/rfc4648#section-5). A 32 character string encoded to base64url results in a 43 character length string. Thus, this change aligns Synapse's generated `nonce` value with the spec.

---

While this change is intended to satisfy an external spec, the change only increases security (while only adding three extra bytes to a request). The matrix spec does not cover this flow, instead (rightly) offloading it to [RFC7636](https://datatracker.ietf.org/doc/html/rfc7636#section-4.1). That RFC only demands a 43 character length for the `code_verifier` parameter, which Synapse [does comply with](https://github.com/element-hq/synapse/blob/39bd6e2c167dd2c8b1b46ea449f34ecf072fd614/synapse/handlers/oidc.py#L1018). Whereas Gematik have opted to adapt that length requirement to the `nonce` parameter as well.