### PR TITLE
Store hashes of media files, and allow quarantining by hash.

### DIFF
--- a/changelog.d/18277.feature
+++ b/changelog.d/18277.feature
@@ -1,1 +1,1 @@
-Hashes of media files are now tracked by Synapse. Quarantining media will now apply to all files with the same hash.
+Hashes of media files are now tracked by Synapse. Media quarantines will now apply to all files with the same hash.

--- a/changelog.d/18277.feature
+++ b/changelog.d/18277.feature
@@ -1,0 +1,1 @@
+Hashes of media files are now tracked by Synapse. Quarantining media will now apply to all files with the same hash.

--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -61,8 +61,8 @@ from synapse.media._base import (
 from synapse.media.filepath import MediaFilePaths
 from synapse.media.media_storage import (
     MediaStorage,
-    SHA256TransparentBinaryIO,
-    SHA256TransparentIO,
+    SHA256TransparentIOReader,
+    SHA256TransparentIOWriter,
 )
 from synapse.media.storage_provider import StorageProviderWrapper
 from synapse.media.thumbnailer import Thumbnailer, ThumbnailError
@@ -305,7 +305,7 @@ class MediaRepository:
             auth_user: The user_id of the uploader
         """
         file_info = FileInfo(server_name=None, file_id=media_id)
-        wrapped_content = SHA256TransparentIO(content)
+        wrapped_content = SHA256TransparentIOReader(content)
         # This implements all of IO as it has a passthrough
         fname = await self.media_storage.store_file(
             cast(IO, wrapped_content), file_info
@@ -360,7 +360,7 @@ class MediaRepository:
 
         file_info = FileInfo(server_name=None, file_id=media_id)
         # This implements all of IO as it has a passthrough
-        wrapped_content = SHA256TransparentIO(content)
+        wrapped_content = SHA256TransparentIOReader(content)
         fname = await self.media_storage.store_file(
             cast(IO, wrapped_content), file_info
         )
@@ -785,10 +785,8 @@ class MediaRepository:
 
         file_info = FileInfo(server_name=server_name, file_id=file_id)
 
-        digest = None
-
         async with self.media_storage.store_into_file(file_info) as (f, fname):
-            wrapped_f = SHA256TransparentBinaryIO(f)
+            wrapped_f = SHA256TransparentIOWriter(f)
             try:
                 length, headers = await self.client.download_media(
                     server_name,
@@ -916,7 +914,7 @@ class MediaRepository:
         file_info = FileInfo(server_name=server_name, file_id=file_id)
 
         async with self.media_storage.store_into_file(file_info) as (f, fname):
-            wrapped_f = SHA256TransparentBinaryIO(f)
+            wrapped_f = SHA256TransparentIOWriter(f)
             try:
                 res = await self.client.federation_download_media(
                     server_name,

--- a/synapse/media/media_storage.py
+++ b/synapse/media/media_storage.py
@@ -31,11 +31,9 @@ from typing import (
     IO,
     TYPE_CHECKING,
     Any,
-    AnyStr,
     AsyncIterator,
     BinaryIO,
     Callable,
-    Generic,
     List,
     Optional,
     Sequence,
@@ -105,12 +103,16 @@ class SHA256TransparentIOWriter:
         """
         return self._hash.hexdigest()
 
+    def wrap(self) -> BinaryIO:
+        # This class implements a subset the IO interface and passes through everything else via __getattr__
+        return cast(BinaryIO, self)
+
     # Passthrough any other calls
     def __getattr__(self, attr_name: str) -> Any:
         return getattr(self._source, attr_name)
 
 
-class SHA256TransparentIOReader(Generic[AnyStr]):
+class SHA256TransparentIOReader:
     """Will generate a SHA256 hash from a source stream transparently.
 
     Args:
@@ -121,7 +123,7 @@ class SHA256TransparentIOReader(Generic[AnyStr]):
         self._hash = hashlib.sha256()
         self._source = source
 
-    def read(self, n: int = -1) -> AnyStr:
+    def read(self, n: int = -1) -> bytes:
         """Wrapper for source.read()
 
         Args:
@@ -141,6 +143,10 @@ class SHA256TransparentIOReader(Generic[AnyStr]):
             The digest in hex formaat.
         """
         return self._hash.hexdigest()
+
+    def wrap(self) -> IO:
+        # This class implements a subset the IO interface and passes through everything else via __getattr__
+        return cast(IO, self)
 
     # Passthrough any other calls
     def __getattr__(self, attr_name: str) -> Any:

--- a/synapse/media/media_storage.py
+++ b/synapse/media/media_storage.py
@@ -19,11 +19,11 @@
 #
 #
 import contextlib
+import hashlib
 import json
 import logging
 import os
 import shutil
-import hashlib
 from contextlib import closing
 from io import BytesIO
 from types import TracebackType
@@ -31,9 +31,11 @@ from typing import (
     IO,
     TYPE_CHECKING,
     Any,
+    AnyStr,
     AsyncIterator,
     BinaryIO,
     Callable,
+    Generic,
     List,
     Optional,
     Sequence,
@@ -70,28 +72,79 @@ logger = logging.getLogger(__name__)
 
 CRLF = b"\r\n"
 
-class SHA256TransparentFile:
-    def __init__(self, source):
+
+class SHA256TransparentBinaryIO:
+    """Will generate a SHA256 hash from a source stream transparently.
+
+    Args:
+        source: Source stream.
+    """
+
+    def __init__(self, source: BinaryIO):
         self._sig = hashlib.sha256()
         self._source = source
 
-    def read(self, buffer):
-        # we ignore the buffer size, just use the `.next()` value in the source iterator
-        try:
-            bytes = self._source.read()
-            self._sig.update(bytes)
-            return bytes
-        except StopIteration:
-            return b''
+    def write(self, buffer: Union[bytes, bytearray]) -> int:
+        """Wrapper for source.write()
 
-    def write(self, buffer):
-        logger.info("Writing buffer %s", buffer)
+        Args:
+            buffer
+
+        Returns:
+            the value of source.write()
+        """
         res = self._source.write(buffer)
         self._sig.update(buffer)
         return res
 
-    def digest(self):
+    def hexdigest(self) -> str:
+        """The digest of the written or read value.
+
+        Returns:
+            The digest in hex formaat.
+        """
         return self._sig.hexdigest()
+
+    # Passthrough any other calls
+    def __getattr__(self, attr_name: str) -> Any:
+        return getattr(self.obj, attr_name)
+
+
+class SHA256TransparentIO(Generic[AnyStr]):
+    """Will generate a SHA256 hash from a source stream transparently.
+
+    Args:
+        source: Source IO stream.
+    """
+
+    def __init__(self, source: IO):
+        self._sig = hashlib.sha256()
+        self._source = source
+
+    def read(self, n: int = -1) -> AnyStr:
+        """Wrapper for source.read()
+
+        Args:
+            n
+
+        Returns:
+            the value of source.read()
+        """
+        bytes = self._source.read(n)
+        self._sig.update(bytes)
+        return bytes
+
+    def hexdigest(self) -> str:
+        """The digest of the written or read value.
+
+        Returns:
+            The digest in hex formaat.
+        """
+        return self._sig.hexdigest()
+
+    # Passthrough any other calls
+    def __getattr__(self, attr_name: str) -> Any:
+        return getattr(self.obj, attr_name)
 
 
 class MediaStorage:
@@ -120,7 +173,7 @@ class MediaStorage:
         self.clock = hs.get_clock()
 
     @trace_with_opname("MediaStorage.store_file")
-    async def store_file(self, source: IO, file_info: FileInfo) -> tuple[str,str]:
+    async def store_file(self, source: IO, file_info: FileInfo) -> str:
         """Write `source` to the on disk media store, and also any other
         configured storage providers
 
@@ -131,17 +184,16 @@ class MediaStorage:
         Returns:
             the file path written to in the primary media store
         """
-        digest = None
         async with self.store_into_file(file_info) as (f, fname):
             # Write to the main media repository
-            digest = await self.write_to_file(source, f)
+            await self.write_to_file(source, f)
 
-        return fname, digest
+        return fname
 
     @trace_with_opname("MediaStorage.write_to_file")
-    async def write_to_file(self, source: IO, output: IO) -> str:
+    async def write_to_file(self, source: IO, output: IO) -> None:
         """Asynchronously write the `source` to `output`."""
-        return await defer_to_thread(self.reactor, _write_file_synchronously, source, output)
+        await defer_to_thread(self.reactor, _write_file_synchronously, source, output)
 
     @trace_with_opname("MediaStorage.store_into_file")
     @contextlib.asynccontextmanager
@@ -345,9 +397,7 @@ def _write_file_synchronously(source: IO, dest: IO) -> None:
         dest: A file like object to be written to
     """
     source.seek(0)  # Ensure we read from the start of the file
-    transport = SHA256TransparentFile(source)
-    shutil.copyfileobj(transport, dest)
-    return transport.digest()
+    shutil.copyfileobj(source, dest)
 
 
 class FileResponder(Responder):

--- a/synapse/media/media_storage.py
+++ b/synapse/media/media_storage.py
@@ -131,7 +131,7 @@ class SHA256TransparentIOReader(Generic[AnyStr]):
             the value of source.read()
         """
         bytes = self._source.read(n)
-        self._sig.update(bytes)
+        self._hash.update(bytes)
         return bytes
 
     def hexdigest(self) -> str:
@@ -140,7 +140,7 @@ class SHA256TransparentIOReader(Generic[AnyStr]):
         Returns:
             The digest in hex formaat.
         """
-        return self._sig.hexdigest()
+        return self._hash.hexdigest()
 
     # Passthrough any other calls
     def __getattr__(self, attr_name: str) -> Any:

--- a/synapse/media/media_storage.py
+++ b/synapse/media/media_storage.py
@@ -73,7 +73,7 @@ logger = logging.getLogger(__name__)
 CRLF = b"\r\n"
 
 
-class SHA256TransparentBinaryIO:
+class SHA256TransparentIOWriter:
     """Will generate a SHA256 hash from a source stream transparently.
 
     Args:
@@ -81,7 +81,7 @@ class SHA256TransparentBinaryIO:
     """
 
     def __init__(self, source: BinaryIO):
-        self._sig = hashlib.sha256()
+        self._hash = hashlib.sha256()
         self._source = source
 
     def write(self, buffer: Union[bytes, bytearray]) -> int:
@@ -94,7 +94,7 @@ class SHA256TransparentBinaryIO:
             the value of source.write()
         """
         res = self._source.write(buffer)
-        self._sig.update(buffer)
+        self._hash.update(buffer)
         return res
 
     def hexdigest(self) -> str:
@@ -103,14 +103,14 @@ class SHA256TransparentBinaryIO:
         Returns:
             The digest in hex formaat.
         """
-        return self._sig.hexdigest()
+        return self._hash.hexdigest()
 
     # Passthrough any other calls
     def __getattr__(self, attr_name: str) -> Any:
         return getattr(self._source, attr_name)
 
 
-class SHA256TransparentIO(Generic[AnyStr]):
+class SHA256TransparentIOReader(Generic[AnyStr]):
     """Will generate a SHA256 hash from a source stream transparently.
 
     Args:
@@ -118,7 +118,7 @@ class SHA256TransparentIO(Generic[AnyStr]):
     """
 
     def __init__(self, source: IO):
-        self._sig = hashlib.sha256()
+        self._hash = hashlib.sha256()
         self._source = source
 
     def read(self, n: int = -1) -> AnyStr:

--- a/synapse/media/media_storage.py
+++ b/synapse/media/media_storage.py
@@ -107,7 +107,7 @@ class SHA256TransparentBinaryIO:
 
     # Passthrough any other calls
     def __getattr__(self, attr_name: str) -> Any:
-        return getattr(self.obj, attr_name)
+        return getattr(self._source, attr_name)
 
 
 class SHA256TransparentIO(Generic[AnyStr]):
@@ -144,7 +144,7 @@ class SHA256TransparentIO(Generic[AnyStr]):
 
     # Passthrough any other calls
     def __getattr__(self, attr_name: str) -> Any:
-        return getattr(self.obj, attr_name)
+        return getattr(self._source, attr_name)
 
 
 class MediaStorage:

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -1007,14 +1007,14 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
             SELECT 1
             FROM local_media_repository
             WHERE sha256 = ? AND quarantined_by IS NOT NULL
-            LIMIT 1
 
             UNION ALL
 
             SELECT 1
             FROM remote_media_cache
             WHERE sha256 = ? AND quarantined_by IS NOT NULL
-            LIMIT 1"""
+            LIMIT 1
+            """
             txn.execute(sql, (sha256, sha256))
             row = txn.fetchone()
             return row is not None

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -163,7 +163,7 @@ class MediaRepositoryBackgroundUpdateStore(SQLBaseStore):
             update_name="local_media_repository_sha256_idx",
             index_name="local_media_repository_sha256",
             table="local_media_repository",
-            where_clause="WHERE sha256 IS NOT NULL",
+            where_clause="sha256 IS NOT NULL",
             columns=[
                 "sha256",
             ],
@@ -173,7 +173,7 @@ class MediaRepositoryBackgroundUpdateStore(SQLBaseStore):
             update_name="remote_media_cache_sha256_idx",
             index_name="remote_media_cache_sha256",
             table="remote_media_cache",
-            where_clause="WHERE sha256 IS NOT NULL",
+            where_clause="sha256 IS NOT NULL",
             columns=[
                 "sha256",
             ],

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -509,7 +509,6 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
         await self.db_pool.simple_update_one(
             "local_media_repository",
             keyvalues={
-                "user_id": user_id.to_string(),
                 "media_id": media_id,
             },
             updatevalues=updatevalues,

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1167,11 +1167,11 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
         # Split results into hashes, and hashless media.
         hashes = set()
         non_hashed_media_ids = set()
-        for row in results:
-            if row[0]:
-                hashes.add(row[0])
+        for sha256, media_id in txn:
+            if sha256:
+                hashes.add(sha256)
             else:
-                non_hashed_media_ids.add(row[1])
+                non_hashed_media_ids.add(media_id)
 
         total_media_quarantined = 0
 
@@ -1246,15 +1246,15 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
             mxcs,
         )
 
-        hash_sql = f"SELECT sha256, media_id, media_origin FROM remote_media_cache WHERE {hash_sql_in_list_clause}"
+        hash_sql = f"SELECT sha256, media_origin, media_id FROM remote_media_cache WHERE {hash_sql_in_list_clause}"
         txn.execute(hash_sql, hash_sql_args)
+
         # Split results into hashes, and hashless media.
-        row = txn.fetchone()
-        if row:
-            if row[0]:
-                hashes.add(row[0])
+        for sha256, media_origin, media_id in txn:
+            if sha256:
+                hashes.add(sha256)
             else:
-                non_hashed_media_ids.add((row[1], row[2]))
+                non_hashed_media_ids.add((media_origin, media_id))
 
         total_media_quarantined = 0
         # Effectively a legacy path, update any media

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1152,8 +1152,8 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
         sql = """
             UPDATE local_media_repository
             SET quarantined_by = ?
-            WHERE media_id = ?
-            OR sha256 IN (SELECT DISTINCT sha256 FROM local_media_repository WHERE media_id = ?)
+            WHERE (media_id = ?
+            OR sha256 IN (SELECT DISTINCT sha256 FROM local_media_repository WHERE media_id = ?))
         """
 
         # set quarantine

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1178,7 +1178,10 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
                 WHERE media_origin = ? AND media_id = ?
                 OR sha256 IN (SELECT DISTINCT sha256 FROM remote_media_cache WHERE media_origin = ? AND media_id = ?)
             """,
-            [(quarantined_by, origin, media_id, origin, media_id) for origin, media_id in remote_mxcs],
+            [
+                (quarantined_by, origin, media_id, origin, media_id)
+                for origin, media_id in remote_mxcs
+            ],
         )
         total_media_quarantined += txn.rowcount if txn.rowcount > 0 else 0
 

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -42,7 +42,7 @@ try:
     import icu
 
     USE_ICU = True
-except ModuleNotFoundError:
+except Exception:
     USE_ICU = False
 
 from synapse.api.errors import StoreError

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -42,7 +42,7 @@ try:
     import icu
 
     USE_ICU = True
-except Exception:
+except ModuleNotFoundError:
     USE_ICU = False
 
 from synapse.api.errors import StoreError

--- a/synapse/storage/schema/__init__.py
+++ b/synapse/storage/schema/__init__.py
@@ -19,7 +19,7 @@
 #
 #
 
-SCHEMA_VERSION = 90  # remember to update the list below when updating
+SCHEMA_VERSION = 91  # remember to update the list below when updating
 """Represents the expectations made by the codebase about the database schema
 
 This should be incremented whenever the codebase changes its requirements on the

--- a/synapse/storage/schema/main/delta/91/01_media_hash.sql
+++ b/synapse/storage/schema/main/delta/91/01_media_hash.sql
@@ -11,10 +11,6 @@
 -- See the GNU Affero General Public License for more details:
 -- <https://www.gnu.org/licenses/agpl-3.0.html>.
 
--- Add a column `sha256` to `local_media_repository` table.
+-- Store the SHA256 content hash of media files.
 ALTER TABLE local_media_repository ADD COLUMN sha256 TEXT;
 ALTER TABLE remote_media_cache ADD COLUMN sha256 TEXT;
-
--- Add a cache
-CREATE INDEX local_media_repository_sha256 ON local_media_repository (sha256, media_id);
-CREATE INDEX remote_media_cache_sha256 ON remote_media_cache (sha256, media_id);

--- a/synapse/storage/schema/main/delta/91/01_media_hash.sql
+++ b/synapse/storage/schema/main/delta/91/01_media_hash.sql
@@ -14,3 +14,8 @@
 -- Store the SHA256 content hash of media files.
 ALTER TABLE local_media_repository ADD COLUMN sha256 TEXT;
 ALTER TABLE remote_media_cache ADD COLUMN sha256 TEXT;
+
+-- Add a background updates to handle creating the new index.
+INSERT INTO background_updates (ordering, update_name, progress_json) VALUES
+    (9101, 'local_media_repository_sha256_idx', '{}'),
+    (9101, 'remote_media_cache_sha256_idx', '{}');

--- a/synapse/storage/schema/main/delta/91/01_media_hash.sql
+++ b/synapse/storage/schema/main/delta/91/01_media_hash.sql
@@ -1,0 +1,20 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2025 New Vector, Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+-- Add a column `sha256` to `local_media_repository` table.
+ALTER TABLE local_media_repository ADD COLUMN sha256 TEXT;
+ALTER TABLE remote_media_cache ADD COLUMN sha256 TEXT;
+
+-- Add a cache
+CREATE INDEX local_media_repository_sha256 ON local_media_repository (sha256, media_id);
+CREATE INDEX remote_media_cache_sha256 ON remote_media_cache (sha256, media_id);

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -369,6 +369,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                 time_now_ms=self.clock.time_msec(),
                 upload_name=None,
                 filesystem_id="xyz",
+                sha256="abcdefg12345",
             )
         )
 

