### PR TITLE
Fix the 'Login as a user' Admin API not checking if the user exists before issuing an access token.

### DIFF
--- a/changelog.d/18518.bugfix
+++ b/changelog.d/18518.bugfix
@@ -1,0 +1,1 @@
+Fix the 'Login as a user' Admin API not checking if the user exists before issuing an access token.

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -1068,6 +1068,7 @@ class UserTokenRestServlet(RestServlet):
         self.store = hs.get_datastores().main
         self.auth = hs.get_auth()
         self.auth_handler = hs.get_auth_handler()
+        self.admin_handler = hs.get_admin_handler()
         self.is_mine_id = hs.is_mine_id
 
     async def on_POST(
@@ -1081,6 +1082,10 @@ class UserTokenRestServlet(RestServlet):
             raise SynapseError(
                 HTTPStatus.BAD_REQUEST, "Only local users can be logged in as"
             )
+
+        _user_info_dict = await self.admin_handler.get_user(UserID.from_string(user_id))
+        if not _user_info_dict:
+            raise NotFoundError("User not found")
 
         body = parse_json_object_from_request(request, allow_empty_body=True)
 


### PR DESCRIPTION
Fixes: #18503
