### PR TITLE
Move index creation to background update

### DIFF
--- a/changelog.d/18439.bugfix
+++ b/changelog.d/18439.bugfix
@@ -1,0 +1,1 @@
+Fix startup being blocked on creating a new index. Introduced in v1.130.0rc1.

--- a/synapse/storage/databases/main/sliding_sync.py
+++ b/synapse/storage/databases/main/sliding_sync.py
@@ -72,7 +72,7 @@ class SlidingSyncStore(SQLBaseStore):
             update_name="sliding_sync_membership_snapshots_user_id_stream_ordering",
             index_name="sliding_sync_membership_snapshots_user_id",
             table="sliding_sync_membership_snapshots",
-            columns=("user_id" "event_stream_ordering",),
+            columns=("user_id", "event_stream_ordering",),
             replaces_index="sliding_sync_membership_snapshots_user_id",
         )
 

--- a/synapse/storage/databases/main/sliding_sync.py
+++ b/synapse/storage/databases/main/sliding_sync.py
@@ -68,6 +68,14 @@ class SlidingSyncStore(SQLBaseStore):
             columns=("membership_event_id",),
         )
 
+        self.db_pool.updates.register_background_index_update(
+            update_name="sliding_sync_membership_snapshots_user_id_stream_ordering",
+            index_name="sliding_sync_membership_snapshots_user_id",
+            table="sliding_sync_membership_snapshots",
+            columns=("user_id" "event_stream_ordering",),
+            replaces_index="sliding_sync_membership_snapshots_user_id",
+        )
+
     async def get_latest_bump_stamp_for_room(
         self,
         room_id: str,

--- a/synapse/storage/databases/main/sliding_sync.py
+++ b/synapse/storage/databases/main/sliding_sync.py
@@ -70,9 +70,9 @@ class SlidingSyncStore(SQLBaseStore):
 
         self.db_pool.updates.register_background_index_update(
             update_name="sliding_sync_membership_snapshots_user_id_stream_ordering",
-            index_name="sliding_sync_membership_snapshots_user_id",
+            index_name="sliding_sync_membership_snapshots_user_id_stream_ordering",
             table="sliding_sync_membership_snapshots",
-            columns=("user_id", "event_stream_ordering",),
+            columns=("user_id", "event_stream_ordering"),
             replaces_index="sliding_sync_membership_snapshots_user_id",
         )
 

--- a/synapse/storage/schema/main/delta/92/03_ss_membership_snapshot_idx.sql
+++ b/synapse/storage/schema/main/delta/92/03_ss_membership_snapshot_idx.sql
@@ -12,5 +12,5 @@
 -- <https://www.gnu.org/licenses/agpl-3.0.html>.
 
 -- So we can fetch all rooms for a given user sorted by stream order
-DROP INDEX IF EXISTS sliding_sync_membership_snapshots_user_id;
-CREATE INDEX IF NOT EXISTS sliding_sync_membership_snapshots_user_id ON sliding_sync_membership_snapshots(user_id, event_stream_ordering);
+INSERT INTO background_updates (ordering, update_name, progress_json) VALUES
+  (9203, 'sliding_sync_membership_snapshots_user_id_stream_ordering', '{}');

--- a/synapse/storage/schema/main/delta/92/04_ss_membership_snapshot_idx.sql
+++ b/synapse/storage/schema/main/delta/92/04_ss_membership_snapshot_idx.sql
@@ -13,4 +13,4 @@
 
 -- So we can fetch all rooms for a given user sorted by stream order
 INSERT INTO background_updates (ordering, update_name, progress_json) VALUES
-  (9203, 'sliding_sync_membership_snapshots_user_id_stream_ordering', '{}');
+  (9204, 'sliding_sync_membership_snapshots_user_id_stream_ordering', '{}');


### PR DESCRIPTION
Follow on from #18375. This prevents blocking startup on creating the index, which can take a while