### PR TITLE
perf: filter pdus before serialization

### DIFF
--- a/changelog.d/18381.misc
+++ b/changelog.d/18381.misc
@@ -1,0 +1,1 @@
+Rename `serialize_and_filter_pdus` to `filter_and_serialize_pdus` and perform filtering prior to serialization.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -66,7 +66,7 @@ from synapse.federation.federation_base import (
     event_from_pdu_json,
 )
 from synapse.federation.persistence import TransactionActions
-from synapse.federation.units import Edu, Transaction, serialize_and_filter_pdus
+from synapse.federation.units import Edu, Transaction, filter_and_serialize_pdus
 from synapse.handlers.worker_lock import NEW_EVENT_DURING_PURGE_LOCK_NAME
 from synapse.http.servlet import assert_params_in_dict
 from synapse.logging.context import (
@@ -641,8 +641,8 @@ class FederationServer(FederationBase):
         )
 
         return {
-            "pdus": serialize_and_filter_pdus(pdus),
-            "auth_chain": serialize_and_filter_pdus(auth_chain),
+            "pdus": filter_and_serialize_pdus(pdus),
+            "auth_chain": filter_and_serialize_pdus(auth_chain),
         }
 
     async def on_pdu_request(
@@ -772,8 +772,8 @@ class FederationServer(FederationBase):
         event_json = event.get_pdu_json(time_now)
         resp = {
             "event": event_json,
-            "state": serialize_and_filter_pdus(state_events, time_now),
-            "auth_chain": serialize_and_filter_pdus(auth_chain_events, time_now),
+            "state": filter_and_serialize_pdus(state_events, time_now),
+            "auth_chain": filter_and_serialize_pdus(auth_chain_events, time_now),
             "members_omitted": caller_supports_partial_state,
         }
 
@@ -1017,7 +1017,7 @@ class FederationServer(FederationBase):
 
             time_now = self._clock.time_msec()
             auth_pdus = await self.handler.on_event_auth(event_id)
-            res = {"auth_chain": serialize_and_filter_pdus(auth_pdus, time_now)}
+            res = {"auth_chain": filter_and_serialize_pdus(auth_pdus, time_now)}
         return 200, res
 
     async def on_query_client_keys(
@@ -1102,7 +1102,7 @@ class FederationServer(FederationBase):
 
             time_now = self._clock.time_msec()
 
-        return {"events": serialize_and_filter_pdus(missing_events, time_now)}
+        return {"events": filter_and_serialize_pdus(missing_events, time_now)}
 
     async def on_openid_userinfo(self, token: str) -> Optional[str]:
         ts_now_ms = self._clock.time_msec()

--- a/synapse/federation/units.py
+++ b/synapse/federation/units.py
@@ -127,7 +127,16 @@ def filter_pdus_for_valid_depth(pdus: Sequence[JsonDict]) -> List[JsonDict]:
     return filtered_pdus
 
 
-def serialize_and_filter_pdus(
+def is_pdu_valid(pdu: EventBase) -> bool:
+    return (
+        # Drop PDUs that have a depth that is outside of the range allowed
+        # by canonical json.
+        isinstance(pdu.depth, int)
+        and CANONICALJSON_MIN_INT <= pdu.depth <= CANONICALJSON_MAX_INT
+    )
+
+
+def filter_and_serialize_pdus(
     pdus: Sequence[EventBase], time_now: Optional[int] = None
 ) -> List[JsonDict]:
-    return filter_pdus_for_valid_depth([pdu.get_pdu_json(time_now) for pdu in pdus])
+    return [pdu.get_pdu_json(time_now) for pdu in pdus if is_pdu_valid(pdu)]


### PR DESCRIPTION
The serialization-before-filtering in `serialize_and_filter_pdus` is redundant for entries not passing the filter.


This duplicates the validation logic from `filter_pdus_for_valid_depth` in order to skip redundant (de)serialization.



### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
