### PR TITLE
Use hosts in rooms of the hierarchy for via parameter

### DIFF
--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -197,6 +197,10 @@ class RoomSummaryHandler:
                 errcode=Codes.NOT_JOINED,
             )
 
+        # When dealing with a hierarchy, it is useful to infer via servers by looking
+        # at hosts already in one of the rooms of the hierarchy
+        gathered_via = set()
+
         if not local_room:
             room_hierarchy = await self._summarize_remote_room_hierarchy(
                 _RoomQueueEntry(requested_room_id, ()),
@@ -285,6 +289,9 @@ class RoomSummaryHandler:
                     room_id,
                     suggested_only,
                 )
+                if room_entry:
+                    hosts = await self._store.get_current_hosts_in_room(room_id)
+                    gathered_via.update(hosts)
 
             # Otherwise, attempt to use information for federation.
             else:
@@ -337,17 +344,21 @@ class RoomSummaryHandler:
                     # The children get added in reverse order so that the next
                     # room to process, according to the ordering, is the last
                     # item in the list.
-                    room_queue.extend(
-                        _RoomQueueEntry(
-                            ev["state_key"],
-                            ev["content"]["via"],
-                            current_depth + 1,
-                            children_room_entries.get(ev["state_key"]),
-                        )
-                        for ev in reversed(room_entry.children_state_events)
-                        if ev["type"] == EventTypes.SpaceChild
-                        and ev["state_key"] not in inaccessible_children
-                    )
+
+                    for ev in reversed(room_entry.children_state_events):
+                        if ev["type"] == EventTypes.SpaceChild and ev["state_key"] not in inaccessible_children:
+                            # We use a dict here instead of a set to keep the insertion order
+                            via = {}
+                            via.update({host: None for host in ev["content"]["via"]})
+                            via.update({v: None for v in gathered_via})
+                            room_queue.append(
+                                _RoomQueueEntry(
+                                    ev["state_key"],
+                                    via.keys(),
+                                    current_depth + 1,
+                                    children_room_entries.get(ev["state_key"]),
+                                )
+                            )
 
         result: JsonDict = {"rooms": rooms_result}
 


### PR DESCRIPTION
### Pull Request Checklist

Scenarii to reproduce:
- user A on server A creates a space
- user A creates a room in this space, with join restricted to the members of the space
- user B on server B joins the space and the room
- user A leaves the space and the room
- user AB on server A joins the space
- user AB can't see the room in the roomlist of the space
- if an user on server A joins the room, the problem is solved

What is happening is that there is no valid via anymore for the room: it is not avail anymore on its original homeserver A, which is the only `via` available in the child event.

This PR gathers `via` parameters of all rooms of the hierarchy previously handled, and pass it to the fed endpoint when trying to fetch the remote hierarchy.

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