--- a/tests/media/test_media_retention.py
+++ b/tests/media/test_media_retention.py
@@ -31,6 +31,9 @@ from synapse.rest.client import login, register, room
 from synapse.server import HomeServer
 from synapse.types import UserID
 from synapse.util import Clock
+from synapse.util.stringutils import (
+    random_string,
+)
 
 from tests import unittest
 from tests.unittest import override_config
@@ -65,7 +68,6 @@ class MediaRetentionTestCase(unittest.HomeserverTestCase):
         # quarantined media) into both the local store and the remote cache, plus
         # one additional local media that is marked as protected from quarantine.
         media_repository = hs.get_media_repository()
-        test_media_content = b"example string"
 
         def _create_media_and_set_attributes(
             last_accessed_ms: Optional[int],
@@ -73,12 +75,14 @@ class MediaRetentionTestCase(unittest.HomeserverTestCase):
             is_protected: Optional[bool] = False,
         ) -> MXCUri:
             # "Upload" some media to the local media store
+            # If the meda
+            random_content = bytes(random_string(24), "utf-8")
             mxc_uri: MXCUri = self.get_success(
                 media_repository.create_content(
                     media_type="text/plain",
                     upload_name=None,
-                    content=io.BytesIO(test_media_content),
-                    content_length=len(test_media_content),
+                    content=io.BytesIO(random_content),
+                    content_length=len(random_content),
                     auth_user=UserID.from_string(test_user_id),
                 )
             )
