### PR TITLE
docs/workers.md: Add  ^/_matrix/federation/v1/event/ to list of delegatable endpoints

### DIFF
--- a/changelog.d/18377.doc
+++ b/changelog.d/18377.doc
@@ -1,0 +1,1 @@
+Add ^/_matrix/federation/v1/event/ to list of delegatable federation endpoints.

--- a/changelog.d/18377.doc
+++ b/changelog.d/18377.doc
@@ -1,1 +1,1 @@
-Add ^/_matrix/federation/v1/event/ to list of delegatable federation endpoints.
+Add `/_matrix/federation/v1/version` to list of federation endpoints that can be handled by workers.

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -202,6 +202,7 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
         "app": "synapse.app.generic_worker",
         "listener_resources": ["federation"],
         "endpoint_patterns": [
+            "^/_matrix/federation/v1/version$",
             "^/_matrix/federation/(v1|v2)/event/",
             "^/_matrix/federation/(v1|v2)/state/",
             "^/_matrix/federation/(v1|v2)/state_ids/",

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -123,7 +123,7 @@ stacking them up. You can monitor the currently running background updates with
 
 The endpoint `^/_matrix/federation/v1/version$` can be delegated to a federation
 worker. This is not new behaviour, but had not been documented yet. The 
-[list of delegatable endpoints](workers.md#available-worker-applications) has 
+[list of delegatable endpoints](workers.md#synapseappgeneric_worker) has 
 been updated to include it. Make sure to check your reverse proxy rules if you
 are using workers. 
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -117,6 +117,16 @@ each upgrade are complete before moving on to the next upgrade, to avoid
 stacking them up. You can monitor the currently running background updates with
 [the Admin API](usage/administration/admin_api/background_updates.html#status).
 
+# Upgrading to v1.130.0
+
+## Documented endpoint which can delegated to a federation worker
+
+The endpoint `^/_matrix/federation/v1/version$` can be delegated to a federation
+worker. This is not new behaviour, but had not been documented yet. The 
+[list of delegatable endpoints](workers.md#available-worker-applications) has 
+been updated to include it. Make sure to check your reverse proxy rules if you
+are using workers. 
+
 # Upgrading to v1.126.0
 
 ## Room list publication rules change

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -119,7 +119,7 @@ stacking them up. You can monitor the currently running background updates with
 
 # Upgrading to v1.130.0
 
-## Documented endpoint which can delegated to a federation worker
+## Documented endpoint which can be delegated to a federation worker
 
 The endpoint `^/_matrix/federation/v1/version$` can be delegated to a federation
 worker. This is not new behaviour, but had not been documented yet. The 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -200,6 +200,7 @@ information.
     ^/_matrix/client/(api/v1|r0|v3)/rooms/[^/]+/initialSync$
 
     # Federation requests
+    ^/_matrix/federation/v1/version$
     ^/_matrix/federation/v1/event/
     ^/_matrix/federation/v1/state/
     ^/_matrix/federation/v1/state_ids/


### PR DESCRIPTION
Add  ^/_matrix/federation/v1/event/ to list of delegatable endpoints.
Contributed by @spaetz.