### PR TITLE
Config schema documentation CI: fix not failing when it should

### DIFF
--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -51,4 +51,4 @@ jobs:
           > docs/usage/configuration/config_documentation.md
       - name: Error in case of any differences
       # Errors if there are now any modified files (untracked files are ignored).
-        run: 'git diff || ! git status --porcelain=1 | grep "^ M"'
+        run: 'git diff --exit-code || ! git status --porcelain=1 | grep "^ M"'

--- a/changelog.d/18528.doc
+++ b/changelog.d/18528.doc
@@ -1,0 +1,1 @@
+Generate config documentation from JSON Schema file.


### PR DESCRIPTION
Follows: #17892 <!-- -->

<ol>
<li>

Config documentation CI: fix not failing if changes are outstanding 

</li>
</ol>
