### PR TITLE
Use UTF-8 for config doc generation

### DIFF
--- a/scripts-dev/gen_config_documentation.py
+++ b/scripts-dev/gen_config_documentation.py
@@ -473,6 +473,9 @@ def section(prop: str, values: dict) -> str:
 
 
 def main() -> None:
+    # For Windows: reconfigure the terminal to be UTF-8 for `print()` calls.
+    sys.stdout.reconfigure(encoding='utf-8')
+
     def usage(err_msg: str) -> int:
         script_name = (sys.argv[:1] or ["__main__.py"])[0]
         print(err_msg, file=sys.stderr)
@@ -485,7 +488,10 @@ def main() -> None:
             exit(usage("Too many arguments."))
         if not (filepath := (sys.argv[1:] or [""])[0]):
             exit(usage("No schema file provided."))
-        with open(filepath) as f:
+        with open(filepath, 'r', encoding='utf8') as f:
+            # Note: Windows requires that we specify the encoding otherwise it uses
+            # things like CP-1251, which can cause explosions.
+            # See https://github.com/yaml/pyyaml/issues/123 for more info.
             return yaml.safe_load(f)
 
     schema = read_json_file_arg()


### PR DESCRIPTION
This fixes the issue on Windows, which uses CP-1251 by default.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
