### PR TITLE
Fix typo of Math.pow, `^` -> `**`

### DIFF
--- a/changelog.d/18543.bugfix
+++ b/changelog.d/18543.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where "Lock timeout is getting excessive" warnings would be logged even when the lock timeout was <10 minutes.

--- a/synapse/app/phone_stats_home.py
+++ b/synapse/app/phone_stats_home.py
@@ -28,14 +28,12 @@ from prometheus_client import Gauge
 
 from synapse.metrics.background_process_metrics import wrap_as_background_process
 from synapse.types import JsonDict
+from synapse.util.constants import ONE_HOUR_SECONDS, ONE_MINUTE_SECONDS
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
 
 logger = logging.getLogger("synapse.app.homeserver")
-
-ONE_MINUTE_SECONDS = 60
-ONE_HOUR_SECONDS = 60 * ONE_MINUTE_SECONDS
 
 MILLISECONDS_PER_SECOND = 1000
 

--- a/synapse/handlers/worker_lock.py
+++ b/synapse/handlers/worker_lock.py
@@ -56,6 +56,8 @@ if TYPE_CHECKING:
 # will not disappear under our feet as long as we don't delete the room.
 NEW_EVENT_DURING_PURGE_LOCK_NAME = "new_event_during_purge_lock"
 
+ONE_MINUTE_SECONDS = 60
+
 
 class WorkerLocksHandler:
     """A class for waiting on taking out locks, rather than using the storage
@@ -270,7 +272,7 @@ class WaitingLock:
     def _get_next_retry_interval(self) -> float:
         next = self._retry_interval
         self._retry_interval = max(5, next * 2)
-        if self._retry_interval > 5 * 2**7:  # ~10 minutes
+        if self._retry_interval > 10 * ONE_MINUTE_SECONDS:  # >7 iterations
             logging.warning(
                 f"Lock timeout is getting excessive: {self._retry_interval}s. There may be a deadlock."
             )
@@ -349,7 +351,7 @@ class WaitingMultiLock:
     def _get_next_retry_interval(self) -> float:
         next = self._retry_interval
         self._retry_interval = max(5, next * 2)
-        if self._retry_interval > 5 * 2**7:  # ~10 minutes
+        if self._retry_interval > 10 * ONE_MINUTE_SECONDS:  # >7 iterations
             logging.warning(
                 f"Lock timeout is getting excessive: {self._retry_interval}s. There may be a deadlock."
             )

--- a/synapse/handlers/worker_lock.py
+++ b/synapse/handlers/worker_lock.py
@@ -274,8 +274,9 @@ class WaitingLock:
         next = self._retry_interval
         self._retry_interval = max(5, next * 2)
         if self._retry_interval > 10 * ONE_MINUTE_SECONDS:  # >7 iterations
-            logging.warning(
-                f"Lock timeout is getting excessive: {self._retry_interval}s. There may be a deadlock."
+            logger.warning(
+                "Lock timeout is getting excessive: %ss. There may be a deadlock.",
+                self._retry_interval,
             )
         return next * random.uniform(0.9, 1.1)
 
@@ -353,7 +354,8 @@ class WaitingMultiLock:
         next = self._retry_interval
         self._retry_interval = max(5, next * 2)
         if self._retry_interval > 10 * ONE_MINUTE_SECONDS:  # >7 iterations
-            logging.warning(
-                f"Lock timeout is getting excessive: {self._retry_interval}s. There may be a deadlock."
+            logger.warning(
+                "Lock timeout is getting excessive: %ss. There may be a deadlock.",
+                self._retry_interval,
             )
         return next * random.uniform(0.9, 1.1)

--- a/synapse/handlers/worker_lock.py
+++ b/synapse/handlers/worker_lock.py
@@ -44,6 +44,7 @@ from synapse.logging.opentracing import start_active_span
 from synapse.metrics.background_process_metrics import wrap_as_background_process
 from synapse.storage.databases.main.lock import Lock, LockStore
 from synapse.util.async_helpers import timeout_deferred
+from synapse.util.constants import ONE_MINUTE_SECONDS
 
 if TYPE_CHECKING:
     from synapse.logging.opentracing import opentracing
@@ -55,8 +56,6 @@ if TYPE_CHECKING:
 # This is because it is fine to create several events concurrently, since referenced events
 # will not disappear under our feet as long as we don't delete the room.
 NEW_EVENT_DURING_PURGE_LOCK_NAME = "new_event_during_purge_lock"
-
-ONE_MINUTE_SECONDS = 60
 
 
 class WorkerLocksHandler:

--- a/synapse/handlers/worker_lock.py
+++ b/synapse/handlers/worker_lock.py
@@ -270,7 +270,7 @@ class WaitingLock:
     def _get_next_retry_interval(self) -> float:
         next = self._retry_interval
         self._retry_interval = max(5, next * 2)
-        if self._retry_interval > 5 * 2 ^ 7:  # ~10 minutes
+        if self._retry_interval > 5 * 2**7:  # ~10 minutes
             logging.warning(
                 f"Lock timeout is getting excessive: {self._retry_interval}s. There may be a deadlock."
             )
@@ -349,7 +349,7 @@ class WaitingMultiLock:
     def _get_next_retry_interval(self) -> float:
         next = self._retry_interval
         self._retry_interval = max(5, next * 2)
-        if self._retry_interval > 5 * 2 ^ 7:  # ~10 minutes
+        if self._retry_interval > 5 * 2**7:  # ~10 minutes
             logging.warning(
                 f"Lock timeout is getting excessive: {self._retry_interval}s. There may be a deadlock."
             )

--- a/synapse/util/constants.py
+++ b/synapse/util/constants.py
@@ -1,0 +1,20 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2025 New Vector, Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+
+# Time-based constants.
+#
+# Laying these out incrementally, even if only some are required, helps with
+# readability and catching bugs.
+ONE_MINUTE_SECONDS = 60
+ONE_HOUR_SECONDS = 60 * ONE_MINUTE_SECONDS


### PR DESCRIPTION
Fix a small typo I came across.

It appears the only issue this would cause is logging "Lock timeout is getting excessive" unnecessarily in a few cases before `self._retry_interval` built up.

```
>>> 5 * 2 ^ 7
13
```

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
