### PR TITLE
Add `rc_presence` ratelimiting config to demo/start.sh

### DIFF
--- a/changelog.d/18145.bugfix
+++ b/changelog.d/18145.bugfix
@@ -1,0 +1,1 @@
+Add rate limit `rc_presence.per_user`. This prevents load from excessive presence updates sent by clients via sync api. Also rate limit `/_matrix/client/v3/presence` as per the spec. Contributed by @rda0.

--- a/changelog.d/18145.misc
+++ b/changelog.d/18145.misc
@@ -1,0 +1,1 @@
+Set `rc_presence` ratelimit to a high value in the demo script config.

--- a/changelog.d/18145.misc
+++ b/changelog.d/18145.misc
@@ -1,1 +1,0 @@
-Set `rc_presence` ratelimit to a high value in the demo script config.

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -138,6 +138,10 @@ for port in 8080 8081 8082; do
 			  per_user:
 			    per_second: 1000
 			    burst_count: 1000
+			rc_presence:
+			  per_user:
+			    per_second: 1000
+			    burst_count: 1000
 			RC
 			)
             echo "${ratelimiting}" >> "$port.config"


### PR DESCRIPTION
Missed in https://github.com/element-hq/synapse/pull/18000