### PR TITLE
Fix detection of workflow failures in the release script.

### DIFF
--- a/changelog.d/18211.misc
+++ b/changelog.d/18211.misc
@@ -1,0 +1,1 @@
+Fix detection of workflow failures in the release script.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -592,7 +592,7 @@ def _wait_for_actions(gh_token: Optional[str]) -> None:
         if all(
             workflow["status"] != "in_progress" for workflow in resp["workflow_runs"]
         ):
-            success = (
+            success = all(
                 workflow["status"] == "completed" for workflow in resp["workflow_runs"]
             )
             if success:


### PR DESCRIPTION
If one workflow is successful and one fails, currently that is reported as success.
