### PR TITLE
Make user_type extensible and allow default user_type to be set

### DIFF
--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -163,7 +163,7 @@ Body parameters:
 - `locked` - **bool**, optional. If unspecified, locked state will be left unchanged.
 - `user_type` - **string** or null, optional. If not provided, the user type will be
   not be changed. If `null` is given, the user type will be cleared.
-  Other allowed options are: `bot` and `support`.
+  Other allowed options are: `bot` and `support`. # XXXTODO
 
 ## List Accounts
 ### List Accounts (V2)

--- a/synapse/config/_base.pyi
+++ b/synapse/config/_base.pyi
@@ -59,6 +59,7 @@ from synapse.config import (  # noqa: F401
     tls,
     tracer,
     user_directory,
+    user_types,
     voip,
     workers,
 )
@@ -122,6 +123,7 @@ class RootConfig:
     retention: retention.RetentionConfig
     background_updates: background_updates.BackgroundUpdateConfig
     auto_accept_invites: auto_accept_invites.AutoAcceptInvitesConfig
+    user_types: user_types.UserTypesConfig
 
     config_classes: List[Type["Config"]] = ...
     config_files: List[str]

--- a/synapse/config/homeserver.py
+++ b/synapse/config/homeserver.py
@@ -59,6 +59,7 @@ from .third_party_event_rules import ThirdPartyRulesConfig
 from .tls import TlsConfig
 from .tracer import TracerConfig
 from .user_directory import UserDirectoryConfig
+from .user_types import UserTypesConfig
 from .voip import VoipConfig
 from .workers import WorkerConfig
 
@@ -107,4 +108,5 @@ class HomeServerConfig(RootConfig):
         ExperimentalConfig,
         BackgroundUpdateConfig,
         AutoAcceptInvitesConfig,
+        UserTypesConfig,
     ]

--- a/synapse/config/user_types.py
+++ b/synapse/config/user_types.py
@@ -1,0 +1,39 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2025 New Vector, Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+
+from typing import Any, List, Optional
+
+from synapse.api.constants import UserTypes
+from synapse.types import JsonDict
+
+from ._base import Config
+
+
+class UserTypesConfig(Config):
+    section = "user_types"
+
+    def read_config(self, config: JsonDict, **kwargs: Any) -> None:
+        user_types: JsonDict = config.get("user_types", {})
+
+        self.default_user_type: Optional[str] = user_types.get(
+            "default_user_type", None
+        )
+        self.extra_user_types: List[str] = user_types.get("extra_user_types", [])
+        # XXXTODO: provide a way to set which extra user types should be treated as "real" users
+
+        all_user_types: List[str] = []
+        all_user_types.extend(UserTypes.ALL_USER_TYPES)
+        all_user_types.extend(self.extra_user_types)
+
+        self.all_user_types = all_user_types

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -115,6 +115,7 @@ class RegistrationHandler:
         self._user_consent_version = self.hs.config.consent.user_consent_version
         self._server_notices_mxid = hs.config.servernotices.server_notices_mxid
         self._server_name = hs.hostname
+        self._user_types_config = hs.config.user_types
 
         self._spam_checker_module_callbacks = hs.get_module_api_callbacks().spam_checker
 
@@ -305,6 +306,9 @@ class RegistrationHandler:
 
             elif default_display_name is None:
                 default_display_name = localpart
+
+            if user_type is None:
+                user_type = self._user_types_config.default_user_type
 
             await self.register_with_store(
                 user_id=user_id,

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -583,7 +583,9 @@ class RegistrationWorkerStore(CacheInvalidationWorkerStore):
 
         await self.db_pool.runInteraction("set_shadow_banned", set_shadow_banned_txn)
 
-    async def set_user_type(self, user: UserID, user_type: Optional[UserTypes]) -> None:
+    async def set_user_type(
+        self, user: UserID, user_type: Optional[Union[UserTypes, str]]
+    ) -> None:
         """Sets the user type.
 
         Args:
@@ -683,6 +685,7 @@ class RegistrationWorkerStore(CacheInvalidationWorkerStore):
             retcol="user_type",
             allow_none=True,
         )
+        # XXXTODO
         return res is None
 
     def is_support_user_txn(self, txn: LoggingTransaction, user_id: str) -> bool:
@@ -961,6 +964,7 @@ class RegistrationWorkerStore(CacheInvalidationWorkerStore):
     async def count_real_users(self) -> int:
         """Counts all users without a special user_type registered on the homeserver."""
 
+        # XXXTODO
         def _count_users(txn: LoggingTransaction) -> int:
             txn.execute("SELECT COUNT(*) FROM users where user_type is null")
             row = txn.fetchone()
@@ -2545,7 +2549,8 @@ class RegistrationStore(StatsStore, RegistrationBackgroundUpdateStore):
                 the user, setting their displayname to the given value
             admin: is an admin user?
             user_type: type of user. One of the values from api.constants.UserTypes,
-                or None for a normal user.
+                a custom value set in the configuration file, or None for a normal
+                user.
             shadow_banned: Whether the user is shadow-banned, i.e. they may be
                 told their requests succeeded but we ignore them.
             approved: Whether to consider the user has already been approved by an


### PR DESCRIPTION
WIP

- Allows additional user_type values to be set in the config
- Allows a default user_type to be specified that is used when registering users (where a specific user_type hasn't been specified)

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
