### PR TITLE
Export RatelimitOverride from ModuleApi

### DIFF
--- a/changelog.d/18513.bugfix
+++ b/changelog.d/18513.bugfix
@@ -1,0 +1,1 @@
+Support the import of the `RatelimitOverride` type from `synapse.module_api` in modules.

--- a/changelog.d/18513.bugfix
+++ b/changelog.d/18513.bugfix
@@ -1,1 +1,1 @@
-Support the import of the `RatelimitOverride` type from `synapse.module_api` in modules.
+Support the import of the `RatelimitOverride` type from `synapse.module_api` in modules and rename `messages_per_second` to `per_second`.

--- a/docs/modules/ratelimit_callbacks.md
+++ b/docs/modules/ratelimit_callbacks.md
@@ -26,6 +26,11 @@ The limiters that are currently supported are:
 - `rc_invites.per_user`
 - `rc_invites.per_issuer`
 
+The `RatelimitOverride` return type has the following fields:
+
+- `per_second: float`. The number of actions that can be performed in a second. `0.0` means that ratelimiting is disabled.
+- `burst_count: int`. The number of actions that can be performed before being limited.
+
 If multiple modules implement this callback, they will be considered in order. If a
 callback returns `None`, Synapse falls through to the next one. The value of the first
 callback that does not return `None` will be used. If this happens, Synapse will not call

--- a/docs/modules/ratelimit_callbacks.md
+++ b/docs/modules/ratelimit_callbacks.md
@@ -11,7 +11,7 @@ The available ratelimit callbacks are:
 _First introduced in Synapse v1.132.0_
 
 ```python
-async def get_ratelimit_override_for_user(user: str, limiter_name: str) -> Optional[RatelimitOverride]
+async def get_ratelimit_override_for_user(user: str, limiter_name: str) -> Optional[synapse.module_api.RatelimitOverride]
 ```
 
 Called when constructing a ratelimiter of a particular type for a user. The module can

--- a/synapse/api/ratelimiting.py
+++ b/synapse/api/ratelimiting.py
@@ -184,7 +184,7 @@ class Ratelimiter:
             )
 
             if module_override:
