### PR TITLE
Support modules sending server notices

### DIFF
--- a/changelog.d/18570.feat
+++ b/changelog.d/18570.feat
@@ -1,0 +1,1 @@
+Support modules sending server notices.

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -1892,6 +1892,33 @@ class ModuleApi:
         """Returns the current server time in milliseconds."""
         return self._clock.time_msec()
 
+    async def send_server_notice(
+        self, user_id: str, type: str, event_content: JsonDict
+    ) -> JsonDict:
+        """Send a server notice to a user.
+
+        Added in Synapse v1.133.0.
+
+        Args:
+            user_id: The full user ID to send the server notice to. This must be a user
+                local to this homeserver.
+            type: The type of event to send. e.g. m.room.message
+            event_content: A dictionary representing the content of the event to send.
+
+        Returns:
+            The event that was sent. If state event deduplication happened, then
+                the previous, duplicate event instead.
+
+        Raises:
+            SynapseError if the event was not allowed.
+        """
+        # Create and send the notice
+        event = await self._hs.get_server_notices_manager().send_notice(
+            user_id=user_id, event_content=event_content, type=type
+        )
+
+        return event
+
 
 class PublicRoomListManager:
     """Contains methods for adding to, removing from and querying whether a room


### PR DESCRIPTION
Adds `send_server_notice()` to the module API. Relies on https://github.com/element-hq/synapse/pull/18569 to make this safe to do so from workers.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
