### PR TITLE
Add an access token introspection cache to make Matrix Authentication Service integration (MSC3861) more efficient.

### DIFF
--- a/changelog.d/18231.feature
+++ b/changelog.d/18231.feature
@@ -1,0 +1,1 @@
+Add an access token introspection cache to make Matrix Authentication Service integration (MSC3861) more efficient.


### PR DESCRIPTION
Evolution of https://github.com/element-hq/synapse/commit/cd78f3d2ee15ccf3e8229a1f529e0e2c16e15c45

This cache does not have any explicit invalidation, but this is deemed acceptable (see code comment).

We may still prefer to add it eventually, letting us bump up the Time-To-Live (TTL) on the cache as we currently set a 2 minute expiry
to balance the fact that we have no explicit invalidation.


This cache makes several things more efficient:

- reduces number of outbound requests from Synapse, reducing CPU utilisation + network I/O
- reduces request handling time in Synapse, which improves client-visible latency
- reduces load on MAS and its database


---

Other than that, this PR also introduces support for `expires_in` (seconds) on the introspection response.
This lets the cached responses expire at the proper expiry time of the access token, whilst avoiding clock skew issues.

Corresponds to: https://github.com/element-hq/matrix-authentication-service/pull/4241

