### PR TITLE
Fix query for room participation

### DIFF
--- a/changelog.d/18345.bugfix
+++ b/changelog.d/18345.bugfix
@@ -1,0 +1,1 @@
+Fix minor performance regression caused by tracking of room participation. Regressed in v1.128.0.


### PR DESCRIPTION
Follow on from #18068

Currently the subquery in `UPDATE` is pointless, as it will still just update all `room_membership` rows. Instead, we should look at the current membership event ID (which is easily retrieved from `local_current_membership`). We also add a `AND NOT participant` to noop the `UPDATE` when the `participant` flag is already set.

cc @H-Shay 