@@ -129,7 +133,7 @@ class MediaRetentionTestCase(unittest.HomeserverTestCase):
                     time_now_ms=clock.time_msec(),
                     upload_name="testfile.txt",
                     filesystem_id="abcdefg12345",
-                    sha256="abcdefg12345",
+                    sha256=random_string(24),
                 )
             )
 

--- a/tests/media/test_media_retention.py
+++ b/tests/media/test_media_retention.py
@@ -129,6 +129,7 @@ class MediaRetentionTestCase(unittest.HomeserverTestCase):
                     time_now_ms=clock.time_msec(),
                     upload_name="testfile.txt",
                     filesystem_id="abcdefg12345",
+                    sha256="abcdefg12345",
                 )
             )
 

--- a/tests/media/test_media_storage.py
+++ b/tests/media/test_media_storage.py
@@ -1257,3 +1257,26 @@ class RemoteDownloadLimiterTestCase(unittest.HomeserverTestCase):
         )
         assert channel.code == 502
         assert channel.json_body["errcode"] == "M_TOO_LARGE"
+
+class MediaHashesTestCase(unittest.HomeserverTestCase):
+    servlets = [
+        login.register_servlets,
+        admin.register_servlets,
+    ]
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.user = self.register_user("user", "pass")
+        self.tok = self.login("user", "pass")
+        self.store = hs.get_datastores().main
+
+    def create_resource_dict(self) -> Dict[str, Resource]:
+        resources = super().create_resource_dict()
+        resources["/_matrix/media"] = self.hs.get_media_repository_resource()
+        return resources
+
+    async def test_upload_innocent(self) -> None:
+        """Attempt to upload some innocent data that should be allowed."""
+        media = self.helper.upload_media(SMALL_PNG, tok=self.tok, expect_code=200)
+        print(media)
+        store_media = self.store.get_local_media("abcdef")
+        print(store_media)

