### PR TITLE
Dockerfile: set package arch via APT config option

### DIFF
--- a/changelog.d/18271.docker
+++ b/changelog.d/18271.docker
@@ -1,0 +1,1 @@
+Specify the architecture of installed packages via an APT config option, which is more reliable than appending package names with ":{arch}".

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -148,7 +148,7 @@ RUN \
   for arch in arm64 amd64; do \
     mkdir -p /tmp/debs-${arch} && \
     cd /tmp/debs-${arch} && \
-    apt-get download $(sed "s/$/:${arch}/" /tmp/pkg-list); \
+    apt-get -o APT::Architecture="${arch}" download $(cat /tmp/pkg-list); \
   done
 
 # Extract the debs for each architecture


### PR DESCRIPTION
Do this instead of appending package names with ":{arch}", which fails when downloading architecture-independent packages for a non-host arch.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
