### PR TITLE
Fix `force_tracing_for_users` config when using MAS

### DIFF
--- a/changelog.d/18334.bugfix
+++ b/changelog.d/18334.bugfix
@@ -1,0 +1,1 @@
+Fix `force_tracing_for_users` config when using delegated auth.

--- a/synapse/api/auth/msc3861_delegated.py
+++ b/synapse/api/auth/msc3861_delegated.py
@@ -178,6 +178,7 @@ class MSC3861DelegatedAuth(BaseAuth):
         self._http_client = hs.get_proxied_http_client()
         self._hostname = hs.hostname
         self._admin_token: Callable[[], Optional[str]] = self._config.admin_token
+        self._force_tracing_for_users = hs.config.tracing.force_tracing_for_users
 
         # # Token Introspection Cache
         # This remembers what users/devices are represented by which access tokens,


### PR DESCRIPTION
This is a copy of what we do for internal auth, and we should figure out a way to deduplicate some of this stuff:

https://github.com/element-hq/synapse/blob/dd05cc55eedbf086ae224a13c9ae9f0332d96b1f/synapse/api/auth/internal.py#L62-L110