--- a/tests/media/test_media_storage.py
+++ b/tests/media/test_media_storage.py
@@ -42,6 +42,7 @@ from twisted.web.resource import Resource
 from synapse.api.errors import Codes, HttpResponseException
 from synapse.api.ratelimiting import Ratelimiter
 from synapse.events import EventBase
+from synapse.http.client import ByteWriteable
 from synapse.http.types import QueryParams
 from synapse.logging.context import make_deferred_yieldable
 from synapse.media._base import FileInfo, ThumbnailInfo
@@ -59,7 +60,7 @@ from synapse.util import Clock
 
 from tests import unittest
 from tests.server import FakeChannel
-from tests.test_utils import SMALL_CMYK_JPEG, SMALL_PNG
+from tests.test_utils import SMALL_CMYK_JPEG, SMALL_PNG, SMALL_PNG_SHA256
 from tests.unittest import override_config
 from tests.utils import default_config
 
@@ -1258,25 +1259,106 @@ class RemoteDownloadLimiterTestCase(unittest.HomeserverTestCase):
         assert channel.code == 502
         assert channel.json_body["errcode"] == "M_TOO_LARGE"
 
+
 class MediaHashesTestCase(unittest.HomeserverTestCase):
     servlets = [
-        login.register_servlets,
         admin.register_servlets,
+        login.register_servlets,
+        media.register_servlets,
     ]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.user = self.register_user("user", "pass")
         self.tok = self.login("user", "pass")
         self.store = hs.get_datastores().main
