### PR TITLE
Tweaks to prefix-log

### DIFF
--- a/changelog.d/18274.docker
+++ b/changelog.d/18274.docker
@@ -1,0 +1,1 @@
+Make some improvements to the prefix-log script in the workers image.

--- a/docker/prefix-log
+++ b/docker/prefix-log
@@ -11,7 +11,7 @@
 # stdin. The effect is that the output is flushed after each line, rather than being batched, which helps reduce
 # confusion due to to interleaving of the different processes.
 prefixer() {
-    mawk -W interactive '{print ENVIRON["SUPERVISOR_PROCESS_NAME"] | "$0; fflush() }'
+    mawk -W interactive '{print ENVIRON["SUPERVISOR_PROCESS_NAME"]" | "$0; fflush() }'
 }
 exec 1> >(prefixer)
 exec 2> >(prefixer >&2)

--- a/docker/prefix-log
+++ b/docker/prefix-log
@@ -11,7 +11,7 @@
 # stdin. The effect is that the output is flushed after each line, rather than being batched, which helps reduce
 # confusion due to to interleaving of the different processes.
 prefixer() {
-    mawk -W interactive '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0; fflush() }'
+    mawk -W interactive '{print ENVIRON["SUPERVISOR_PROCESS_NAME"] | "$0; fflush() }'
 }
 exec 1> >(prefixer)
 exec 2> >(prefixer >&2)

--- a/docker/prefix-log
+++ b/docker/prefix-log
@@ -10,6 +10,9 @@
 # '-W interactive' is a `mawk` extension which disables buffering on stdout and sets line-buffered reads on
 # stdin. The effect is that the output is flushed after each line, rather than being batched, which helps reduce
 # confusion due to to interleaving of the different processes.
-exec 1> >(mawk -W interactive '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0; fflush() }' >&1)
-exec 2> >(mawk -W interactive '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0; fflush() }' >&2)
+prefixer() {
+    mawk -W interactive '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0; fflush() }'
+}
+exec 1> >(prefixer)
+exec 2> >(prefixer >&2)
 exec "$@"

--- a/docker/prefix-log
+++ b/docker/prefix-log
@@ -10,6 +10,6 @@
 # '-W interactive' is a `mawk` extension which disables buffering on stdout and sets line-buffered reads on
 # stdin. The effect is that the output is flushed after each line, rather than being batched, which helps reduce
 # confusion due to to interleaving of the different processes.
-exec 1> >(awk -W interactive '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0 }' >&1)
-exec 2> >(awk -W interactive '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0 }' >&2)
+exec 1> >(mawk -W interactive '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0; fflush() }' >&1)
+exec 2> >(mawk -W interactive '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0; fflush() }' >&2)
 exec "$@"

--- a/docker/prefix-log
+++ b/docker/prefix-log
@@ -11,7 +11,7 @@
 # stdin. The effect is that the output is flushed after each line, rather than being batched, which helps reduce
 # confusion due to to interleaving of the different processes.
 prefixer() {
-    mawk -W interactive '{print ENVIRON["SUPERVISOR_PROCESS_NAME"]" | "$0; fflush() }'
+    mawk -W interactive '{printf("%s | %s\n", ENVIRON["SUPERVISOR_PROCESS_NAME"], $0); fflush() }'
 }
 exec 1> >(prefixer)
 exec 2> >(prefixer >&2)


### PR DESCRIPTION
- Explicitly use `mawk` instead of `awk`, since an extension of the former is used
- Use `fflush` to reduce interleaving the output of different processes & streams
- Move the `mawk` command to a shell function, instead of writing it twice
- Look up the  `SUPERVISOR_PROCESS_NAME` environment variable in `mawk`, instead of reading it in the shell & using complex quoting to pass it to `mawk`

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
