### PR TITLE
bugfix: calculate the PL for non-creators correctly in v11 rooms

### DIFF
--- a/synapse/state/v2.py
+++ b/synapse/state/v2.py
@@ -255,7 +255,7 @@ async def _get_power_level_for_sender(
             )
             if aev and (aev.type, aev.state_key) == (EventTypes.Create, ""):
                 creator = (
-                    event.sender
+                    aev.sender
                     if event.room_version.implicit_room_creator
                     else aev.content.get("creator")
                 )


### PR DESCRIPTION
The fix in #18534 regressed the PL calculation of non-creators. Added yet more tests to catch this failure mode.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
