### PR TITLE
Migrate to assertEqual

### DIFF
--- a/tests/util/test_task_scheduler.py
+++ b/tests/util/test_task_scheduler.py
@@ -112,11 +112,11 @@ class TestTaskScheduler(HomeserverTestCase):
 
         # At this point, there should be MAX_CONCURRENT_RUNNING_TASKS active tasks and
         # one scheduled task.
-        self.assertEquals(
+        self.assertEqual(
             len(get_tasks_of_status(TaskStatus.ACTIVE)),
             TaskScheduler.MAX_CONCURRENT_RUNNING_TASKS,
         )
-        self.assertEquals(
+        self.assertEqual(
             len(get_tasks_of_status(TaskStatus.SCHEDULED)),
             1,
         )
@@ -126,17 +126,17 @@ class TestTaskScheduler(HomeserverTestCase):
 
         # Check that MAX_CONCURRENT_RUNNING_TASKS tasks have run and that one
         # is still scheduled.
-        self.assertEquals(
+        self.assertEqual(
             len(get_tasks_of_status(TaskStatus.COMPLETE)),
             TaskScheduler.MAX_CONCURRENT_RUNNING_TASKS,
         )
         scheduled_tasks = get_tasks_of_status(TaskStatus.SCHEDULED)
-        self.assertEquals(len(scheduled_tasks), 1)
+        self.assertEqual(len(scheduled_tasks), 1)
 
         # The scheduled task should start 0.1s after the first of the active tasks
         # finishes
         self.reactor.advance(0.1)
-        self.assertEquals(len(get_tasks_of_status(TaskStatus.ACTIVE)), 1)
+        self.assertEqual(len(get_tasks_of_status(TaskStatus.ACTIVE)), 1)
 
         # ... and should finally complete after another second
         self.reactor.advance(1)
@@ -144,7 +144,7 @@ class TestTaskScheduler(HomeserverTestCase):
             self.task_scheduler.get_task(scheduled_tasks[0].id)
         )
         assert prev_scheduled_task is not None
-        self.assertEquals(
+        self.assertEqual(
             prev_scheduled_task.status,
             TaskStatus.COMPLETE,
         )


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

## Change Summary
This small PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```