### PR TITLE
Use provided `batch_size` for the participant background update instead of a hardcoded one

### DIFF
--- a/changelog.d/18401.bugfix
+++ b/changelog.d/18401.bugfix
@@ -1,0 +1,1 @@
+Allow adjusting the batch size for the `populate_participant_bg_update` background update.


### PR DESCRIPTION
Discovered by @reivilibre at https://github.com/element-hq/synapse/pull/18068/files/d85541bd9a9491aac3056dafe73b2a70f96656bf#r2054380323

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
