### PR TITLE
Don't check the `at_hash` (access token hash) in OIDC ID Tokens if we don't use the access token

### DIFF
--- a/changelog.d/18374.misc
+++ b/changelog.d/18374.misc
@@ -1,0 +1,1 @@
+Don't validate the `at_hash` (access token hash) field in OIDC ID Tokens if we don't end up actually using the OIDC Access Token.

--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -587,6 +587,23 @@ class OidcProvider:
         )
 
     @property
+    def _uses_access_token(self) -> bool:
+        """Return True if the `access_token` should be used.
+
+        This is useful to determine whether the access token
+        returned by the identity provider, and
+        any related metadata (such as the `at_hash` field in
+        the ID token), should be validated.
+        """
+        # Currently Synapse only uses the access token to fetch
+        # user metadata from the userinfo endpoint. So we need
+        # only decide based on whether we're using the userinfo
+        # endpoint. This may change in the future if we use the
+        # access token given to us by the IdP for more things,
+        # such as accessing Resource Server APIs.
+        return self._uses_userinfo
+
+    @property
     def issuer(self) -> str:
         """The issuer identifying this provider."""
         return self._config.issuer
@@ -957,7 +974,7 @@ class OidcProvider:
             "nonce": nonce,
             "client_id": self._client_auth.client_id,
         }
-        if self._uses_userinfo and "access_token" in token:
+        if self._uses_access_token and "access_token" in token:
             # If we got an `access_token`, there should be an `at_hash` claim
             # in the `id_token` that we can check against. Setting this
             # instructs authlib to check the value of `at_hash` in the

--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -957,9 +957,16 @@ class OidcProvider:
             "nonce": nonce,
             "client_id": self._client_auth.client_id,
         }
-        if "access_token" in token:
+        if self._uses_userinfo and "access_token" in token:
             # If we got an `access_token`, there should be an `at_hash` claim
-            # in the `id_token` that we can check against.
+            # in the `id_token` that we can check against. Setting this
+            # instructs authlib to check the value of `at_hash` in the
+            # ID token.
+            #
+            # We only need to verify the access token if we actually make
+            # use of it. Which currently only happens when we need to fetch
+            # the user's information from the userinfo_endpoint. Thus, this
+            # check is also gated on self._uses_userinfo.
             claims_params["access_token"] = token["access_token"]
 
         claims_options = {"iss": {"values": [metadata["issuer"]]}}

--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -588,18 +588,16 @@ class OidcProvider:
 
     @property
     def _uses_access_token(self) -> bool:
-        """Return True if the `access_token` should be used.
+        """Return True if the `access_token` will be used during the login process.
 
         This is useful to determine whether the access token
         returned by the identity provider, and
         any related metadata (such as the `at_hash` field in
         the ID token), should be validated.
         """
-        # Currently Synapse only uses the access token to fetch
-        # user metadata from the userinfo endpoint. So we need
-        # only decide based on whether we're using the userinfo
-        # endpoint. This may change in the future if we use the
-        # access token given to us by the IdP for more things,
+        # Currently, Synapse only uses the access_token to fetch
+        # user metadata from the userinfo endpoint. Therefore we only have a single criteria to check right now but this may change in the future and this function should be updated if more usages are introduced. For example, if we start to use the
+        # access_token given to us by the IdP for more things,
         # such as accessing Resource Server APIs.
         return self._uses_userinfo
 

--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -595,10 +595,13 @@ class OidcProvider:
         any related metadata (such as the `at_hash` field in
         the ID token), should be validated.
         """
-        # Currently, Synapse only uses the access_token to fetch
-        # user metadata from the userinfo endpoint. Therefore we only have a single criteria to check right now but this may change in the future and this function should be updated if more usages are introduced. For example, if we start to use the
-        # access_token given to us by the IdP for more things,
-        # such as accessing Resource Server APIs.
+        # Currently, Synapse only uses the access_token to fetch user metadata
+        # from the userinfo endpoint. Therefore we only have a single criteria
+        # to check right now but this may change in the future and this function
+        # should be updated if more usages are introduced.
+        # 
+        # For example, if we start to use the access_token given to us by the
+        # IdP for more things, such as accessing Resource Server APIs.
         return self._uses_userinfo
 
     @property


### PR DESCRIPTION
It doesn't appear necessary to check this value if we don't end up actually using the data it refers to.

This was motivated by our work against the TI-Messenger spec. In our setup, we're receiving the ID Token from the upstream IdP, yet it has an invalid `at_hash` field. We're currently communicating with the IdP's maintainers as to why this is.

In the meantime, we've theorised that checking this field isn't actually necessary in our case. Synapse only uses the access token for fetching user metadata from a separate endpoint:

https://github.com/element-hq/synapse/blob/b3099da71182feebf4fda2ec9eccf7bbffa05143/synapse/handlers/oidc.py#L837-L856

But we don't do this in our setup, as all the user's metadata is included in the ID Token itself. Thus, we never actually use the access token, and it seems silly to validate it.

Currently we're working around this issue in our setup by stripping the `at_hash` field from the ID Token in a network proxy before Synapse receives it, but this seems like the cleaner solution.

FYI `authlib` is the one that actually validates this field, [here](https://github.com/authlib/authlib/blob/fe12a578854fb64c8a3906676ba7d2a2b9579459/authlib/oidc/core/claims.py#L140-L153). It only does so if the `access_token` parameter is set in the claims dict, which is what this PR is disabling when unnecessary.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
