### PR TITLE
Add support for sending notification counts in simplified sliding sync

### DIFF
--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -1066,9 +1066,18 @@ class SlidingSyncRestServlet(RestServlet):
         serialized_rooms: Dict[str, JsonDict] = {}
         for room_id, room_result in rooms.items():
             serialized_rooms[room_id] = {
-                "notification_count": room_result.notification_count,
-                "highlight_count": room_result.highlight_count,
+                "notification_count": room_result.notif_counts.main_timeline.notify_count,
+                "highlight_count": room_result.notif_counts.main_timeline.highlight_count,
             }
+
+            if len(room_result.notif_counts.threads) > 0:
+                serialized_rooms[room_id]["unread_thread_notifications"] = {
+                    thread_id: {
+                        "notification_count": counts.notify_count,
+                        "highlight_count": counts.highlight_count,
+                    }
+                    for thread_id, counts in room_result.notif_counts.threads.items()
+                }
 
             if room_result.bump_stamp is not None:
                 serialized_rooms[room_id]["bump_stamp"] = room_result.bump_stamp

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -666,7 +666,11 @@ class ReceiptsWorkerStore(SQLBaseStore):
         return results
 
     async def get_linearized_receipts_for_user_in_rooms(
-        self, user_id: str, room_ids: StrCollection, to_key: MultiWriterStreamToken
+        self,
+        user_id: str,
+        room_ids: StrCollection,
+        from_key: Optional[MultiWriterStreamToken] = None,
+        to_key: Optional[MultiWriterStreamToken] = None,
     ) -> Mapping[str, Sequence[ReceiptInRoom]]:
         """Fetch all receipts for the user in the given room.
 
@@ -685,11 +689,18 @@ class ReceiptsWorkerStore(SQLBaseStore):
             sql = f"""
                 SELECT instance_name, stream_id, room_id, receipt_type, user_id, event_id, thread_id, data
                 FROM receipts_linearized
-                WHERE {clause} AND user_id = ? AND stream_id <= ?
+                WHERE {clause} AND user_id = ?
             """
 
             args.append(user_id)
-            args.append(to_key.get_max_stream_pos())
+
+            if from_key is not None:
+                sql += " AND stream_id >= ?"
+                args.append(from_key.get_max_stream_pos())
+
+            if to_key is not None:
+                sql += " AND stream_id <= ?"
+                args.append(to_key.get_max_stream_pos())
 
             txn.execute(sql, args)
 

--- a/synapse/types/handlers/sliding_sync.py
+++ b/synapse/types/handlers/sliding_sync.py
@@ -40,6 +40,8 @@ import attr
 from synapse._pydantic_compat import Extra
 from synapse.api.constants import EventTypes
 from synapse.events import EventBase
+from synapse.storage.databases.main.event_push_actions import RoomNotifCounts
+from synapse.storage.databases.main.receipts import ReceiptInRoom
 from synapse.types import (
     DeviceListUpdates,
     JsonDict,
@@ -163,10 +165,10 @@ class SlidingSyncResult:
                 own user ID. (same as sync `v2 m.joined_member_count`)
             invited_count: The number of users with membership of invite. (same as sync v2
                 `m.invited_member_count`)
-            notification_count: The total number of unread notifications for this room. (same
-                as sync v2)
-            highlight_count: The number of unread notifications for this room with the highlight
-                flag set. (same as sync v2)
+            notif_counts: An object containing the number of unread notifications for both
+                the main thread and any other threads.
+            room_receipts: A sequence of any read receipts from the user in question in
+                the room, used to calculate whether the notif_counts could have changed
         """
 
         @attr.s(slots=True, frozen=True, auto_attribs=True)
@@ -197,8 +199,8 @@ class SlidingSyncResult:
         bump_stamp: Optional[int]
         joined_count: Optional[int]
         invited_count: Optional[int]
-        notification_count: int
-        highlight_count: int
+        notif_counts: RoomNotifCounts
+        room_receipts: Sequence[ReceiptInRoom]
 
         def __bool__(self) -> bool:
             return (
@@ -215,6 +217,7 @@ class SlidingSyncResult:
                 or bool(self.required_state)
                 or bool(self.timeline_events)
                 or bool(self.stripped_state)
+                or bool(self.room_receipts)
             )
 
     @attr.s(slots=True, frozen=True, auto_attribs=True)


### PR DESCRIPTION
WIP PR for adding notification count support to simplified sliding sync, ie. implementing the `notification_count` and `highlight_count` fields which are already in the SSS MSC but were set to dummy values, and also adding `unread_thread_notifications` which I've [proposed adding to the MSC](https://github.com/matrix-org/matrix-spec-proposals/pull/4186#discussion_r2016980379). 

This allows notifications to work properly in Element Web's SSS support without us rewriting it to crawl complete room history (again, since we already do this on desktop for search, but not in the right place).

Early eyes would be appreciated on this to make sure it's going in the right direction before I write tests, as I've had to re-jig a few things to allow it to know when to omit and include rooms based on when the notification counts may change.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
