### PR TITLE
Raise an error if someone is using an incorrect suffix in a config duration string

### DIFF
--- a/changelog.d/18112.bugfix
+++ b/changelog.d/18112.bugfix
@@ -1,0 +1,1 @@
+Raise an error if someone is using an incorrect suffix in a config duration string.

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -258,7 +258,9 @@ class Config:
 
             return int(value) * size
         else:
-            raise TypeError(f"Bad duration {value!r}")
+            raise TypeError(
+                f"Bad duration type {value!r} (expected int or string duration)"
+            )
 
     @staticmethod
     def abspath(file_path: str) -> str:

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -221,7 +221,8 @@ class Config:
             The number of milliseconds in the duration.
 
         Raises:
-            TypeError, if given something other than an integer or a string
+            TypeError: if given something other than an integer or a string, or the
+                duration is using an incorrect suffix.
             ValueError: if given a string not of the form described above.
         """
         if type(value) is int:  # noqa: E721
@@ -246,6 +247,15 @@ class Config:
             if suffix in sizes:
                 value = value[:-1]
                 size = sizes[suffix]
+            elif suffix.isdigit():
+                #  No suffix is treated as milliseconds.
+                value = value
+                size = 1
+            else:
+                raise TypeError(
+                    f"Bad duration suffix {value} (expected no suffix or one of these suffixes: {sizes.keys()})"
+                )
+
             return int(value) * size
         else:
             raise TypeError(f"Bad duration {value!r}")

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -225,6 +225,9 @@ class Config:
                 duration is using an incorrect suffix.
             ValueError: if given a string not of the form described above.
         """
+        # For integers, we prefer to use `type(value) is int` instead of
+        # `isinstance(value, int)` because we want to exclude subclasses of int, such as
+        # bool.
         if type(value) is int:  # noqa: E721
             return value
         elif isinstance(value, str):


### PR DESCRIPTION
Raise an error if someone is using an incorrect suffix in a config duration string.

Previously, a value like `5q` would be interpreted as 5 milliseconds. We should just raise an error instead of letting someone run with a misconfiguration.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