+        self.client = hs.get_federation_http_client()
 
     def create_resource_dict(self) -> Dict[str, Resource]:
         resources = super().create_resource_dict()
         resources["/_matrix/media"] = self.hs.get_media_repository_resource()
         return resources
 
-    async def test_upload_innocent(self) -> None:
-        """Attempt to upload some innocent data that should be allowed."""
+    def test_ensure_correct_sha256(self) -> None:
+        """Check that the hash does not change"""
         media = self.helper.upload_media(SMALL_PNG, tok=self.tok, expect_code=200)
-        print(media)
-        store_media = self.store.get_local_media("abcdef")
-        print(store_media)
+        mxc = media.get("content_uri")
+        assert mxc
+        store_media = self.get_success(self.store.get_local_media(mxc[11:]))
+        assert store_media
+        self.assertEqual(
+            store_media.sha256,
+            SMALL_PNG_SHA256,
+        )
+
+    def test_ensure_multiple_correct_sha256(self) -> None:
+        """Check that two media items have the same hash."""
+        media_a = self.helper.upload_media(SMALL_PNG, tok=self.tok, expect_code=200)
+        mxc_a = media_a.get("content_uri")
+        assert mxc_a
+        store_media_a = self.get_success(self.store.get_local_media(mxc_a[11:]))
+        assert store_media_a
+
+        media_b = self.helper.upload_media(SMALL_PNG, tok=self.tok, expect_code=200)
+        mxc_b = media_b.get("content_uri")
+        assert mxc_b
+        store_media_b = self.get_success(self.store.get_local_media(mxc_b[11:]))
+        assert store_media_b
+
+        self.assertNotEqual(
+            store_media_a.media_id,
+            store_media_b.media_id,
+        )
+        self.assertEqual(
+            store_media_a.sha256,
+            store_media_b.sha256,
+        )
+
+    @staticmethod
+    def read_body(
+        response: IResponse, stream: ByteWriteable, max_size: Optional[int]
+    ) -> Deferred:
+        d: Deferred = defer.Deferred()
+        stream.write(SMALL_PNG)
+        d.callback(len(SMALL_PNG))
+        return d
+
+    @override_config(
+        {
+            "enable_authenticated_media": False,
+        }
+    )
+    # mock actually reading file body
+    @patch(
+        "synapse.http.matrixfederationclient.read_body_with_max_size",
+        read_body,
+    )
+    def test_ensure_correct_sha256_federated(self) -> None:
+        """Check that federated media have the same hash."""
+
+        # Mock getting a file over federation
+        async def _send_request(*args: Any, **kwargs: Any) -> IResponse:
+            resp = MagicMock(spec=IResponse)
+            resp.code = 200
+            resp.length = 500
+            resp.headers = Headers({"Content-Type": ["application/octet-stream"]})
+            resp.phrase = b"OK"
+            return resp
+
+        self.client._send_request = _send_request  # type: ignore
+
+        # first request should go through
+        channel = self.make_request(
+            "GET",
+            "/_matrix/media/v3/download/remote.org/abc",
+            shorthand=False,
+            access_token=self.tok,
+        )
+        assert channel.code == 200
+        store_media = self.get_success(
+            self.store.get_cached_remote_media("remote.org", "abc")
+        )
+        assert store_media
+        self.assertEqual(
+            store_media.sha256,
+            SMALL_PNG_SHA256,
+        )

