### PR TITLE
Document missing server config options

### DIFF
--- a/changelog.d/18122.doc
+++ b/changelog.d/18122.doc
@@ -1,0 +1,1 @@
+Document missing server config options (`daemonize`, `print_pidfile`, `user_agent_suffix`, `use_frozen_dicts`, `manhole`).

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -162,6 +162,53 @@ Example configuration:
 pid_file: DATADIR/homeserver.pid
 ```
 ---
+### `daemonize`
+
+Specifies whether Synapse should be started as a daemon process. If Synapse is being
+managed by [systemd](../../systemd-with-workers/), this option must be omitted or set to
+`false`.
+
+This can also be set by the `--daemonize` (`-D`) argument when starting Synapse.
+
+See [`worker_daemonize`](TODO) for more information on daemonizing workers.
+
+Example configuration:
+```yaml
+daemonize: true
+```
+---
+### `print_pidfile`
+
+Print the path to the pidfile just before daemonizing. Defaults to false.
+
+This can also be set by the `--print-pidfile` argument when starting Synapse.
+
+Example configuration:
+```yaml
+print_pidfile: true
+```
+---
+### `user_agent_suffix`
+
+A suffix that is appended to the Synapse user-agent (ex. `Synapse/v1.123.0`). Defaults
+to None
+
+Example configuration:
+```yaml
+user_agent_suffix: " (I'm a teapot; Linux x86_64)"
+```
+---
+### `use_frozen_dicts`
+
+Determines whether we should freeze the internal dict object in `FrozenEvent`. Freezing
+prevents bugs where we accidentally share e.g. signature dicts. However, freezing a
+dict is expensive. Defaults to false.
+
+Example configuration:
+```yaml
+use_frozen_dicts: true
+```
+---
 ### `web_client_location`
 
 The absolute URL to the web client which `/` will redirect to. Defaults to none.
@@ -595,6 +642,15 @@ listeners:
       - names: [client, federation]
 ```
 
+---
+### `manhole`
+
+Turn on the Twisted telnet manhole service on the given port. Defaults to none.
+
+Example configuration:
+```yaml
+manhole: 1234
+```
 ---
 ### `manhole_settings`
 

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -170,7 +170,7 @@ managed by [systemd](../../systemd-with-workers/), this option must be omitted o
 
 This can also be set by the `--daemonize` (`-D`) argument when starting Synapse.
 
-See [`worker_daemonize`](TODO) for more information on daemonizing workers.
+See `worker_daemonize` for more information on daemonizing workers.
 
 Example configuration:
 ```yaml
@@ -646,6 +646,8 @@ listeners:
 ### `manhole`
 
 Turn on the Twisted telnet manhole service on the given port. Defaults to none.
+
+This can also be set by the `--manhole` argument when starting Synapse.
 
 Example configuration:
 ```yaml

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -53,17 +53,16 @@ from synapse.util.stringutils import strtobool
 if TYPE_CHECKING:
     from synapse.events.builder import EventBuilder
 
+# Whether we should use frozen_dict in FrozenEvent. Using frozen_dicts prevents
+# bugs where we accidentally share e.g. signature dicts. However, converting a
+# dict to frozen_dicts is expensive.
+#
+# NOTE: This is overridden by the configuration by the Synapse worker apps, but
+# for the sake of tests, it is set here while it cannot be configured on the
+# homeserver object itself.
 
-USE_FROZEN_DICTS = False
-"""
-Whether we should use frozen_dict in FrozenEvent. Using frozen_dicts prevents
-bugs where we accidentally share e.g. signature dicts. However, converting a
-dict to frozen_dicts is expensive.
+USE_FROZEN_DICTS = strtobool(os.environ.get("SYNAPSE_USE_FROZEN_DICTS", "0"))
 
-NOTE: This is overridden by the configuration by the Synapse worker apps, but
-for the sake of tests, it is set here because it cannot be configured on the
-homeserver object itself.
-"""
 
 T = TypeVar("T")
 

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -53,16 +53,17 @@ from synapse.util.stringutils import strtobool
 if TYPE_CHECKING:
     from synapse.events.builder import EventBuilder
 
-# Whether we should use frozen_dict in FrozenEvent. Using frozen_dicts prevents
-# bugs where we accidentally share e.g. signature dicts. However, converting a
-# dict to frozen_dicts is expensive.
-#
-# NOTE: This is overridden by the configuration by the Synapse worker apps, but
-# for the sake of tests, it is set here while it cannot be configured on the
-# homeserver object itself.
 
-USE_FROZEN_DICTS = strtobool(os.environ.get("SYNAPSE_USE_FROZEN_DICTS", "0"))
+USE_FROZEN_DICTS = False
+"""
+Whether we should use frozen_dict in FrozenEvent. Using frozen_dicts prevents
+bugs where we accidentally share e.g. signature dicts. However, converting a
+dict to frozen_dicts is expensive.
 
+NOTE: This is overridden by the configuration by the Synapse worker apps, but
+for the sake of tests, it is set here because it cannot be configured on the
+homeserver object itself.
+"""
 
 T = TypeVar("T")
 


### PR DESCRIPTION
I was looking into the `USE_FROZEN_DICTS` option during the review of https://github.com/element-hq/synapse/pull/18103#discussion_r1935876168 and noticed that there are several other server config options that aren't in the docs.


### Dev notes

https://github.com/element-hq/synapse/blob/a9361c4f51ab35a7dd4955dfdb3db7c57ae2bc9b/synapse/config/server.py#L421-L424

https://github.com/element-hq/synapse/blob/a9361c4f51ab35a7dd4955dfdb3db7c57ae2bc9b/synapse/config/server.py#L774

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
