### PR TITLE
Add option to disable presence tracking for offline devices.

### DIFF
--- a/changelog.d/18132.feature
+++ b/changelog.d/18132.feature
@@ -1,0 +1,1 @@
+Add option to disable presence tracking for offline devices.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -386,6 +386,11 @@ class ServerConfig(Config):
         self.presence_enabled = bool(presence_enabled)
         # Whether to internally track presence, requires that presence is enabled,
         self.track_presence = self.presence_enabled and presence_enabled != "untracked"
+        self.track_offline_presence = (
+            self.presence_enabled
+            and self.track_presence
+            and presence_enabled != "offline_untracked"
+        )
 
         # Determines if presence results for offline users are included on initial/full sync
         self.presence_include_offline_users_on_sync = presence_config.get(


### PR DESCRIPTION
This pull request adds the option `offline_untracked` to the `presence.enabled` configuration. This prevents synapse from updating the `last_active_ts` when receiving events from a client which is currently offline. 

This would improve privacy by enabling users to decide whether they want their activity seen by other users with a shared room.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
