### PR TITLE
Allow (un)block_room storage functions to be called on workers

### DIFF
--- a/changelog.d/18119.bugfix
+++ b/changelog.d/18119.bugfix
@@ -1,0 +1,1 @@
+Allow room block and unblock storage functions to be called on workers.

--- a/changelog.d/18119.bugfix
+++ b/changelog.d/18119.bugfix
@@ -1,1 +1,1 @@
-Allow room block and unblock storage functions to be called on workers.
+Fix a bug where the [Delete Room Admin API](https://element-hq.github.io/synapse/latest/admin_api/rooms.html#version-2-new-version) would fail if the `block` parameter was set to `true` and a worker other than the main process was configured to handle background tasks.


### PR DESCRIPTION
This is so workers can call these functions.

This was preventing the [Delete Room Admin API](https://element-hq.github.io/synapse/latest/admin_api/rooms.html#version-2-new-version) from succeeding when `block: true` was specified. This was because we had `run_background_tasks_on` configured to run on a separate worker.

As workers weren't able to call the `block_room` storage function before this PR, the (delete room) task failed when taken off the queue by the worker.