### PR TITLE
Fix internal server error when updating 3pid address with invalid email

### DIFF
--- a/changelog.d/18125.bugfix
+++ b/changelog.d/18125.bugfix
@@ -1,0 +1,1 @@
+Fix a bug when updating a user 3pid with invalid returns 500 server error change to 400 with a message

--- a/changelog.d/18125.bugfix
+++ b/changelog.d/18125.bugfix
@@ -1,1 +1,1 @@
-Fix a bug when updating a user 3pid with invalid returns 500 server error change to 400 with a message
+Fix a bug when updating a user 3pid with invalid returns 500 server error change to 400 with a message.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -1579,7 +1579,10 @@ class AuthHandler:
         # for the presence of an email address during password reset was
         # case sensitive).
         if medium == "email":
-            address = canonicalise_email(address)
+            try:
+                address = canonicalise_email(address)
+            except ValueError as e:
+                raise SynapseError(400, str(e))
 
         await self.store.user_add_threepid(
             user_id, medium, address, validated_at, self.hs.get_clock().time_msec()
@@ -1610,7 +1613,10 @@ class AuthHandler:
         """
         # 'Canonicalise' email addresses as per above
         if medium == "email":
-            address = canonicalise_email(address)
+            try:
+                address = canonicalise_email(address)
+            except ValueError as e:
+                raise SynapseError(400, str(e))
 
         await self.store.user_delete_threepid(user_id, medium, address)
 


### PR DESCRIPTION
When updating 3pid for a user email from admin api and sending invalid email the server throws 500 internal server error.
changed to 400 Bad request and returned the error message
### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
