### PR TITLE
Add Zizmor check in CI to check the CI configuration for security problems.

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,43 @@
+name: GitHub Actions security check (zizmor)
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - .github/workflows/**
+  pull_request:
+    branches: ["**"]
+    paths:
+      - .github/workflows/**
+
+jobs:
+  zizmor:
+    name: zizmor latest via PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read # only needed for private repos
+      actions: read # only needed for private repos
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Run zizmor
+        run: uvx zizmor --format sarif . > results.sarif 
+
+
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+
+
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/changelog.d/18256.misc
+++ b/changelog.d/18256.misc
@@ -1,0 +1,1 @@
+Add Zizmor check in CI to check the CI configuration for security problems.


### PR DESCRIPTION
More or less a copy of <https://woodruffw.github.io/zizmor/usage/#use-in-github-actions> but with path conditions.
