### PR TITLE
Remove the trigger added in #18260 and then reverted

### DIFF
--- a/changelog.d/18373.misc
+++ b/changelog.d/18373.misc
@@ -1,0 +1,1 @@
+Revert "Add total event, unencrypted message, and e2ee event counts to stats reporting".

--- a/synapse/storage/schema/__init__.py
+++ b/synapse/storage/schema/__init__.py
@@ -19,7 +19,7 @@
 #
 #
 
-SCHEMA_VERSION = 91  # remember to update the list below when updating
+SCHEMA_VERSION = 92  # remember to update the list below when updating
 """Represents the expectations made by the codebase about the database schema
 
 This should be incremented whenever the codebase changes its requirements on the

--- a/synapse/storage/schema/__init__.py
+++ b/synapse/storage/schema/__init__.py
@@ -162,6 +162,12 @@ Changes in SCHEMA_VERSION = 89
 Changes in SCHEMA_VERSION = 90
     - Add a column `participant` to `room_memberships` table
     - Add background update to delete unreferenced state groups.
+
+Changes in SCHEMA_VERSION = 91
+    - Add a `sha256` column to the `local_media_repository` and `remote_media_cache` tables.
+
+Changes in SCHEMA_VERSION = 92
+    - Cleaned up a trigger that was added in #18260 and then reverted.
 """
 
 

--- a/synapse/storage/schema/main/delta/92/01_remove_trigger.sql.postgres
+++ b/synapse/storage/schema/main/delta/92/01_remove_trigger.sql.postgres
@@ -1,0 +1,16 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2025 New Vector, Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+-- Removes the trigger that was added in #18260 and then reverted
+DROP TRIGGER IF EXISTS event_stats_increment_counts_trigger ON events;
+DROP FUNCTION IF EXISTS event_stats_increment_counts();

--- a/synapse/storage/schema/main/delta/92/01_remove_trigger.sql.sqlite
+++ b/synapse/storage/schema/main/delta/92/01_remove_trigger.sql.sqlite
@@ -1,0 +1,16 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2025 New Vector, Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+-- Removes the trigger that was added in #18260 and then reverted
+DROP TRIGGER IF EXISTS event_stats_events_insert_trigger;
+DROP TRIGGER IF EXISTS event_stats_events_delete_trigger;


### PR DESCRIPTION
See #18260

This is useful for anyone who tried Synapse v1.129.0rc1 out

Fixes #18349

To test:

 - checkout v1.129.0rc1 and start
 - check that the events table has the trigger (`\dS events` with postgres)
 - checkout this PR and start
 - check that the events table doesn't have the trigger anymore