### PR TITLE
Add docs for how to clear out the Poetry wheel cache

### DIFF
--- a/changelog.d/18283.doc
+++ b/changelog.d/18283.doc
@@ -1,0 +1,1 @@
+Add docs for how to clear out the Poetry wheel cache.

--- a/docs/development/dependencies.md
+++ b/docs/development/dependencies.md
@@ -150,6 +150,24 @@ $ poetry shell
 $ poetry install --extras all
 ```
 
+If you want to go even further and remove the Poetry caches (this is necessary in order
+to rebuild or fetch new wheels):
+
+```shell
+# Find your Poetry cache directory
+# Docs: https://github.com/python-poetry/poetry/blob/main/docs/configuration.md#cache-directory
+$ poetry config cache-dir
+
+# Remove packages from all cached repositories
+$ poetry cache clear --all .
+
+# Go completely nuclear and clear out everything Poetry cache related
+# including the wheel artifacts which is not covered by the above command
+# (see https://github.com/python-poetry/poetry/issues/10304)
+$ rm -rf $(poetry config cache-dir)
+```
+
+
 ## ...run a command in the `poetry` virtualenv?
 
 Use `poetry run cmd args` when you need the python virtualenv context.

--- a/docs/development/dependencies.md
+++ b/docs/development/dependencies.md
@@ -150,8 +150,7 @@ $ poetry shell
 $ poetry install --extras all
 ```
 
-If you want to go even further and remove the Poetry caches (this is necessary in order
-to rebuild or fetch new wheels):
+If you want to go even further and remove the Poetry caches:
 
 ```shell
 # Find your Poetry cache directory
@@ -164,6 +163,11 @@ $ poetry cache clear --all .
 # Go completely nuclear and clear out everything Poetry cache related
 # including the wheel artifacts which is not covered by the above command
 # (see https://github.com/python-poetry/poetry/issues/10304)
+#
+# This is necessary in order to rebuild or fetch new wheels. For example, if you update
+# the `icu` library in on your system, you will need to rebuild the PyICU Python package
+# in order to incorporate the correct dynamically linked library locations otherwise you
+# will run into errors like: `ImportError: libicui18n.so.75: cannot open shared object file: No such file or directory`
 $ rm -rf $(poetry config cache-dir)
 ```
 


### PR DESCRIPTION
Add docs for how to clear out the Poetry wheel cache

As shared by @reivilibre, https://github.com/element-hq/synapse/pull/18261#issuecomment-2754607816

Relevant Poetry issue around how this should be handled by them: https://github.com/python-poetry/poetry/issues/10304


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
