### PR TITLE
Document suspension Admin API

### DIFF
--- a/changelog.d/18162.misc
+++ b/changelog.d/18162.misc
@@ -1,0 +1,1 @@
+Document suspension Admin API.

--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -414,6 +414,32 @@ The following actions are **NOT** performed. The list may be incomplete.
 - Remove from monthly active users
 - Remove user's consent information (consent version and timestamp)
 
+## Suspend/Unsuspend Account
+
+This API allows an admin to suspend/unsuspend an account. While an account is suspended, the user is 
+prohibited from sending invites, joining or knocking on rooms, sending messages, changing profile data, and redacting messages other than their own. 
+
+The api is:
+
+```
+PUT /_synapse/admin/v1/suspend/<user_id>
+```
+
+with a body of:
+
+```json
+{
+    "suspend": true
+}
+```
+
+To unsuspend a user, use the same endpoint with a body of:
+```json
+{
+  "suspend": false
+}
+```
+
 ## Reset password
 
 **Note:** This API is disabled when MSC3861 is enabled. [See #15582](https://github.com/matrix-org/synapse/pull/15582)


### PR DESCRIPTION
Missed in the transition from experimental to stable. 

Fixes #18160