### PR TITLE
fix(docker): allow PYTHON_VERSION deviating from debian dist version

### DIFF
--- a/changelog.d/18389.docker
+++ b/changelog.d/18389.docker
@@ -1,0 +1,1 @@
+Docker image can now be built with `PYTHON_VERSION` other than 3.11.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -118,7 +118,7 @@ RUN \
 ###
 ### Stage 2: runtime dependencies download for ARM64 and AMD64
 ###
-FROM --platform=$BUILDPLATFORM docker.io/library/debian:${DEBIAN_VERSION} AS runtime-deps
+FROM --platform=$BUILDPLATFORM docker.io/library/python:${PYTHON_VERSION}-slim-${DEBIAN_VERSION} AS runtime-deps
 
 # Tell apt to keep downloaded package files, as we're using cache mounts.
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache


### PR DESCRIPTION
### Pull Request Checklist

Debian bullseye Python version (3.11) overrides build-arg `PYTHON_VERSION` due to entirety of `/usr/local/bin` being copied from `runtime-deps`, thereby removing the base image python installation.

This fixes it by changing the intermediary image to be based on one with the expected `PYTHON_VERSION`.


* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
