### PR TITLE
Add support for overriding `id_token_signing_alg_values_supported` for an OpenID identity provider

### DIFF
--- a/changelog.d/18177.feature
+++ b/changelog.d/18177.feature
@@ -1,0 +1,1 @@
+Add support for specifying/overriding `id_token_signing_alg_values_supported` for an OpenID identity provider.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3579,6 +3579,24 @@ Options for each entry include:
    to `auto`, which uses PKCE if supported during metadata discovery. Set to `always`
    to force enable PKCE or `never` to force disable PKCE.
 
+* `id_token_signing_alg_values_supported`: List of the JWS signing algorithms (`alg`
+  values) that are supported for signing the `id_token`.
+
+  This is *not* required if `discovery` is disabled. We default to supporting `RS256` in
+  the downstream usage if no algorithms are configured here or in the discovery
+  document.
+
+  According to the spec, the algorithm `"RS256"` MUST be included. The absolute rigid
+  approach would be to reject this provider as non-compliant if it's not included but we
+  simply allow whatever and see what happens (you're the one that configured the value
+  and cooperating with the identity provider).
+
+  The `alg` value `"none"` MAY be supported but can only be used if the Authorization
+  Endpoint does not include `id_token` in the `response_type` (ex.
+  `/authorize?response_type=code` where `none` can apply,
+  `/authorize?response_type=code%20id_token` where `none` can't apply) (such as when
+  using the Authorization Code Flow).
+
 * `scopes`: list of scopes to request. This should normally include the "openid"
    scope. Defaults to `["openid"]`.
 

--- a/synapse/config/oidc.py
+++ b/synapse/config/oidc.py
@@ -409,7 +409,7 @@ class OidcProviderConfig:
     # Valid values are 'auto', 'always', and 'never'.
     pkce_method: str
 
-    id_token_signing_alg_values_supported: Optional[List[str]] = None
+    id_token_signing_alg_values_supported: Optional[List[str]]
     """
     List of the JWS signing algorithms (`alg` values) that are supported for signing the
     `id_token`.

--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -640,6 +640,9 @@ class OidcProvider:
         elif self._config.pkce_method == "never":
             metadata.pop("code_challenge_methods_supported", None)
 
+        if self._config.id_token_signing_alg_values_supported:
+            metadata["id_token_signing_alg_values_supported"] = self._config.id_token_signing_alg_values_supported
+
         self._validate_metadata(metadata)
 
         return metadata

--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -641,7 +641,9 @@ class OidcProvider:
             metadata.pop("code_challenge_methods_supported", None)
 
         if self._config.id_token_signing_alg_values_supported:
-            metadata["id_token_signing_alg_values_supported"] = self._config.id_token_signing_alg_values_supported
+            metadata["id_token_signing_alg_values_supported"] = (
+                self._config.id_token_signing_alg_values_supported
+            )
 
         self._validate_metadata(metadata)
 


### PR DESCRIPTION
Add support for overriding `id_token_signing_alg_values_supported` for an OpenID identity provider.

Normally, when `discovery` is enabled, `id_token_signing_alg_values_supported` comes from the OpenID Discovery Document (`/.well-known/openid-configuration`). If nothing was specified, we default to supporting `RS256` in the downstream usage.

This PR just adds support for adding a default/overriding the the discovered value [just like we do for other things like the `token_endpoint`](https://github.com/element-hq/synapse/blob/1525a3b4d48a0f5657d61423e1f205bff9a77948/docs/usage/configuration/config_documentation.md#oidc_providers), etc.

### Todo

 - [x] Maybe add tests

### Dev notes

```
poetry run trial tests.handlers.test_oidc.OidcHandlerTestCase
```


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
