### PR TITLE
Don't allow users to ignore themselves.

### DIFF
--- a/changelog.d/18508.bugfix
+++ b/changelog.d/18508.bugfix
@@ -1,0 +1,1 @@
+Prevent users from adding themselves to their own ignore list.

--- a/synapse/storage/databases/main/account_data.py
+++ b/synapse/storage/databases/main/account_data.py
@@ -34,6 +34,7 @@ from typing import (
 )
 
 from synapse.api.constants import AccountDataTypes
+from synapse.api.errors import Codes, SynapseError
 from synapse.replication.tcp.streams import AccountDataStream
 from synapse.storage._base import db_to_json
 from synapse.storage.database import (
@@ -759,6 +760,9 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
             currently_ignored_users = set(ignored_users_content)
         else:
             currently_ignored_users = set()
+
+        if user_id in currently_ignored_users:
+            raise SynapseError(400, "You cannot ignore yourself", Codes.INVALID_PARAM)
 
         # If the data has not changed, nothing to do.
         if previously_ignored_users == currently_ignored_users:


### PR DESCRIPTION
Fixes the self-ignore issues we've being seeing of reports of by ignoring bad requests from clients. 
Fixes https://github.com/element-hq/synapse/issues/11963

Fix https://github.com/element-hq/element-web/issues/29969 although this should also be fixed on the client to avoid confusing errors popping up while rejecting invites.

Related to https://github.com/matrix-org/matrix-rust-sdk/issues/5073

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
