### PR TITLE
Move User Event Redaction Admin API version indicator to the correct place

### DIFF
--- a/changelog.d/18152.doc
+++ b/changelog.d/18152.doc
@@ -1,0 +1,1 @@
+Move incorrectly placed version indicator in User Event Redaction Admin API docs.

--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -1468,12 +1468,12 @@ The following JSON body parameter must be provided:
 -  `rooms` - A list of rooms to redact the user's events in. If an empty list is provided all events in all rooms
   the user is a member of will be redacted
 
-_Added in Synapse 1.116.0._
-
 The following JSON body parameters are optional:
 
 - `reason` - Reason the redaction is being requested, ie "spam", "abuse", etc. This will be included in each redaction event, and be visible to users.
 - `limit` - a limit on the number of the user's events to search for ones that can be redacted (events are redacted newest to oldest) in each room, defaults to 1000 if not provided
+
+_Added in Synapse 1.116.0._
 
 
 ## Check the status of a redaction process


### PR DESCRIPTION
Previously it was in the middle of the parameter definitions.