### PR TITLE
Update `rc_presence` config docs with int burst_count

### DIFF
--- a/changelog.d/18159.doc
+++ b/changelog.d/18159.doc
@@ -1,0 +1,1 @@
+Make `burst_count` field an integer in `rc_presence` config documentation example.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1944,7 +1944,7 @@ Example configuration:
 rc_presence:
   per_user:
     per_second: 0.05
-    burst_count: 0.5
+    burst_count: 1
 ```
 ---
 ### `federation_rr_transactions_per_room_per_second`


### PR DESCRIPTION
`burst_count` is an int, so 0.5 is floored to 0. Set it to 0 instead.

Found by @bjoe2k4 in [this comment](https://github.com/element-hq/synapse/pull/18000#discussion_r1953462063).