### PR TITLE
Switch `poetry.dev-dependencies` -> `poetry.group.dev.dependencies`

### DIFF
--- a/changelog.d/18386.misc
+++ b/changelog.d/18386.misc
@@ -1,0 +1,1 @@
+Migrate from deprecated `poetry.dev-dependencies` -> `poetry.group.dev.dependencies` in pyproject.toml.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,7 +315,7 @@ all = [
     #   - systemd: this is a system-based requirement
 ]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 # We pin development dependencies in poetry.lock so that our tests don't start
 # failing on new releases. Keeping lower bounds loose here means that dependabot
 # can bump versions without having to update the content-hash in the lockfile.


### PR DESCRIPTION
As the former is deprecated since poetry 1.2.0: https://github.com/python-poetry/poetry/pull/4260

![image](https://github.com/user-attachments/assets/38a6f19c-d590-4e85-a2d6-2014fbb7b60e)

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