-                rate_hz = module_override.messages_per_second
+                rate_hz = module_override.per_second
                 burst_count = module_override.burst_count
 
         # Override default values if set

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -96,6 +96,7 @@ from synapse.module_api.callbacks.media_repository_callbacks import (
 )
 from synapse.module_api.callbacks.ratelimit_callbacks import (
     GET_RATELIMIT_OVERRIDE_FOR_USER_CALLBACK,
+    RatelimitOverride,
 )
 from synapse.module_api.callbacks.spamchecker_callbacks import (
     CHECK_EVENT_FOR_SPAM_CALLBACK,
@@ -197,6 +198,7 @@ __all__ = [
     "ProfileInfo",
     "RoomAlias",
     "UserProfile",
+    "RatelimitOverride",
 ]
 
 logger = logging.getLogger(__name__)
@@ -212,16 +214,6 @@ class UserIpAndAgent:
     user_agent: str
     # The time at which this user agent/ip was last seen.
     last_seen: int
-
-
-@attr.s(auto_attribs=True)
-class RatelimitOverride:
-    """Represents a ratelimit being overridden."""
-
-    messages_per_second: float
-    """The number of actions that can be performed in a second. `0.0` mean that ratelimiting is disabled."""
-    burst_count: int
-    """How many actions that can be performed before being limited."""
 
 
 def cached(

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -136,7 +136,6 @@ from synapse.storage.background_updates import (
     ON_UPDATE_CALLBACK,
 )
 from synapse.storage.database import DatabasePool, LoggingTransaction
-from synapse.storage.databases.main.room import RatelimitOverride
 from synapse.storage.databases.main.roommember import ProfileInfo
 from synapse.types import (
     DomainSpecificString,
@@ -198,7 +197,6 @@ __all__ = [
     "ProfileInfo",
     "RoomAlias",
     "UserProfile",
-    "RatelimitOverride",
 ]
 
 logger = logging.getLogger(__name__)
@@ -214,6 +212,16 @@ class UserIpAndAgent:
     user_agent: str
     # The time at which this user agent/ip was last seen.
     last_seen: int
+
+
+@attr.s(auto_attribs=True)
+class RatelimitOverride:
+    """Represents a ratelimit being overridden."""
+
+    messages_per_second: float
+    """The number of actions that can be performed in a second. `0.0` mean that ratelimiting is disabled."""
+    burst_count: int
+    """How many actions that can be performed before being limited."""
 
 
 def cached(

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -136,6 +136,7 @@ from synapse.storage.background_updates import (
     ON_UPDATE_CALLBACK,
 )
 from synapse.storage.database import DatabasePool, LoggingTransaction
+from synapse.storage.databases.main.room import RatelimitOverride
 from synapse.storage.databases.main.roommember import ProfileInfo
 from synapse.types import (
     DomainSpecificString,
@@ -197,6 +198,7 @@ __all__ = [
     "ProfileInfo",
     "RoomAlias",
     "UserProfile",
+    "RatelimitOverride",
 ]
 
 logger = logging.getLogger(__name__)

--- a/synapse/module_api/callbacks/ratelimit_callbacks.py
+++ b/synapse/module_api/callbacks/ratelimit_callbacks.py
@@ -15,17 +15,17 @@
 import logging
 from typing import TYPE_CHECKING, Awaitable, Callable, List, Optional
 
-from synapse.storage.databases.main.room import RatelimitOverride
 from synapse.util.async_helpers import delay_cancellation
 from synapse.util.metrics import Measure
 
 if TYPE_CHECKING:
+    from synapse.module_api import RatelimitOverride
     from synapse.server import HomeServer
 
 logger = logging.getLogger(__name__)
 
 GET_RATELIMIT_OVERRIDE_FOR_USER_CALLBACK = Callable[
-    [str, str], Awaitable[Optional[RatelimitOverride]]
+    [str, str], Awaitable[Optional["RatelimitOverride"]]
 ]
 
 
@@ -50,10 +50,10 @@ class RatelimitModuleApiCallbacks:
 
     async def get_ratelimit_override_for_user(
         self, user_id: str, limiter_name: str
-    ) -> Optional[RatelimitOverride]:
+    ) -> Optional["RatelimitOverride"]:
         for callback in self._get_ratelimit_override_for_user_callbacks:
             with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
-                res: Optional[RatelimitOverride] = await delay_cancellation(
+                res: Optional["RatelimitOverride"] = await delay_cancellation(
                     callback(user_id, limiter_name)
                 )
             if res:

--- a/synapse/module_api/callbacks/ratelimit_callbacks.py
+++ b/synapse/module_api/callbacks/ratelimit_callbacks.py
@@ -31,7 +31,7 @@ class RatelimitOverride:
     """Represents a ratelimit being overridden."""
 
     per_second: float
-    """The number of actions that can be performed in a second. `0.0` mean that ratelimiting is disabled."""
+    """The number of actions that can be performed in a second. `0.0` means that ratelimiting is disabled."""
     burst_count: int
     """How many actions that can be performed before being limited."""
 

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -77,7 +77,9 @@ logger = logging.getLogger(__name__)
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
 class RatelimitOverride:
-    messages_per_second: float
+    # n.b. elsewhere in Synapse messages_per_second is represented as a float, but it is
+    # an integer in the database
+    messages_per_second: int
     burst_count: int
 
 

--- a/tests/api/test_ratelimiting.py
+++ b/tests/api/test_ratelimiting.py
@@ -477,7 +477,7 @@ class TestRatelimiter(unittest.HomeserverTestCase):
         ) -> Optional[RatelimitOverride]:
             if user_id == test_user_id:
                 return RatelimitOverride(
-                    messages_per_second=0.1,
+                    per_second=0.1,
                     burst_count=10,
                 )
             return None

--- a/tests/api/test_ratelimiting.py
+++ b/tests/api/test_ratelimiting.py
@@ -3,8 +3,8 @@ from typing import Optional
 from synapse.api.ratelimiting import LimitExceededError, Ratelimiter
 from synapse.appservice import ApplicationService
 from synapse.config.ratelimiting import RatelimitSettings
+from synapse.module_api import RatelimitOverride
 from synapse.module_api.callbacks.ratelimit_callbacks import RatelimitModuleApiCallbacks
-from synapse.storage.databases.main.room import RatelimitOverride
 from synapse.types import create_requester
 
 from tests import unittest


### PR DESCRIPTION
This should have been part of https://github.com/element-hq/synapse/pull/18458 and allows for a module to do:

```python
from synapse.module_api import RatelimitOverride
```

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
