### PR TITLE
make tests tolerant to authlib 1.5.2 error messages

### DIFF
--- a/changelog.d/18390.misc
+++ b/changelog.d/18390.misc
@@ -1,0 +1,1 @@
+Fixed test failures when using authlib 1.5.2.

--- a/tests/rest/client/test_login.py
+++ b/tests/rest/client/test_login.py
@@ -1262,18 +1262,18 @@ class JWTTestCase(unittest.HomeserverTestCase):
         channel = self.jwt_login({"sub": "kermit", "iss": "invalid"})
         self.assertEqual(channel.code, 403, msg=channel.result)
         self.assertEqual(channel.json_body["errcode"], "M_FORBIDDEN")
-        self.assertEqual(
+        self.assertRegex(
             channel.json_body["error"],
-            'JWT validation failed: invalid_claim: Invalid claim "iss"',
+            r"^JWT validation failed: invalid_claim: Invalid claim [\"']iss[\"']$",
         )
 
         # Not providing an issuer.
         channel = self.jwt_login({"sub": "kermit"})
         self.assertEqual(channel.code, 403, msg=channel.result)
         self.assertEqual(channel.json_body["errcode"], "M_FORBIDDEN")
-        self.assertEqual(
+        self.assertRegex(
             channel.json_body["error"],
-            'JWT validation failed: missing_claim: Missing "iss" claim',
+            r"^JWT validation failed: missing_claim: Missing [\"']iss[\"'] claim$",
         )
 
     def test_login_iss_no_config(self) -> None:
@@ -1294,18 +1294,18 @@ class JWTTestCase(unittest.HomeserverTestCase):
         channel = self.jwt_login({"sub": "kermit", "aud": "invalid"})
         self.assertEqual(channel.code, 403, msg=channel.result)
         self.assertEqual(channel.json_body["errcode"], "M_FORBIDDEN")
-        self.assertEqual(
+        self.assertRegex(
             channel.json_body["error"],
-            'JWT validation failed: invalid_claim: Invalid claim "aud"',
+            r"^JWT validation failed: invalid_claim: Invalid claim [\"']aud[\"']$",
         )
 
         # Not providing an audience.
         channel = self.jwt_login({"sub": "kermit"})
         self.assertEqual(channel.code, 403, msg=channel.result)
         self.assertEqual(channel.json_body["errcode"], "M_FORBIDDEN")
-        self.assertEqual(
+        self.assertRegex(
             channel.json_body["error"],
-            'JWT validation failed: missing_claim: Missing "aud" claim',
+            r"^JWT validation failed: missing_claim: Missing [\"']aud[\"'] claim$",
         )
 
     def test_login_aud_no_config(self) -> None:
@@ -1313,9 +1313,9 @@ class JWTTestCase(unittest.HomeserverTestCase):
         channel = self.jwt_login({"sub": "kermit", "aud": "invalid"})
         self.assertEqual(channel.code, 403, msg=channel.result)
         self.assertEqual(channel.json_body["errcode"], "M_FORBIDDEN")
-        self.assertEqual(
+        self.assertRegex(
             channel.json_body["error"],
-            'JWT validation failed: invalid_claim: Invalid claim "aud"',
+            r"^JWT validation failed: invalid_claim: Invalid claim [\"']aud[\"']$",
         )
 
     def test_login_default_sub(self) -> None:


### PR DESCRIPTION
authlib 1.5.2 now single-quotes error messages in the claims, causing three tests to fail.

Replace the comparison with a regex that accepts both single or double quotes.

This succeeds the tests with both authlib 1.5.1 and 1.5.2.

See https://github.com/NixOS/nixpkgs/pull/402797 for context.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
