### PR TITLE
bugfix: ensure _get_power_level_for_sender works when there is no PL event

### DIFF
--- a/changelog.d/18534.bugfix
+++ b/changelog.d/18534.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue where Synapse could incorrectly calculate the power level of the creator when there was no power levels event in the room.

--- a/changelog.d/18534.bugfix
+++ b/changelog.d/18534.bugfix
@@ -1,1 +1,1 @@
-Fixed an issue where Synapse could incorrectly calculate the power level of the creator when there was no power levels event in the room.
+Fix an issue where during state resolution for v11 rooms Synapse would incorrectly calculate the power level of the creator when there was no power levels event in the room.

--- a/synapse/state/v2.py
+++ b/synapse/state/v2.py
@@ -263,7 +263,8 @@ async def _get_power_level_for_sender(
                     logger.warning(
                         "_get_power_level_for_sender: event %s has no PL in auth_events and "
                         "creator is missing from create event %s",
-                        event_id, aev.event_id
+                        event_id,
+                        aev.event_id,
                     )
                 if creator == event.sender:
                     return 100

--- a/synapse/state/v2.py
+++ b/synapse/state/v2.py
@@ -261,8 +261,9 @@ async def _get_power_level_for_sender(
                 )
                 if not creator:
                     logger.warning(
-                        f"_get_power_level_for_sender: event {event_id} has no PL in auth_events and "
-                        + f"creator is missing from create event {aev.event_id}"
+                        "_get_power_level_for_sender: event %s has no PL in auth_events and "
+                        "creator is missing from create event %s",
+                        event_id, aev.event_id
                     )
                 if creator == event.sender:
                     return 100

--- a/synapse/state/v2.py
+++ b/synapse/state/v2.py
@@ -254,7 +254,17 @@ async def _get_power_level_for_sender(
                 room_id, aid, event_map, state_res_store, allow_none=True
             )
             if aev and (aev.type, aev.state_key) == (EventTypes.Create, ""):
-                if aev.content.get("creator") == event.sender:
+                creator = (
+                    event.sender
+                    if event.room_version.implicit_room_creator
+                    else aev.content.get("creator")
+                )
+                if not creator:
+                    logger.warning(
+                        f"_get_power_level_for_sender: event {event_id} has no PL in auth_events and "
+                        + f"creator is missing from create event {aev.event_id}"
+                    )
+                if creator == event.sender:
                     return 100
                 break
         return 0

--- a/tests/state/test_v2.py
+++ b/tests/state/test_v2.py
@@ -41,6 +41,7 @@ from synapse.event_auth import auth_types_for_event
 from synapse.events import EventBase, make_event_from_dict
 from synapse.state.v2 import (
     _get_auth_chain_difference,
+    _get_power_level_for_sender,
     lexicographical_topological_sort,
     resolve_events_with_store,
 )
@@ -862,6 +863,121 @@ class AuthChainDifferenceTestCase(unittest.TestCase):
         difference = self.successResultOf(defer.ensureDeferred(diff_d))
 
         self.assertEqual(difference, {d.event_id, e.event_id})
+
+    def test_get_power_level_for_sender(self) -> None:
+        store = TestStateResolutionStore({})
+        for room_version in [RoomVersions.V10, RoomVersions.V11]:
+            create_event = make_event_from_dict(
+                {
+                    "room_id": ROOM_ID,
+                    "sender": ALICE,
+                    "type": EventTypes.Create,
+                    "state_key": "",
+                    "content": {
+                        "room_version": room_version.identifier,
+                    }
+                    # conditionally add 'creator' if the version doesn't use implicit room creators
+                    | (
+                        {"creator": ALICE}
+                        if not room_version.implicit_room_creator
+                        else {}
+                    ),
+                },
+                room_version,
+            )
+            member_event = make_event_from_dict(
+                {
+                    "room_id": ROOM_ID,
+                    "sender": ALICE,
+                    "type": EventTypes.Member,
+                    "state_key": ALICE,
+                    "content": {
+                        "membership": "join",
+                    },
+                    "auth_events": [create_event.event_id],
+                    "prev_events": [create_event.event_id],
+                },
+                room_version,
+            )
+            pl_event = make_event_from_dict(
+                {
+                    "room_id": ROOM_ID,
+                    "sender": ALICE,
+                    "type": EventTypes.PowerLevels,
+                    "state_key": "",
+                    "content": {
+                        "users": {
+                            ALICE: 100,
+                            BOB: 50,
+                        },
+                        "users_default": 10,
+                    },
+                    "auth_events": [create_event.event_id, member_event.event_id],
+                    "prev_events": [member_event.event_id],
+                },
+                room_version,
+            )
+
+            event_map = {
+                create_event.event_id: create_event,
+                member_event.event_id: member_event,
+                pl_event.event_id: pl_event,
+            }
+            want_pls = {
+                ALICE: 100,
+                BOB: 50,
+                CHARLIE: 10,
+            }
+            for user_id, want_pl in want_pls.items():
+                test_event = make_event_from_dict(
+                    {
+                        "room_id": ROOM_ID,
+                        "sender": user_id,
+                        "type": EventTypes.Topic,
+                        "state_key": "",
+                        "content": {"topic": "Test"},
+                        "auth_events": [
+                            create_event.event_id,
+                            member_event.event_id,
+                            pl_event.event_id,
+                        ],
+                        "prev_events": [pl_event.event_id],
+                    },
+                    room_version,
+                )
+                event_map[test_event.event_id] = test_event
+                got_pl = self.successResultOf(
+                    defer.ensureDeferred(
+                        _get_power_level_for_sender(
+                            ROOM_ID, test_event.event_id, event_map, store
+                        )
+                    )
+                )
+                self.assertEqual(
+                    got_pl,
+                    want_pl,
+                    f"wrong pl for {user_id} on v{room_version.identifier}",
+                )
+
+            # the creator alone without PL is 100
+            got_creator_pl = self.successResultOf(
+                defer.ensureDeferred(
+                    _get_power_level_for_sender(
+                        ROOM_ID,
+                        member_event.event_id,
+                        {
+                            member_event.event_id: member_event,
+                            create_event.event_id: create_event,
+                        },
+                        store,
+                    )
+                )
+            )
+            self.assertEqual(
+                got_creator_pl,
+                100,
+                f"wrong pl for creator with no PL event on v{room_version.identifier}",
+            )
 
 
 T = TypeVar("T")

--- a/tests/state/test_v2.py
+++ b/tests/state/test_v2.py
@@ -865,6 +865,8 @@ class AuthChainDifferenceTestCase(unittest.TestCase):
         self.assertEqual(difference, {d.event_id, e.event_id})
 
     def test_get_power_level_for_sender(self) -> None:
+        """Test that we use the correct definition of `creator` depending
+        on room version"""
         store = TestStateResolutionStore({})
         for room_version in [RoomVersions.V10, RoomVersions.V11]:
             create_event = make_event_from_dict(


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
