### PR TITLE
Add method to get current server time in milliseconds in ModuleApi

### DIFF
--- a/changelog.d/18144.feature
+++ b/changelog.d/18144.feature
@@ -1,1 +1,1 @@
-Introduced the get_current_time method in ModuleApi to provide the current server time in milliseconds, as wrapper around self.module_api._clock.time_msec() to avoid accessing private variables
+Add `get_current_time()` method to the [module API](https://matrix-org.github.io/synapse/latest/modules/writing_a_module.html) for sound time comparisons with Synapse.

--- a/changelog.d/18144.feature
+++ b/changelog.d/18144.feature
@@ -1,1 +1,1 @@
-Add `get_current_time()` method to the [module API](https://matrix-org.github.io/synapse/latest/modules/writing_a_module.html) for sound time comparisons with Synapse.
+Add `get_current_time_msec()` method to the [module API](https://matrix-org.github.io/synapse/latest/modules/writing_a_module.html) for sound time comparisons with Synapse.

--- a/changelog.d/18144.feature
+++ b/changelog.d/18144.feature
@@ -1,0 +1,1 @@
+Introduced the get_current_time method in ModuleApi to provide the current server time in milliseconds, as wrapper around self.module_api._clock.time_msec() to avoid accessing private variables

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -1846,7 +1846,7 @@ class ModuleApi:
             deactivation=deactivation,
         )
 
-    def get_current_time(self) -> int:
+    def get_current_time_msec(self) -> int:
         """Returns the current server time in milliseconds."""
         return self._clock.time_msec()
 

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -1850,6 +1850,7 @@ class ModuleApi:
         """Returns the current server time in milliseconds."""
         return self._clock.time_msec()
 
+
 class PublicRoomListManager:
     """Contains methods for adding to, removing from and querying whether a room
     is in the public room list.

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -1846,6 +1846,9 @@ class ModuleApi:
             deactivation=deactivation,
         )
 
+    def get_current_time(self) -> int:
+        """Returns the current server time in milliseconds."""
+        return self._clock.time_msec()
 
 class PublicRoomListManager:
     """Contains methods for adding to, removing from and querying whether a room


### PR DESCRIPTION
- Add `get_current_time_msec()` method to the [module API](https://matrix-org.github.io/synapse/latest/modules/writing_a_module.html) for sound time comparisons with Synapse.
- Fixes #18104 

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
