### PR TITLE
Implementation of MSC4155

### DIFF
--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -280,6 +280,8 @@ class AccountDataTypes:
     IGNORED_USER_LIST: Final = "m.ignored_user_list"
     TAG: Final = "m.tag"
     PUSH_RULES: Final = "m.push_rules"
+    # MSC4155: Invite filtering
+    INVITE_PERMISSION_CONFIG: Final = "org.matrix.msc4155.invite_permission_config"
 
 
 class HistoryVisibility:

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -560,3 +560,6 @@ class ExperimentalConfig(Config):
 
         # MSC4076: Add `disable_badge_count`` to pusher configuration
         self.msc4076_enabled: bool = experimental.get("msc4076_enabled", False)
+
+        # MSC4076: Invite filtering
+        self.msc4155_enabled: bool = experimental.get("msc4155_enabled", False)

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -904,6 +904,18 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                     logger.info("Blocking invite due to spam checker")
                     block_invite_result = spam_check
 
+            if self.config.experimental.msc4155_enabled:
+                invite_config = await self.store.get_invite_config_for_user(target_id)
+                if not invite_config.invite_allowed(requester.user):
+                    logger.info(
+                        f"User {target_id} rejected invite from {requester.user}"
+                    )
+                    raise SynapseError(
+                        403,
+                        "You are not permitted to invite this user.",
+                        errcode=Codes.FORBIDDEN,
+                    )
+
             if block_invite_result is not None:
                 raise SynapseError(
                     403,

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -174,6 +174,7 @@ class VersionsRestServlet(RestServlet):
                     "org.matrix.simplified_msc3575": msc3575_enabled,
                     # Arbitrary key-value profile fields.
                     "uk.tcpip.msc4133": self.config.experimental.msc4133_enabled,
+                    "org.matrix.msc4155": self.config.experimental.msc4155_enabled,
                 },
             },
         )


### PR DESCRIPTION
This implements https://github.com/matrix-org/matrix-spec-proposals/pull/4155, which adds support for a new account data type that blocks an invite based on some conditions in the event contents.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
