### PR TITLE
Disable room list publication by default

### DIFF
--- a/changelog.d/18175.misc
+++ b/changelog.d/18175.misc
@@ -1,0 +1,1 @@
+Disable room list publication by default.

--- a/docker/complement/conf/workers-shared-extra.yaml.j2
+++ b/docker/complement/conf/workers-shared-extra.yaml.j2
@@ -139,4 +139,9 @@ caches:
   sync_response_cache_duration: 0
 
 
+# Complement assumes that it can publish to the room list by default.
+room_list_publication_rules:
+  - action: allow
+
+
 {% include "shared-orig.yaml.j2" %}

--- a/docker/conf/homeserver.yaml
+++ b/docker/conf/homeserver.yaml
@@ -191,3 +191,9 @@ trusted_key_servers:
 
 password_config:
    enabled: true
+
+
+## Rooms ##
+
+room_list_publication_rules:
+  - action: allow

--- a/docker/conf/homeserver.yaml
+++ b/docker/conf/homeserver.yaml
@@ -191,9 +191,3 @@ trusted_key_servers:
 
 password_config:
    enabled: true
-
-
-## Rooms ##
-
-room_list_publication_rules:
-  - action: allow

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -117,6 +117,26 @@ each upgrade are complete before moving on to the next upgrade, to avoid
 stacking them up. You can monitor the currently running background updates with
 [the Admin API](usage/administration/admin_api/background_updates.html#status).
 
+# Upgrading to v1.126.0
+
+## Room list publication rules change
+
+The default [`room_list_publication_rules`] setting was changed to disallow
+anyone (except server admins) from publishing to the room list by default.
+
+This is in line with Synapse policy of locking down features by default that can
+be abused without moderation.
+
+To keep the previous behavior of allowing publication by default, add the
+following to the config:
+
+```yaml
+room_list_publication_rules:
+  - "action": "allow"
+```
+
+[`room_list_publication_rules`]: usage/configuration/config_documentation.md#room_list_publication_rules
+
 # Upgrading to v1.122.0
 
 ## Dropping support for PostgreSQL 11 and 12

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -4227,8 +4227,8 @@ unwanted entries from being published in the public room list.
 
 The format of this option is the same as that for
 [`alias_creation_rules`](#alias_creation_rules): an optional list of 0 or more
-rules. By default, no list is provided, meaning that all rooms may be
-published to the room list.
+rules. By default, no list is provided, meaning that no one may publish to the
+room list (except server admins).
 
 Otherwise, requests to publish a room are matched against each rule in order.
 The first rule that matches decides if the request is allowed or denied. If no
@@ -4252,6 +4252,10 @@ Each of the glob patterns is optional, defaulting to `*` ("match anything").
 Note that the patterns match against fully qualified IDs, e.g. against
 `@alice:example.com`, `#room:example.com` and `!abcdefghijk:example.com` instead
 of `alice`, `room` and `abcedgghijk`.
+
+
+_Changed in Synapse 1.126.0: The default was changed to deny publishing to the
+room list by default_
 
 
 Example configuration:

--- a/synapse/config/room_directory.py
+++ b/synapse/config/room_directory.py
@@ -54,9 +54,7 @@ class RoomDirectoryConfig(Config):
                 for rule in room_list_publication_rules
             ]
         else:
-            self._room_list_publication_rules = [
-                _RoomDirectoryRule("room_list_publication_rules", {"action": "allow"})
-            ]
+            self._room_list_publication_rules = []
 
     def is_alias_creation_allowed(self, user_id: str, room_id: str, alias: str) -> bool:
         """Checks if the given user is allowed to create the given alias

--- a/tests/handlers/test_directory.py
+++ b/tests/handlers/test_directory.py
@@ -587,6 +587,7 @@ class TestRoomListSearchDisabled(unittest.HomeserverTestCase):
         self.room_list_handler = hs.get_room_list_handler()
         self.directory_handler = hs.get_directory_handler()
 
+    @unittest.override_config({"room_list_publication_rules": [{"action": "allow"}]})
     def test_disabling_room_list(self) -> None:
         self.room_list_handler.enable_room_list_search = True
         self.directory_handler.enable_room_list_search = True

--- a/tests/handlers/test_room_list.py
+++ b/tests/handlers/test_room_list.py
@@ -6,6 +6,7 @@ from synapse.rest.client import directory, login, room
 from synapse.types import JsonDict
 
 from tests import unittest
+from tests.utils import default_config
 
 
 class RoomListHandlerTestCase(unittest.HomeserverTestCase):
@@ -29,6 +30,11 @@ class RoomListHandlerTestCase(unittest.HomeserverTestCase):
         )
         assert channel.code == HTTPStatus.OK, f"couldn't publish room: {channel.result}"
         return room_id
+
+    def default_config(self) -> JsonDict:
+        config = default_config("test")
+        config["room_list_publication_rules"] = [{"action": "allow"}]
+        return config
 
     def test_acls_applied_to_room_directory_results(self) -> None:
         """

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -1282,6 +1282,7 @@ class RoomTestCase(unittest.HomeserverTestCase):
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")
 
+    @unittest.override_config({"room_list_publication_rules": [{"action": "allow"}]})
     def test_list_rooms(self) -> None:
         """Test that we can list rooms"""
         # Create 3 test rooms
@@ -1795,6 +1796,7 @@ class RoomTestCase(unittest.HomeserverTestCase):
         self.assertEqual(room_id, channel.json_body["rooms"][0].get("room_id"))
         self.assertEqual("ж", channel.json_body["rooms"][0].get("name"))
 
+    @unittest.override_config({"room_list_publication_rules": [{"action": "allow"}]})
     def test_filter_public_rooms(self) -> None:
         self.helper.create_room_as(
             self.admin_user, tok=self.admin_user_tok, is_public=True
@@ -1872,6 +1874,7 @@ class RoomTestCase(unittest.HomeserverTestCase):
         self.assertEqual(1, response.json_body["total_rooms"])
         self.assertEqual(1, len(response.json_body["rooms"]))
 
+    @unittest.override_config({"room_list_publication_rules": [{"action": "allow"}]})
     def test_single_room(self) -> None:
         """Test that a single room can be requested correctly"""
         # Create two test rooms

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -67,6 +67,7 @@ from tests.http.server._base import make_request_with_cancellation_test
 from tests.storage.test_stream import PaginationTestCase
 from tests.test_utils.event_injection import create_event
 from tests.unittest import override_config
+from tests.utils import default_config
 
 PATH_PREFIX = b"/_matrix/client/api/v1"
 
@@ -2547,6 +2548,11 @@ class PublicRoomsRoomTypeFilterTestCase(unittest.HomeserverTestCase):
             },
             tok=self.token,
         )
+
+    def default_config(self) -> JsonDict:
+        config = default_config("test")
+        config["room_list_publication_rules"] = [{"action": "allow"}]
+        return config
 
     def make_public_rooms_request(
         self,


### PR DESCRIPTION
This is in line with our general policy of ensuring that the default config is reasonably locked down.

SyTest PR to fix tests: https://github.com/matrix-org/sytest/pull/1396