### PR TITLE
Pass `client_id` when making an OAuth access token request

### DIFF
--- a/changelog.d/18176.bugfix
+++ b/changelog.d/18176.bugfix
@@ -1,0 +1,1 @@
+Pass required parameter `client_id` when making an OAuth access token request.

--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -731,6 +731,7 @@ class OidcProvider:
         }
 
         args = {
+            "client_id": self._client_auth.client_id,
             "grant_type": "authorization_code",
             "code": code,
             "redirect_uri": self._callback_url,


### PR DESCRIPTION
Pass `client_id` when making an OAuth access token request (exchange authorization code for an access token) as it's required:


> #### 4.1.3.  Access Token Request
>
> [...]
>
>   `grant_type`
>         REQUIRED.  Value MUST be set to "authorization_code".
>
>   `code`
>         REQUIRED.  The authorization code received from the
>         authorization server.
>
>   `redirect_uri`
>         REQUIRED, if the "redirect_uri" parameter was included in the
>         authorization request as described in Section 4.1.1, and their
>         values MUST be identical.
>
>   `client_id`
>         REQUIRED, if the client is not authenticating with the
>         authorization server as described in Section 3.2.1.
>
> *-- https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3*

> #### 3.2.1.  Client Authentication
>
> A client MAY use the "client_id" request parameter to identify itself
> when sending requests to the token endpoint.  In the
> "authorization_code" "grant_type" request to the token endpoint, an
> unauthenticated client MUST send its "client_id" to prevent itself
> from inadvertently accepting a code intended for a client with a
> different "client_id".  This protects the client from substitution of
> the authentication code.  (It provides no additional security for the
> protected resource.)
>
> *-- https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1*

---

Noticed while working on an OAuth server implementation configured against Synapse.



### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
