### PR TITLE
Move GET /devices/ off main process

### DIFF
--- a/changelog.d/18355.feature
+++ b/changelog.d/18355.feature
@@ -1,0 +1,1 @@
+Add support for handling `GET /devices/` on workers.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -280,6 +280,7 @@ Additionally, the following REST endpoints can be handled for GET requests:
 
     ^/_matrix/client/(api/v1|r0|v3|unstable)/pushrules/
     ^/_matrix/client/unstable/org.matrix.msc4140/delayed_events
+    ^/_matrix/client/(api/v1|r0|v3|unstable)/devices/
 
     # Account data requests
     ^/_matrix/client/(r0|v3|unstable)/.*/tags

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -181,8 +181,9 @@ class DeviceRestServlet(RestServlet):
     ) -> Tuple[int, JsonDict]:
         # Can only be run on main process
         if not self._is_main_process:
-            logger.error("DELETE on /devices/ must be routed to main process")
-            raise SynapseError(500, "Server misconfigured")
+            error_message = "DELETE on /devices/ must be routed to main process"
+            logger.error(error_message)
+            raise SynapseError(500, error_message)
         assert isinstance(self.device_handler, DeviceHandler)
 
         requester = await self.auth.get_user_by_req(request)

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -179,7 +179,8 @@ class DeviceRestServlet(RestServlet):
     async def on_DELETE(
         self, request: SynapseRequest, device_id: str
     ) -> Tuple[int, JsonDict]:
-        # Can only be run on main process
+        # Can only be run on main process, as changes to device lists must
+        # happen on main.
         if not self._is_main_process:
             error_message = "DELETE on /devices/ must be routed to main process"
             logger.error(error_message)
@@ -230,10 +231,12 @@ class DeviceRestServlet(RestServlet):
     async def on_PUT(
         self, request: SynapseRequest, device_id: str
     ) -> Tuple[int, JsonDict]:
-        # Can only be run on main process
+        # Can only be run on main process, as changes to device lists must
+        # happen on main.
         if not self._is_main_process:
-            logger.error("PUT on /devices/ must be routed to main process")
-            raise SynapseError(500, "Server misconfigured")
+            error_message = "PUT on /devices/ must be routed to main process"
+            logger.error(error_message)
+            raise SynapseError(500, error_message)
         assert isinstance(self.device_handler, DeviceHandler)
 
         requester = await self.auth.get_user_by_req(request, allow_guest=True)


### PR DESCRIPTION
We can't move PUT/DELETE as they do need to happen on main process (due to notification of device changes).