### PR TITLE
Make 'fix lint' action also regenerate config docs

### DIFF
--- a/.github/workflows/fix_lint.yaml
+++ b/.github/workflows/fix_lint.yaml
@@ -24,6 +24,9 @@ jobs:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
 
+      - name: Install PyYAML
+        run: pip install PyYAML==6.0.2
+
       - name: Setup Poetry
         uses: matrix-org/setup-python-poetry@5bbf6603c5c930615ec8a29f1b5d7d258d905aa4 # v2.0.0
         with:
@@ -42,6 +45,13 @@ jobs:
         continue-on-error: true
 
       - run: cargo fmt
+        continue-on-error: true
+
+      - name: Regenerate config
+        run: |
+          scripts-dev/gen_config_documentation.py \
+            schema/synapse-config.schema.yaml \
+          > docs/usage/configuration/config_documentation.md
         continue-on-error: true
 
       - uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0

--- a/changelog.d/18579.misc
+++ b/changelog.d/18579.misc
@@ -1,0 +1,1 @@
+Make 'fix lint' action also regenerate config docs.


### PR DESCRIPTION
This is what the lint.sh script does, so for people that can't run the script we can offer the same function via GHA. 

**Note:** I have no way of testing this, and copy/pasted code from the lint (schema) action.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
