### PR TITLE
Limit size of user directory search queries

### DIFF
--- a/changelog.d/18172.misc
+++ b/changelog.d/18172.misc
@@ -1,0 +1,1 @@
+Reduce database load of user search when using large search terms.

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -1239,7 +1239,7 @@ def _parse_query_postgres(search_term: str) -> Tuple[str, str, str]:
 
     escaped_words = []
     for index, word in enumerate(_parse_words(search_term)):
-        if index > 10:
+        if index >= 10:
             # We limit how many terms we include, as otherwise it can use
             # excessive database time if people accidentally search for large
             # strings.

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -1238,7 +1238,13 @@ def _parse_query_postgres(search_term: str) -> Tuple[str, str, str]:
     search_term = _filter_text_for_index(search_term)
 
     escaped_words = []
-    for word in _parse_words(search_term):
+    for index, word in enumerate(_parse_words(search_term)):
+        if index > 10:
+            # We limit how many terms we include, as otherwise it can use
+            # excessive database time if people accidentally search for large
+            # strings.
+            break
+
         # Postgres tsvector and tsquery quoting rules:
         # words potentially containing punctuation should be quoted
         # and then existing quotes and backslashes should be doubled


### PR DESCRIPTION
If a user search has many words we can end up creating really large queries that take a long time for the database to process. Generally, such searches don't return any results anyway (due to limits on user ID and display name length).

We "fix" this by cheating and only searching for the first ten words.