--- a/tests/media/test_media_storage.py
+++ b/tests/media/test_media_storage.py
@@ -1260,6 +1260,15 @@ class RemoteDownloadLimiterTestCase(unittest.HomeserverTestCase):
         assert channel.json_body["errcode"] == "M_TOO_LARGE"
 
 
+def read_body(
+    response: IResponse, stream: ByteWriteable, max_size: Optional[int]
+) -> Deferred:
+    d: Deferred = defer.Deferred()
+    stream.write(SMALL_PNG)
+    d.callback(len(SMALL_PNG))
+    return d
+
+
 class MediaHashesTestCase(unittest.HomeserverTestCase):
     servlets = [
         admin.register_servlets,
@@ -1312,15 +1321,6 @@ class MediaHashesTestCase(unittest.HomeserverTestCase):
             store_media_a.sha256,
             store_media_b.sha256,
         )
-
-    @staticmethod
-    def read_body(
-        response: IResponse, stream: ByteWriteable, max_size: Optional[int]
-    ) -> Deferred:
-        d: Deferred = defer.Deferred()
-        stream.write(SMALL_PNG)
-        d.callback(len(SMALL_PNG))
-        return d
 
     @override_config(
         {

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -32,6 +32,7 @@ from synapse.http.server import JsonResource
 from synapse.rest.admin import VersionServlet
 from synapse.rest.client import login, media, room
 from synapse.server import HomeServer
+from synapse.types import UserID
 from synapse.util import Clock
 
 from tests import unittest
@@ -227,10 +228,26 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
         # Upload some media
         response_1 = self.helper.upload_media(SMALL_PNG, tok=non_admin_user_tok)
         response_2 = self.helper.upload_media(SMALL_PNG, tok=non_admin_user_tok)
+        response_3 = self.helper.upload_media(SMALL_PNG, tok=non_admin_user_tok)
 
         # Extract media IDs
         server_and_media_id_1 = response_1["content_uri"][6:]
         server_and_media_id_2 = response_2["content_uri"][6:]
+        server_and_media_id_3 = response_3["content_uri"][6:]
+
+        # Remove the hash from the media to simulate historic media.
+        self.get_success(
+            self.hs.get_datastores().main.update_local_media(
+                server_and_media_id_3.split("/")[1],
+                "image/png",
+                None,
+                500,
+                UserID.from_string(non_admin_user),
+                None,
+                None,
+                None,
+            )
+        )
 
         # Quarantine all media by this user
         url = "/_synapse/admin/v1/user/%s/media/quarantine" % urllib.parse.quote(
@@ -244,12 +261,13 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
         self.pump(1.0)
         self.assertEqual(200, channel.code, msg=channel.json_body)
         self.assertEqual(
-            channel.json_body, {"num_quarantined": 2}, "Expected 2 quarantined items"
+            channel.json_body, {"num_quarantined": 3}, "Expected 3 quarantined items"
         )
 
         # Attempt to access each piece of media
         self._ensure_quarantined(admin_user_tok, server_and_media_id_1)
         self._ensure_quarantined(admin_user_tok, server_and_media_id_2)
+        self._ensure_quarantined(admin_user_tok, server_and_media_id_3)
 
     def test_cannot_quarantine_safe_media(self) -> None:
         self.register_user("user_admin", "pass", admin=True)

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -20,7 +20,7 @@
 #
 
 import urllib.parse
-from typing import Dict
+from typing import Dict, cast
 
 from parameterized import parameterized
 
@@ -238,14 +238,13 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
         # Remove the hash from the media to simulate historic media.
         self.get_success(
             self.hs.get_datastores().main.update_local_media(
-                server_and_media_id_3.split("/")[1],
-                "image/png",
-                None,
-                500,
-                UserID.from_string(non_admin_user),
-                None,
-                None,
-                None,
+                media_id=server_and_media_id_3.split("/")[1],
+                media_type="image/png",
+                upload_name=None,
+                media_length=123,
+                user_id=UserID.from_string(non_admin_user),
+                # Hack to force some media to have no hash.
+                sha256=cast(str, None),
             )
         )
 

--- a/tests/rest/admin/test_media.py
+++ b/tests/rest/admin/test_media.py
@@ -35,7 +35,7 @@ from synapse.server import HomeServer
 from synapse.util import Clock
 
 from tests import unittest
-from tests.test_utils import SMALL_PNG
+from tests.test_utils import SMALL_CMYK_JPEG, SMALL_PNG
 from tests.unittest import override_config
 
 VALID_TIMESTAMP = 1609459200000  # 2021-01-01 in milliseconds
@@ -598,23 +598,27 @@ class DeleteMediaByDateSizeTestCase(_AdminMediaTests):
 
 
 class QuarantineMediaByIDTestCase(_AdminMediaTests):
+    def upload_media_and_return_media_id(self, data: bytes) -> str:
+        # Upload some media into the room
+        response = self.helper.upload_media(
+            data,
+            tok=self.admin_user_tok,
+            expect_code=200,
+        )
+        # Extract media ID from the response
+        server_and_media_id = response["content_uri"][6:]  # Cut off 'mxc://'
+        return server_and_media_id.split("/")[1]
+
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.server_name = hs.hostname
 
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")
-
-        # Upload some media into the room
-        response = self.helper.upload_media(
-            SMALL_PNG,
-            tok=self.admin_user_tok,
-            expect_code=200,
-        )
-        # Extract media ID from the response
-        server_and_media_id = response["content_uri"][6:]  # Cut off 'mxc://'
-        self.media_id = server_and_media_id.split("/")[1]
-
+        self.media_id = self.upload_media_and_return_media_id(SMALL_PNG)
+        self.media_id_2 = self.upload_media_and_return_media_id(SMALL_PNG)
+        self.media_id_3 = self.upload_media_and_return_media_id(SMALL_PNG)
+        self.media_id_other = self.upload_media_and_return_media_id(SMALL_CMYK_JPEG)
         self.url = "/_synapse/admin/v1/media/%s/%s/%s"
 
     @parameterized.expand(["quarantine", "unquarantine"])
@@ -685,6 +689,52 @@ class QuarantineMediaByIDTestCase(_AdminMediaTests):
         media_info = self.get_success(self.store.get_local_media(self.media_id))
         assert media_info is not None
         self.assertFalse(media_info.quarantined_by)
+
+    def test_quarantine_media_match_hash(self) -> None:
+        """
+        Tests that quarantining removes all media with the same hash
+        """
+
+        media_info = self.get_success(self.store.get_local_media(self.media_id))
+        assert media_info is not None
+        self.assertFalse(media_info.quarantined_by)
+
+        # quarantining
+        channel = self.make_request(
+            "POST",
+            self.url % ("quarantine", self.server_name, self.media_id),
+            access_token=self.admin_user_tok,
+        )
+
+        self.assertEqual(200, channel.code, msg=channel.json_body)
+        self.assertFalse(channel.json_body)
+
+        # Test that ALL similar media was quarantined.
+        for media in [self.media_id, self.media_id_2, self.media_id_3]:
+            media_info = self.get_success(self.store.get_local_media(media))
+            assert media_info is not None
+            self.assertTrue(media_info.quarantined_by)
+
+        # Test that other media was not.
+        media_info = self.get_success(self.store.get_local_media(self.media_id_other))
+        assert media_info is not None
+        self.assertFalse(media_info.quarantined_by)
+
+        # remove from quarantine
+        channel = self.make_request(
+            "POST",
+            self.url % ("unquarantine", self.server_name, self.media_id),
+            access_token=self.admin_user_tok,
+        )
+
+        self.assertEqual(200, channel.code, msg=channel.json_body)
+        self.assertFalse(channel.json_body)
+
+        # Test that ALL similar media is now reset.
+        for media in [self.media_id, self.media_id_2, self.media_id_3]:
+            media_info = self.get_success(self.store.get_local_media(media))
+            assert media_info is not None
+            self.assertFalse(media_info.quarantined_by)
 
     def test_quarantine_protected_media(self) -> None:
         """

--- a/tests/rest/client/test_media.py
+++ b/tests/rest/client/test_media.py
@@ -137,6 +137,7 @@ class MediaDomainBlockingTests(unittest.HomeserverTestCase):
                 time_now_ms=clock.time_msec(),
                 upload_name="test.png",
                 filesystem_id=file_id,
+                sha256=file_id,
             )
         )
         self.register_user("user", "password")
@@ -2593,6 +2594,7 @@ class AuthenticatedMediaTestCase(unittest.HomeserverTestCase):
                 time_now_ms=self.clock.time_msec(),
                 upload_name="remote_test.png",
                 filesystem_id=file_id,
+                sha256=file_id,
             )
         )
 
@@ -2725,6 +2727,7 @@ class AuthenticatedMediaTestCase(unittest.HomeserverTestCase):
                 time_now_ms=self.clock.time_msec(),
                 upload_name="remote_test.png",
                 filesystem_id=file_id,
+                sha256=file_id,
             )
         )
 

--- a/tests/rest/media/test_domain_blocking.py
+++ b/tests/rest/media/test_domain_blocking.py
@@ -61,6 +61,7 @@ class MediaDomainBlockingTests(unittest.HomeserverTestCase):
                 time_now_ms=clock.time_msec(),
                 upload_name="test.png",
                 filesystem_id=file_id,
+                sha256=file_id,
             )
         )
 

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -140,6 +140,8 @@ SMALL_PNG = unhexlify(
     b"0a2db40000000049454e44ae426082"
 )
 
+SMALL_PNG_SHA256 = "ebf4f635a17d10d6eb46ba680b70142419aa3220f228001a036d311a22ee9d2a"
+
 # A small CMYK-encoded JPEG image used in some tests.
 #
 # Generated with:

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -139,7 +139,7 @@ SMALL_PNG = unhexlify(
     b"0000001f15c4890000000a49444154789c63000100000500010d"
     b"0a2db40000000049454e44ae426082"
 )
-
+# The SHA256 hexdigest for the above bytes.
 SMALL_PNG_SHA256 = "ebf4f635a17d10d6eb46ba680b70142419aa3220f228001a036d311a22ee9d2a"
 
 # A small CMYK-encoded JPEG image used in some tests.


### PR DESCRIPTION
This PR makes a few radical changes to media. This now stores the SHA256 hash of each file stored in the database (excluding thumbnails, more on that later). If a set of media is quarantined, any additional uploads of the same file contents or any other files with the same hash will be quarantined at the same time.

Currently this does NOT:
 - De-duplicate media, although a future extension could be to do that.
 - Run any background jobs to identify the hashes of older files. This could also be a future extension, though the value of doing so is limited to combat the abuse of recent media.
 - Hash thumbnails. It's assumed that thumbnails are parented to some form of media, so you'd likely be wanting to quarantine the media and the thumbnail at the same time.

This needs further refinement, but just about works. I'll take this out of draft when it's ready.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
