### PR TITLE
Allow the multi-pg, workers, asyncio Synapse config to fail

### DIFF
--- a/.ci/scripts/calculate_jobs.py
+++ b/.ci/scripts/calculate_jobs.py
@@ -120,6 +120,7 @@ sytest_tests = [
         "postgres": "multi-postgres",
         "workers": "workers",
         "reactor": "asyncio",
+        "failure_allowed": True,
     },
 ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -525,6 +525,11 @@ jobs:
       - name: Run SyTest
         run: /bootstrap.sh synapse
         working-directory: /src
+        # Prevent failures of this configuration from causing all of CI to
+        # marked as failed. This is useful for testing a new Synapse configuration
+        # in anger without causing sporatic CI failures.
+        continue-on-error: ${{ matrix.job.failure_allowed || false }}
+
       - name: Summarise results.tap
         if: ${{ always() }}
         run: /sytest/scripts/tap_to_gha.pl /logs/results.tap


### PR DESCRIPTION
Without causing CI to fail, as it's very flaky. This is intended as a stop-gap solution while we lack the time to debug and fix the configuration.

Another alternative is to disable the job altogether, which would save CI minutes.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
