### PR TITLE
Reduce disk wastage by cleaning up `received_transactions` older than 1 day, rather than 30 days.

### DIFF
--- a/changelog.d/18310.misc
+++ b/changelog.d/18310.misc
@@ -1,0 +1,1 @@
+Reduce disk wastage by cleaning up `received_transactions` older than 1 day, rather than 30 days.

--- a/synapse/storage/databases/main/transactions.py
+++ b/synapse/storage/databases/main/transactions.py
@@ -86,10 +86,10 @@ class TransactionWorkerStore(CacheInvalidationWorkerStore):
     @wrap_as_background_process("cleanup_transactions")
     async def _cleanup_transactions(self) -> None:
         now = self._clock.time_msec()
-        month_ago = now - 30 * 24 * 60 * 60 * 1000
+        day_ago = now - 24 * 60 * 60 * 1000
 
         def _cleanup_transactions_txn(txn: LoggingTransaction) -> None:
-            txn.execute("DELETE FROM received_transactions WHERE ts < ?", (month_ago,))
+            txn.execute("DELETE FROM received_transactions WHERE ts < ?", (day_ago,))
 
         await self.db_pool.runInteraction(
             "_cleanup_transactions", _cleanup_transactions_txn


### PR DESCRIPTION
Clean up `received_transactions` older than 1 day, rather than 30 days \
Reduces disk waste by homeservers

Closes #6437