### PR TITLE
Allow only requiring a field be present in an SSO response, rather than specifying a required value

### DIFF
--- a/changelog.d/18454.misc
+++ b/changelog.d/18454.misc
@@ -1,0 +1,1 @@
+Allow checking only for the existence of a field in an SSO provider's response, rather than requiring the value(s) to check.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3785,6 +3785,9 @@ attribute_requirements:
        one_of: ["Stephensson", "Smith"]
      - attribute: groups
        value: "admin"
+     # If `value` or `one_of` are not specified, the attribute only needs
+     # to exist, regardless of value.
+     - attribute: picture
 ```
 
 `attribute` is a required field, while `value` and `one_of` are optional.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3782,17 +3782,20 @@ match particular values in the OIDC userinfo. The requirements can be listed und
 ```yaml
 attribute_requirements:
      - attribute: family_name
-       value: "Stephensson"
+       one_of: ["Stephensson", "Smith"]
      - attribute: groups
        value: "admin"
 ```
+
+`attribute` is a required field, while `value` and `one_of` are optional.
+
 All of the listed attributes must match for the login to be permitted. Additional attributes can be added to
 userinfo by expanding the `scopes` section of the OIDC config to retrieve
 additional information from the OIDC provider.
 
 If the OIDC claim is a list, then the attribute must match any value in the list.
 Otherwise, it must exactly match the value of the claim. Using the example
-above, the `family_name` claim MUST be "Stephensson", but the `groups`
+above, the `family_name` claim MUST be either "Stephensson" or "Smith", but the `groups`
 claim MUST contain "admin".
 
 Example configuration:

--- a/synapse/config/sso.py
+++ b/synapse/config/sso.py
@@ -43,8 +43,7 @@ class SsoAttributeRequirement:
     """Object describing a single requirement for SSO attributes."""
 
     attribute: str
-    # If neither value nor one_of is given, the attribute must simply exist. This is
-    # only true for CAS configs which use a different JSON schema than the one below.
+    # If neither `value` nor `one_of` is given, the attribute must simply exist.
     value: Optional[str] = None
     one_of: Optional[List[str]] = None
 
@@ -56,10 +55,6 @@ class SsoAttributeRequirement:
             "one_of": {"type": "array", "items": {"type": "string"}},
         },
         "required": ["attribute"],
-        "oneOf": [
-            {"required": ["value"]},
-            {"required": ["one_of"]},
-        ],
     }
 
 


### PR DESCRIPTION
Note: the use case for this was driven by OIDC login, but this change applied to all SSO login types.

The final portion of OIDC login involves receiving an `id_token` and `access_token` from the Identity Provider. If configured, the `id_token` will contain metadata about the user (such as their `family_name`, `email`, etc.) in addition to the usual `sub` (unique third-party identifier) fields.

Internally we had a use case for an enterprise customer where we wanted to require that certain claims were present in the `id_token`. We don't care what the field's *value* was, just that the field is present. If it's not present, Synapse should abort the login attempt.

This wasn't possible with Synapse today, as while Synapse does allow you to abort a login if certain fields don't have the correct _values_, you couldn't require that the field only be _present_. See the following config:

```yaml
oidc_providers:
  - idp_id: my_cool_idp
    # ...
    attribute_requirements:
      - attribute: family_name
        value: Smith  # this field (or `one_of`) was previously *required*
```

the logic that uses this config already supports only checking for the existence of a field:

https://github.com/element-hq/synapse/blob/fa4a00a2da753a52dde582c0f56e3ea6567bd53b/synapse/handlers/sso.py#L1279-L1281

The only blocker is that the schema validator requires that either `value` or `one_of` be present under `attribute_requirements`. So, this PR changes that. It also clarifies the relevant documentation, and adds a test.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
