### PR TITLE
Mark dehydrated devices in admin get devices endpoint

### DIFF
--- a/synapse/rest/admin/devices.py
+++ b/synapse/rest/admin/devices.py
@@ -142,6 +142,17 @@ class DevicesRestServlet(RestServlet):
             raise NotFoundError("Unknown user")
 
         devices = await self.device_handler.get_devices_by_user(target_user.to_string())
+
+        # mark the dehydrated device by adding a "dehydrated" flag
+        dehydrated_device_info = await self.device_handler.get_dehydrated_device(
+            target_user.to_string()
+        )
+        if dehydrated_device_info:
+            dehydrated_device_id = dehydrated_device_info[0]
+            for device in devices:
+                if device["device_id"] == dehydrated_device_id:
+                    device["dehydrated"] = True
+
         return HTTPStatus.OK, {"devices": devices, "total": len(devices)}
 
     async def on_POST(

--- a/tests/rest/admin/test_device.py
+++ b/tests/rest/admin/test_device.py
@@ -27,7 +27,7 @@ from twisted.test.proto_helpers import MemoryReactor
 import synapse.rest.admin
 from synapse.api.errors import Codes
 from synapse.handlers.device import DeviceHandler
-from synapse.rest.client import login
+from synapse.rest.client import devices, login
 from synapse.server import HomeServer
 from synapse.util import Clock
 
@@ -299,6 +299,7 @@ class DeviceRestTestCase(unittest.HomeserverTestCase):
 class DevicesRestTestCase(unittest.HomeserverTestCase):
     servlets = [
         synapse.rest.admin.register_servlets,
+        devices.register_servlets,
         login.register_servlets,
     ]
 
@@ -390,14 +391,62 @@ class DevicesRestTestCase(unittest.HomeserverTestCase):
         self.assertEqual(0, channel.json_body["total"])
         self.assertEqual(0, len(channel.json_body["devices"]))
 
+    @unittest.override_config(
+        {"experimental_features": {"msc2697_enabled": False, "msc3814_enabled": True}}
+    )
     def test_get_devices(self) -> None:
         """
         Tests that a normal lookup for devices is successfully
         """
         # Create devices
         number_devices = 5
-        for _ in range(number_devices):
+        # we create 2 fewer devices in the loop, because we will create another
+        # login after the loop, and we will create a dehydrated device
+        for _ in range(number_devices - 2):
             self.login("user", "pass")
+
+        other_user_token = self.login("user", "pass")
+        dehydrated_device_url = (
+            "/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device"
+        )
+        content = {
+            "device_data": {
+                "algorithm": "m.dehydration.v1.olm",
+            },
+            "device_id": "dehydrated_device",
+            "initial_device_display_name": "foo bar",
+            "device_keys": {
+                "user_id": "@user:test",
+                "device_id": "dehydrated_device",
+                "valid_until_ts": "80",
+                "algorithms": [
+                    "m.olm.curve25519-aes-sha2",
+                ],
+                "keys": {
+                    "<algorithm>:<device_id>": "<key_base64>",
+                },
+                "signatures": {
+                    "@user:test": {"<algorithm>:<device_id>": "<signature_base64>"}
+                },
+            },
+            "fallback_keys": {
+                "alg1:device1": "f4llb4ckk3y",
+                "signed_<algorithm>:<device_id>": {
+                    "fallback": "true",
+                    "key": "f4llb4ckk3y",
+                    "signatures": {
+                        "@user:test": {"<algorithm>:<device_id>": "<key_base64>"}
+                    },
+                },
+            },
+            "one_time_keys": {"alg1:k1": "0net1m3k3y"},
+        }
+        self.make_request(
+            "PUT",
+            dehydrated_device_url,
+            access_token=other_user_token,
+            content=content,
+        )
 
         # Get devices
         channel = self.make_request(
@@ -410,13 +459,21 @@ class DevicesRestTestCase(unittest.HomeserverTestCase):
         self.assertEqual(number_devices, channel.json_body["total"])
         self.assertEqual(number_devices, len(channel.json_body["devices"]))
         self.assertEqual(self.other_user, channel.json_body["devices"][0]["user_id"])
-        # Check that all fields are available
+        # Check that all fields are available, and that the dehydrated device is marked as dehydrated
+        found_dehydrated = False
         for d in channel.json_body["devices"]:
             self.assertIn("user_id", d)
             self.assertIn("device_id", d)
             self.assertIn("display_name", d)
             self.assertIn("last_seen_ip", d)
             self.assertIn("last_seen_ts", d)
+            if d["device_id"] == "dehydrated_device":
+                self.assertEqual(True, d.get("dehydrated"))
+                found_dehydrated = True
+            else:
+                self.assertNotIn("dehydrated", d)
+
+        self.assertEqual(True, found_dehydrated)
 
 
 class DeleteDevicesRestTestCase(unittest.HomeserverTestCase):


### PR DESCRIPTION
Mark the dehydrated device.  This is needed for dehydrated devices and MAS, because MAS tries to delete all the devices that it doesn't know about, so it needs to know about the dehydrated device so that it can ignore it.

Companion PR: [TODO]

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
