### PR TITLE
Add 'on_user_search' callback to third_party_rules callback

### DIFF
--- a/changelog.d/18155.feature
+++ b/changelog.d/18155.feature
@@ -1,0 +1,6 @@
+Add 'on_user_search' callback to the third_party_rules section of the [module API](https://matrix-org.github.io/synapse/latest/modules/writing_a_module.html).
+This allows to write modules that can trigger on search requests on the user directory and alter the results.
+Possible use cases:
+- Filter or group user search results
+- Exclude MxIDs from the user search results
+- Include MxIDs in the user search results even if they do not match the search criteria (e.g. a helper Bot)

--- a/docs/modules/third_party_rules_callbacks.md
+++ b/docs/modules/third_party_rules_callbacks.md
@@ -315,6 +315,28 @@ identifier from an identity server (via a call to [`POST
 
 If multiple modules implement this callback, Synapse runs them all in order.
 
+### `on_user_search`
+
+_First introduced in Synapse v1.xxx.0_
+
+```python
+async def on_user_search(results: SearchResult) -> None:
+```
+
+Called after a search in the user directory has been performed. The module is given
+the search results in the SearchResult data format.
+
+Modules can modify the `results` (e.g. by adding the address of a chatbot by default, filtering
+the results for some criteria or grouping the results in a special manner. Be aware that altering
+the results structure can affect the compatibility with the matrix specification and matrix clients),
+or completely deny the user search by raising a `module_api.errors.SynapseError`.
+
+If multiple modules implement this callback, they will be considered in order. If a
+callback returns without raising an exception, Synapse falls through to the next one. The
+user search will be forbidden as soon as one of the callbacks raises an exception. If
+this happens, Synapse will not call any of the subsequent implementations of this
+callback.
+
 ## Example
 
 The example below is a module that implements the third-party rules callback

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -118,6 +118,7 @@ from synapse.module_api.callbacks.third_party_event_rules_callbacks import (
     ON_REMOVE_USER_THIRD_PARTY_IDENTIFIER_CALLBACK,
     ON_THREEPID_BIND_CALLBACK,
     ON_USER_DEACTIVATION_STATUS_CHANGED_CALLBACK,
+    ON_USER_SEARCH_CALLBACK,
 )
 from synapse.push.httppusher import HttpPusher
 from synapse.rest.client.login import LoginResponse
@@ -385,6 +386,7 @@ class ModuleApi:
         on_remove_user_third_party_identifier: Optional[
             ON_REMOVE_USER_THIRD_PARTY_IDENTIFIER_CALLBACK
         ] = None,
+        on_user_search: Optional[ON_USER_SEARCH_CALLBACK] = None,
     ) -> None:
         """Registers callbacks for third party event rules capabilities.
 
@@ -403,6 +405,7 @@ class ModuleApi:
             on_threepid_bind=on_threepid_bind,
             on_add_user_third_party_identifier=on_add_user_third_party_identifier,
             on_remove_user_third_party_identifier=on_remove_user_third_party_identifier,
+            on_user_search=on_user_search,
         )
 
     def register_presence_router_callbacks(


### PR DESCRIPTION
Add 'on_user_search' callback to the third_party_rules section of the [module API](https://matrix-org.github.io/synapse/latest/modules/writing_a_module.html).
This allows to write modules that can trigger on search requests on the user directory and alter the results.
Possible use cases:
- Filter or group user search results
- Exclude MxIDs from the user search results
- Include MxIDs in the user search results even if they do not match the search criteria (e.g. a helper Bot)

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
