### PR TITLE
Fix wheel building configuration in CI by installing libatomic1.

### DIFF
--- a/.ci/before_build_wheel.sh
+++ b/.ci/before_build_wheel.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+# On 32-bit Linux platforms, we need libatomic1 to use rustup
+if command -v apt-get &> /dev/null; then
+    apt-get update
+    apt-get install libatomic1
+fi
+
+# Install a Rust toolchain
+curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.82.0 -y --profile minimal

--- a/changelog.d/18212.misc
+++ b/changelog.d/18212.misc
@@ -1,0 +1,1 @@
+Fix wheel building configuration in CI by installing libatomic1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -390,7 +390,7 @@ skip = "cp36* cp37* cp38* pp37* pp38* *-musllinux_i686 pp*aarch64 *-musllinux_aa
 #
 # We temporarily pin Rust to 1.82.0 to work around
 # https://github.com/element-hq/synapse/issues/17988
-before-all =  "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.82.0 -y --profile minimal"
+before-all =  "sh .ci/before_build_wheel.sh"
 environment= { PATH = "$PATH:$HOME/.cargo/bin" }
 
 # For some reason if we don't manually clean the build directory we


### PR DESCRIPTION
Without this, we get the following error when building for 32-bit i686 Linux:

```
Running before_all...
  
      + /opt/python/cp38-cp38/bin/python -c 'import sys, json, os; json.dump(os.environ.copy(), sys.stdout)'
      + sh -c 'curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.82.0 -y --profile minimal'
  info: downloading installer
  warn: Not enforcing strong cipher suites for TLS, this is potentially less secure
  /tmp/tmp.KlFNNCWiwj/rustup-init: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
                                                              ✕ 1.30s
Error: Command ['sh', '-c', 'curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.82.0 -y --profile minimal'] failed with code 1. 
```

There may be other platforms where this is relevant, too. (libatomic provides software support for some atomic operations when not supported directly by hardware)
