### PR TITLE
[sso] Remove external ids when user is deactivated

### DIFF
--- a/changelog.d/18110.bugfix
+++ b/changelog.d/18110.bugfix
@@ -1,0 +1,1 @@
+When deactivating a user, delete mappings to its external identities (sso).

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -184,6 +184,9 @@ class DeactivateAccountHandler:
         # Remove account data (including ignored users and push rules).
         await self.store.purge_account_data_for_user(user_id)
 
+        # remove mappings to external identities
+        await self.store.remove_external_ids_by_user(user_id)
+
         # Delete any server-side backup keys
         await self.store.bulk_delete_backup_keys_and_versions_for_user(user_id)
 

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -790,6 +790,25 @@ class RegistrationWorkerStore(CacheInvalidationWorkerStore):
             desc="remove_user_external_id",
         )
 
+    async def remove_external_ids_by_user(
+        self, user_id: str
+    ) -> None:
+        """Remove all mappings from external user ids to a mxid
+        If no mappings are not found, this method does nothing.
+
+        Args:
+            user_id: complete mxid that it is mapped to
+        """
+
+        await self.db_pool.simple_delete(
+            table="user_external_ids",
+            keyvalues={
+                "user_id": user_id,
+            },
+            desc="remove_external_ids_by_user",
+        )
+    
+
     async def replace_user_external_id(
         self,
         record_external_ids: List[Tuple[str, str]],

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -807,7 +807,6 @@ class RegistrationWorkerStore(CacheInvalidationWorkerStore):
             },
             desc="remove_external_ids_by_user",
         )
-    
 
     async def replace_user_external_id(
         self,


### PR DESCRIPTION
Issue : https://github.com/element-hq/synapse/issues/11072

When deactivating a user, delete its external identities. 

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
