### PR TITLE
Catch other error variant of missing `icu` dependency

### DIFF
--- a/changelog.d/18261.misc
+++ b/changelog.d/18261.misc
@@ -1,0 +1,1 @@
+Catch other error variant of missing `icu` dependency.

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -42,7 +42,7 @@ try:
     import icu
 
     USE_ICU = True
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     USE_ICU = False
 
 from synapse.api.errors import StoreError


### PR DESCRIPTION
Catch other error variant of missing `icu` dependency

```sh
$ poetry run synapse_homeserver --config-path homeserver.yaml
The "poetry.dev-dependencies" section is deprecated and will be removed in a future version. Use "poetry.group.dev.dependencies" instead.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import sys; from importlib import import_module; sys.argv = ['/home/eric/.cache/pypoetry/virtualenvs/matrix-synapse-xCtC9ulO-py3.13/bin/synapse_homeserver', '--config-path', 'homeserver.yaml']; sys.exit(import_module('synapse.app.homeserver').main())
                                                                                                                                                                                                               ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/eric/Documents/github/element/synapse/synapse/app/homeserver.py", line 43, in <module>
    from synapse.app import _base
  File "/home/eric/Documents/github/element/synapse/synapse/app/_base.py", line 71, in <module>
    from synapse.events.auto_accept_invites import InviteAutoAccepter
  File "/home/eric/Documents/github/element/synapse/synapse/events/auto_accept_invites.py", line 28, in <module>
    from synapse.module_api import EventBase, ModuleApi, run_as_background_process
  File "/home/eric/Documents/github/element/synapse/synapse/module_api/__init__.py", line 60, in <module>
    from synapse.handlers.auth import (
    ...<7 lines>...
    )
  File "/home/eric/Documents/github/element/synapse/synapse/handlers/auth.py", line 63, in <module>
    from synapse.api.ratelimiting import Ratelimiter
  File "/home/eric/Documents/github/element/synapse/synapse/api/ratelimiting.py", line 28, in <module>
    from synapse.storage.databases.main import DataStore
  File "/home/eric/Documents/github/element/synapse/synapse/storage/__init__.py", line 40, in <module>
    from synapse.storage.databases import Databases
  File "/home/eric/Documents/github/element/synapse/synapse/storage/databases/__init__.py", line 27, in <module>
    from synapse.storage.databases.main.events import PersistEventsStore
  File "/home/eric/Documents/github/element/synapse/synapse/storage/databases/main/__init__.py", line 86, in <module>
    from .user_directory import UserDirectoryStore
  File "/home/eric/Documents/github/element/synapse/synapse/storage/databases/main/user_directory.py", line 42, in <module>
    import icu
  File "/home/eric/.cache/pypoetry/virtualenvs/matrix-synapse-xCtC9ulO-py3.13/lib/python3.13/site-packages/icu/__init__.py", line 37, in <module>
    from ._icu_ import *
ImportError: libicui18n.so.75: cannot open shared object file: No such file or directory
```

I'm not sure why I ran into this error as I think I have `icu` installed on my system:

Manjaro Linux (arch-based):
```sh
$ pamac search icu --installed
lib32-icu  76.1-1                                                                                                     multilib
    International Components for Unicode library (32 bit)
harfbuzz-icu  10.4.0-1                                                                                                   extra
    OpenType text shaping engine - ICU integration
icu  76.1-1                                                                                                               core
    International Components for Unicode library
```

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
