### PR TITLE
(encoding of confusion: unreferenced state group deletion either doesn't make sense, or can explode size of `state_groups_state`)

### DIFF
--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -739,8 +739,8 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
         room_id: str,
         state_groups_to_sequence_numbers: Mapping[int, int],
     ) -> bool:
-        """Deletes no longer referenced state groups and de-deltas any state
-        groups that reference them.
+        """Deletes state groups that are no longer referenced by events <<<TODO confirm this is the intended meaning>>>
+        and de-deltas any state groups that reference them.
 
         Args:
             room_id: The room the state groups belong to (must all be in the


### PR DESCRIPTION
This is intended as a demonstrative example for #18217 and is not a PR to merge.

---

The docstring

> Deletes no longer referenced state groups and de-deltas any state
groups that reference them.

does not make sense; or rather, it's contradictory — if a state group is no longer referenced, then it follows that no state groups reference it and thus there should be no de-delta-ing to be done.

BUT if we edit it slightly, maybe the docstring starts to make sense?

> Deletes state groups **that are no longer referenced by events** and de-deltas any state
groups that reference them.

frankly: I don't actually know if this is the intended meaning. But it sounds plausible.

If we go by that assumption, then we can write a test to demonstrate a situation in which state group deletion causes **more** rows to be added to `state_groups_state` than deleted.