### PR TITLE
Refactor `Measure` block metrics to be homeserver-scoped

### DIFF
--- a/changelog.d/18591.misc
+++ b/changelog.d/18591.misc
@@ -1,0 +1,1 @@
+Refactor `Measure` block metrics to be homeserver-scoped.

--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -58,6 +58,7 @@ from synapse.logging.context import (
     make_deferred_yieldable,
     run_in_background,
 )
+from synapse.metrics.homeserver_metrics_manager import HomeserverMetricsManager
 from synapse.notifier import ReplicationNotifier
 from synapse.storage.database import DatabasePool, LoggingTransaction, make_conn
 from synapse.storage.databases.main import FilteringWorkerStore
@@ -308,12 +309,16 @@ class Store(
 class MockHomeserver:
     def __init__(self, config: HomeServerConfig):
         self.clock = Clock(reactor)
+        self.metrics_manager = HomeserverMetricsManager()
         self.config = config
         self.hostname = config.server.server_name
         self.version_string = SYNAPSE_VERSION
 
     def get_clock(self) -> Clock:
         return self.clock
+
+    def get_metrics_manager(self) -> HomeserverMetricsManager:
+        return self.metrics_manager
 
     def get_reactor(self) -> ISynapseReactor:
         return reactor

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -49,7 +49,7 @@ from synapse.config.server import ListenerConfig, TCPListenerConfig
 from synapse.federation.transport.server import TransportLayerServer
 from synapse.http.server import JsonResource, OptionsResource
 from synapse.logging.context import LoggingContext
-from synapse.metrics import METRICS_PREFIX, MetricsResource, RegistryProxy
+from synapse.metrics import METRICS_PREFIX, MetricsResource
 from synapse.replication.http import REPLICATION_PREFIX, ReplicationRestResource
 from synapse.rest import ClientRestResource, admin
 from synapse.rest.health import HealthResource
@@ -186,7 +186,9 @@ class GenericWorkerServer(HomeServer):
         for res in listener_config.http_options.resources:
             for name in res.names:
                 if name == "metrics":
-                    resources[METRICS_PREFIX] = MetricsResource(RegistryProxy)
+                    resources[METRICS_PREFIX] = MetricsResource(
+                        metrics_manager=self.get_metrics_manager()
+                    )
                 elif name == "client":
                     resource: Resource = ClientRestResource(self)
 
@@ -294,6 +296,7 @@ class GenericWorkerServer(HomeServer):
                         _base.listen_metrics(
                             listener.bind_addresses,
                             listener.port,
+                            self.get_metrics_manager(),
                         )
                     else:
                         raise ConfigError(

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -60,7 +60,7 @@ from synapse.http.server import (
     StaticResource,
 )
 from synapse.logging.context import LoggingContext
-from synapse.metrics import METRICS_PREFIX, MetricsResource, RegistryProxy
+from synapse.metrics import METRICS_PREFIX, MetricsResource
 from synapse.replication.http import REPLICATION_PREFIX, ReplicationRestResource
 from synapse.rest import ClientRestResource, admin
 from synapse.rest.health import HealthResource
@@ -252,7 +252,9 @@ class SynapseHomeServer(HomeServer):
             resources[SERVER_KEY_PREFIX] = KeyResource(self)
 
         if name == "metrics" and self.config.metrics.enable_metrics:
-            metrics_resource: Resource = MetricsResource(RegistryProxy)
+            metrics_resource: Resource = MetricsResource(
+                metrics_manager=self.get_metrics_manager()
+            )
             if compress:
                 metrics_resource = gz_wrap(metrics_resource)
             resources[METRICS_PREFIX] = metrics_resource
@@ -296,6 +298,7 @@ class SynapseHomeServer(HomeServer):
                         _base.listen_metrics(
                             listener.bind_addresses,
                             listener.port,
+                            self.get_metrics_manager(),
                         )
                     else:
                         raise ConfigError(

--- a/synapse/federation/send_queue.py
+++ b/synapse/federation/send_queue.py
@@ -73,6 +73,7 @@ class FederationRemoteSendQueue(AbstractFederationSender):
     def __init__(self, hs: "HomeServer"):
         self.server_name = hs.hostname
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         self.notifier = hs.get_notifier()
         self.is_mine_id = hs.is_mine_id
         self.is_mine_server_name = hs.is_mine_server_name
@@ -156,7 +157,7 @@ class FederationRemoteSendQueue(AbstractFederationSender):
 
     def _clear_queue_before_pos(self, position_to_delete: int) -> None:
         """Clear all the queues from before a given position"""
-        with Measure(self.clock, "send_queue._clear"):
+        with Measure(self.clock, self.metrics_manager, "send_queue._clear"):
             # Delete things out of presence maps
             keys = self.presence_destinations.keys()
             i = self.presence_destinations.bisect_left(position_to_delete)

--- a/synapse/federation/send_queue.py
+++ b/synapse/federation/send_queue.py
@@ -73,7 +73,7 @@ class FederationRemoteSendQueue(AbstractFederationSender):
     def __init__(self, hs: "HomeServer"):
         self.server_name = hs.hostname
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self.notifier = hs.get_notifier()
         self.is_mine_id = hs.is_mine_id
         self.is_mine_server_name = hs.is_mine_server_name

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -378,7 +378,7 @@ class FederationSender(AbstractFederationSender):
         self._storage_controllers = hs.get_storage_controllers()
 
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self.is_mine_id = hs.is_mine_id
         self.is_mine_server_name = hs.is_mine_server_name
 

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -378,6 +378,7 @@ class FederationSender(AbstractFederationSender):
         self._storage_controllers = hs.get_storage_controllers()
 
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         self.is_mine_id = hs.is_mine_id
         self.is_mine_server_name = hs.is_mine_server_name
 
@@ -657,7 +658,9 @@ class FederationSender(AbstractFederationSender):
                     logger.debug(
                         "Handling %i events in room %s", len(events), events[0].room_id
                     )
-                    with Measure(self.clock, "handle_room_events"):
+                    with Measure(
+                        self.clock, self.metrics_manager, "handle_room_events"
+                    ):
                         for event in events:
                             await handle_event(event)
 

--- a/synapse/federation/sender/transaction_manager.py
+++ b/synapse/federation/sender/transaction_manager.py
@@ -61,7 +61,7 @@ class TransactionManager:
         self._server_name = hs.hostname
         self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self.metrics_manager = (
-            hs.metrics_manager
+            hs.get_metrics_manager()
         )  # nb must be called this for @measure_func
         self._store = hs.get_datastores().main
         self._transaction_actions = TransactionActions(self._store)

--- a/synapse/federation/sender/transaction_manager.py
+++ b/synapse/federation/sender/transaction_manager.py
@@ -60,6 +60,9 @@ class TransactionManager:
     def __init__(self, hs: "synapse.server.HomeServer"):
         self._server_name = hs.hostname
         self.clock = hs.get_clock()  # nb must be called this for @measure_func
+        self.metrics_manager = (
+            hs.metrics_manager
+        )  # nb must be called this for @measure_func
         self._store = hs.get_datastores().main
         self._transaction_actions = TransactionActions(self._store)
         self._transport_layer = hs.get_federation_transport_client()

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -79,7 +79,7 @@ class ApplicationServicesHandler:
         self.scheduler = hs.get_application_service_scheduler()
         self.started_scheduler = False
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self.notify_appservices = hs.config.worker.should_notify_appservices
         self.event_sources = hs.get_event_sources()
         self._msc2409_to_device_messages_enabled = (

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -58,6 +58,7 @@ class DelayedEventsHandler:
         self._storage_controllers = hs.get_storage_controllers()
         self._config = hs.config
         self._clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         self._event_creation_handler = hs.get_event_creation_handler()
         self._room_member_handler = hs.get_room_member_handler()
 
@@ -159,7 +160,7 @@ class DelayedEventsHandler:
 
         # Loop round handling deltas until we're up to date
         while True:
-            with Measure(self._clock, "delayed_events_delta"):
+            with Measure(self._clock, self.metrics_manager, "delayed_events_delta"):
                 room_max_stream_ordering = self._store.get_room_max_stream_ordering()
                 if self._event_pos == room_max_stream_ordering:
                     return

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -58,7 +58,7 @@ class DelayedEventsHandler:
         self._storage_controllers = hs.get_storage_controllers()
         self._config = hs.config
         self._clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self._event_creation_handler = hs.get_event_creation_handler()
         self._room_member_handler = hs.get_room_member_handler()
 

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -528,7 +528,7 @@ class DeviceHandler(DeviceWorkerHandler):
 
         self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self.metrics_manager = (
-            hs.metrics_manager
+            hs.get_metrics_manager()
         )  # nb must be called this for @measure_func
 
         self.federation_sender = hs.get_federation_sender()
@@ -1224,7 +1224,7 @@ class DeviceListUpdater(DeviceListWorkerUpdater):
 
         self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self.metrics_manager = (
-            hs.metrics_manager
+            hs.get_metrics_manager()
         )  # nb must be called this for @measure_func
 
         self._remote_edu_linearizer = Linearizer(name="remote_device_list")

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -526,6 +526,11 @@ class DeviceHandler(DeviceWorkerHandler):
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
 
+        self.clock = hs.get_clock()  # nb must be called this for @measure_func
+        self.metrics_manager = (
+            hs.metrics_manager
+        )  # nb must be called this for @measure_func
+
         self.federation_sender = hs.get_federation_sender()
         self._account_data_handler = hs.get_account_data_handler()
         self._storage_controllers = hs.get_storage_controllers()
@@ -1214,9 +1219,13 @@ class DeviceListUpdater(DeviceListWorkerUpdater):
     def __init__(self, hs: "HomeServer", device_handler: DeviceHandler):
         self.store = hs.get_datastores().main
         self.federation = hs.get_federation_client()
-        self.clock = hs.get_clock()
         self.device_handler = device_handler
         self._notifier = hs.get_notifier()
+
+        self.clock = hs.get_clock()  # nb must be called this for @measure_func
+        self.metrics_manager = (
+            hs.metrics_manager
+        )  # nb must be called this for @measure_func
 
         self._remote_edu_linearizer = Linearizer(name="remote_device_list")
         self._resync_linearizer = Linearizer(name="remote_device_resync")

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -481,13 +481,13 @@ class EventCreationHandler:
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self.state = hs.get_state_handler()
+        self.validator = EventValidator()
+        self.event_builder_factory = hs.get_event_builder_factory()
         self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self.metrics_manager = (
             hs.metrics_manager
         )  # nb must be called this for @measure_func
-        self.validator = EventValidator()
         self.profile_handler = hs.get_profile_handler()
-        self.event_builder_factory = hs.get_event_builder_factory()
         self.server_name = hs.hostname
         self.notifier = hs.get_notifier()
         self.config = hs.config

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -485,7 +485,7 @@ class EventCreationHandler:
         self.event_builder_factory = hs.get_event_builder_factory()
         self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self.metrics_manager = (
-            hs.metrics_manager
+            hs.get_metrics_manager()
         )  # nb must be called this for @measure_func
         self.profile_handler = hs.get_profile_handler()
         self.server_name = hs.hostname

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -481,7 +481,10 @@ class EventCreationHandler:
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self.state = hs.get_state_handler()
-        self.clock = hs.get_clock()
+        self.clock = hs.get_clock()  # nb must be called this for @measure_func
+        self.metrics_manager = (
+            hs.metrics_manager
+        )  # nb must be called this for @measure_func
         self.validator = EventValidator()
         self.profile_handler = hs.get_profile_handler()
         self.event_builder_factory = hs.get_event_builder_factory()

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -749,7 +749,7 @@ class PresenceHandler(BasePresenceHandler):
         super().__init__(hs)
         self.wheel_timer: WheelTimer[str] = WheelTimer()
         self.notifier = hs.get_notifier()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
 
         federation_registry = hs.get_federation_registry()
 
@@ -1763,7 +1763,7 @@ class PresenceEventSource(EventSource[int, UserPresenceState]):
         self.get_presence_handler = hs.get_presence_handler
         self.get_presence_router = hs.get_presence_router
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self.store = hs.get_datastores().main
 
     async def get_new_events(

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -337,6 +337,7 @@ class SyncHandler:
         self._push_rules_handler = hs.get_push_rules_handler()
         self.event_sources = hs.get_event_sources()
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         self.state = hs.get_state_handler()
         self.auth_blocking = hs.get_auth_blocking()
         self._storage_controllers = hs.get_storage_controllers()
@@ -710,7 +711,7 @@ class SyncHandler:
 
         sync_config = sync_result_builder.sync_config
 
-        with Measure(self.clock, "ephemeral_by_room"):
+        with Measure(self.clock, self.metrics_manager, "ephemeral_by_room"):
             typing_key = since_token.typing_key if since_token else 0
 
             room_ids = sync_result_builder.joined_room_ids
@@ -783,7 +784,7 @@ class SyncHandler:
                 and current token to send down to clients.
             newly_joined_room
         """
-        with Measure(self.clock, "load_filtered_recents"):
+        with Measure(self.clock, self.metrics_manager, "load_filtered_recents"):
             timeline_limit = sync_config.filter_collection.timeline_limit()
             block_all_timeline = (
                 sync_config.filter_collection.blocks_all_room_timeline()
@@ -1174,7 +1175,7 @@ class SyncHandler:
         # updates even if they occurred logically before the previous event.
         # TODO(mjark) Check for new redactions in the state events.
 
-        with Measure(self.clock, "compute_state_delta"):
+        with Measure(self.clock, self.metrics_manager, "compute_state_delta"):
             # The memberships needed for events in the timeline.
             # Only calculated when `lazy_load_members` is on.
             members_to_fetch: Optional[Set[str]] = None
@@ -1791,7 +1792,7 @@ class SyncHandler:
             # the DB.
             return RoomNotifCounts.empty()
 
-        with Measure(self.clock, "unread_notifs_for_room_id"):
+        with Measure(self.clock, self.metrics_manager, "unread_notifs_for_room_id"):
             return await self.store.get_unread_event_push_actions_by_room_for_user(
                 room_id,
                 sync_config.user.to_string(),

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -337,7 +337,7 @@ class SyncHandler:
         self._push_rules_handler = hs.get_push_rules_handler()
         self.event_sources = hs.get_event_sources()
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self.state = hs.get_state_handler()
         self.auth_blocking = hs.get_auth_blocking()
         self._storage_controllers = hs.get_storage_controllers()

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -505,7 +505,7 @@ class TypingNotificationEventSource(EventSource[int, JsonMapping]):
     def __init__(self, hs: "HomeServer"):
         self._main_store = hs.get_datastores().main
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         # We can't call get_typing_handler here because there's a cycle:
         #
         #   Typing -> Notifier -> TypingNotificationEventSource -> Typing

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -505,6 +505,7 @@ class TypingNotificationEventSource(EventSource[int, JsonMapping]):
     def __init__(self, hs: "HomeServer"):
         self._main_store = hs.get_datastores().main
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         # We can't call get_typing_handler here because there's a cycle:
         #
         #   Typing -> Notifier -> TypingNotificationEventSource -> Typing
@@ -535,7 +536,7 @@ class TypingNotificationEventSource(EventSource[int, JsonMapping]):
                   appservice may be interested in.
                 * The latest known room serial.
         """
-        with Measure(self.clock, "typing.get_new_events_as"):
+        with Measure(self.clock, self.metrics_manager, "typing.get_new_events_as"):
             handler = self.get_typing_handler()
 
             events = []
@@ -571,7 +572,7 @@ class TypingNotificationEventSource(EventSource[int, JsonMapping]):
         Find typing notifications for given rooms (> `from_token` and <= `to_token`)
         """
 
-        with Measure(self.clock, "typing.get_new_events"):
+        with Measure(self.clock, self.metrics_manager, "typing.get_new_events"):
             from_key = int(from_key)
             handler = self.get_typing_handler()
 

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -104,7 +104,7 @@ class UserDirectoryHandler(StateDeltasHandler):
         self._storage_controllers = hs.get_storage_controllers()
         self.server_name = hs.hostname
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self.notifier = hs.get_notifier()
         self.is_mine_id = hs.is_mine_id
         self.update_user_directory = hs.config.worker.should_update_user_directory

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -104,6 +104,7 @@ class UserDirectoryHandler(StateDeltasHandler):
         self._storage_controllers = hs.get_storage_controllers()
         self.server_name = hs.hostname
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         self.notifier = hs.get_notifier()
         self.is_mine_id = hs.is_mine_id
         self.update_user_directory = hs.config.worker.should_update_user_directory
@@ -237,7 +238,7 @@ class UserDirectoryHandler(StateDeltasHandler):
 
         # Loop round handling deltas until we're up to date
         while True:
-            with Measure(self.clock, "user_dir_delta"):
+            with Measure(self.clock, self.metrics_manager, "user_dir_delta"):
                 room_max_stream_ordering = self.store.get_room_max_stream_ordering()
                 if self.pos == room_max_stream_ordering:
                     return

--- a/synapse/http/federation/matrix_federation_agent.py
+++ b/synapse/http/federation/matrix_federation_agent.py
@@ -48,6 +48,7 @@ from synapse.http.federation.srv_resolver import Server, SrvResolver
 from synapse.http.federation.well_known_resolver import WellKnownResolver
 from synapse.http.proxyagent import ProxyAgent
 from synapse.logging.context import make_deferred_yieldable, run_in_background
+from synapse.metrics.homeserver_metrics_manager import HomeserverMetricsManager
 from synapse.types import ISynapseReactor
 from synapse.util import Clock
 
@@ -93,6 +94,7 @@ class MatrixFederationAgent:
     def __init__(
         self,
         reactor: ISynapseReactor,
+        metrics_manager: HomeserverMetricsManager,
         tls_client_options_factory: Optional[FederationPolicyForHTTPS],
         user_agent: bytes,
         ip_allowlist: Optional[IPSet],
@@ -128,6 +130,7 @@ class MatrixFederationAgent:
         if _well_known_resolver is None:
             _well_known_resolver = WellKnownResolver(
                 reactor,
+                metrics_manager,
                 agent=BlocklistingAgentWrapper(
                     ProxyAgent(
                         reactor,

--- a/synapse/http/federation/well_known_resolver.py
+++ b/synapse/http/federation/well_known_resolver.py
@@ -35,6 +35,7 @@ from twisted.web.iweb import IAgent, IResponse
 
 from synapse.http.client import BodyExceededMaxSize, read_body_with_max_size
 from synapse.logging.context import make_deferred_yieldable
+from synapse.metrics.homeserver_metrics_manager import HomeserverMetricsManager
 from synapse.util import Clock, json_decoder
 from synapse.util.caches.ttlcache import TTLCache
 from synapse.util.metrics import Measure
@@ -92,6 +93,7 @@ class WellKnownResolver:
     def __init__(
         self,
         reactor: IReactorTime,
+        metrics_manager: HomeserverMetricsManager,
         agent: IAgent,
         user_agent: bytes,
         well_known_cache: Optional[TTLCache[bytes, Optional[bytes]]] = None,
@@ -99,6 +101,7 @@ class WellKnownResolver:
     ):
         self._reactor = reactor
         self._clock = Clock(reactor)
+        self.metrics_manager = metrics_manager
 
         if well_known_cache is None:
             well_known_cache = _well_known_cache

--- a/synapse/http/federation/well_known_resolver.py
+++ b/synapse/http/federation/well_known_resolver.py
@@ -134,7 +134,7 @@ class WellKnownResolver:
         # TODO: should we linearise so that we don't end up doing two .well-known
         # requests for the same server in parallel?
         try:
-            with Measure(self._clock, "get_well_known"):
+            with Measure(self._clock, self.metrics_manager, "get_well_known"):
                 result: Optional[bytes]
                 cache_period: float
 

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -451,6 +451,7 @@ class MatrixFederationHttpClient:
         )
 
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         self._store = hs.get_datastores().main
         self.version_string_bytes = hs.version_string.encode("ascii")
         self.default_timeout_seconds = hs.config.federation.client_timeout_ms / 1000
@@ -697,7 +698,9 @@ class MatrixFederationHttpClient:
                     outgoing_requests_counter.labels(request.method).inc()
 
                     try:
-                        with Measure(self.clock, "outbound_request"):
+                        with Measure(
+                            self.clock, self.metrics_manager, "outbound_request"
+                        ):
                             # we don't want all the fancy cookie and redirect handling
                             # that treq.request gives: just use the raw Agent.
 

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -406,7 +406,7 @@ class MatrixFederationHttpClient:
         self.server_name = hs.hostname
 
         self.reactor = hs.get_reactor()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
 
         user_agent = hs.version_string
         if hs.config.server.user_agent_suffix:
@@ -453,7 +453,7 @@ class MatrixFederationHttpClient:
         )
 
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self._store = hs.get_datastores().main
         self.version_string_bytes = hs.version_string.encode("ascii")
         self.default_timeout_seconds = hs.config.federation.client_timeout_ms / 1000

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -406,6 +406,7 @@ class MatrixFederationHttpClient:
         self.server_name = hs.hostname
 
         self.reactor = hs.get_reactor()
+        self.metrics_manager = hs.metrics_manager
 
         user_agent = hs.version_string
         if hs.config.server.user_agent_suffix:
@@ -418,6 +419,7 @@ class MatrixFederationHttpClient:
             # Talk to federation directly
             federation_agent: IAgent = MatrixFederationAgent(
                 self.reactor,
+                self.metrics_manager,
                 tls_client_options_factory,
                 user_agent.encode("ascii"),
                 hs.config.server.federation_ip_range_allowlist,

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -69,8 +69,8 @@ HAVE_PROC_SELF_STAT = os.path.exists("/proc/self/stat")
 
 class CombinedRegistryProxy:
     """
-    Wrapper around the global Prometheus metric registry so we can also include our
-    homeserver-specific metrics.
+    Wrapper that combines multiple Prometheus `CollectorRegistry` instances, presenting
+    them as a single unified registry when collecting metrics.
 
     Usage:
     ```python
@@ -78,6 +78,9 @@ class CombinedRegistryProxy:
         homeserver_metrics_collector_registry,
         prometheus_client.REGISTRY
     ])
+    # Cheeky cast but matches the signature of a `CollectorRegistry` instance enough
+    # for it to be usable in the contexts in which we use it.
+    # TODO Do something nicer about this.
     registry = cast(CollectorRegistry, combined_registry_proxy)
     ```
     """

--- a/synapse/metrics/homeserver_metrics_manager.py
+++ b/synapse/metrics/homeserver_metrics_manager.py
@@ -1,0 +1,87 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2025 New Vector, Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+
+from prometheus_client import CollectorRegistry, Counter
+
+
+class BlockMetrics:
+    def __init__(
+        self,
+        metrics_collector_registry: CollectorRegistry,
+    ) -> None:
+        self.block_counter = Counter(
+            "synapse_util_metrics_block_count",
+            "",
+            ["block_name"],
+            registry=metrics_collector_registry,
+        )
+
+        self.block_timer = Counter(
+            "synapse_util_metrics_block_time_seconds",
+            "",
+            ["block_name"],
+            registry=metrics_collector_registry,
+        )
+
+        self.block_ru_utime = Counter(
+            "synapse_util_metrics_block_ru_utime_seconds",
+            "",
+            ["block_name"],
+            registry=metrics_collector_registry,
+        )
+
+        self.block_ru_stime = Counter(
+            "synapse_util_metrics_block_ru_stime_seconds",
+            "",
+            ["block_name"],
+            registry=metrics_collector_registry,
+        )
+
+        self.block_db_txn_count = Counter(
+            "synapse_util_metrics_block_db_txn_count",
+            "",
+            ["block_name"],
+            registry=metrics_collector_registry,
+        )
+
+        self.block_db_txn_duration = Counter(
+            "synapse_util_metrics_block_db_txn_duration_seconds",
+            "",
+            ["block_name"],
+            registry=metrics_collector_registry,
+        )
+        """seconds spent waiting for db txns, excluding scheduling time, in this block"""
+
+        self.block_db_sched_duration = Counter(
+            "synapse_util_metrics_block_db_sched_duration_seconds",
+            "",
+            ["block_name"],
+            registry=metrics_collector_registry,
+        )
+        """seconds spent waiting for a db connection, in this block"""
+
+
+class HomeserverMetricsManager:
+    """
+    Homeserver-scoped metrics manager.
+
+    This class serves as a container for the homeserver's global metrics objects.
+    """
+
+    def __init__(self) -> None:
+        self.metrics_collector_registry = CollectorRegistry(auto_describe=True)
+
+        self.block_metrics = BlockMetrics(
+            metrics_collector_registry=self.metrics_collector_registry,
+        )

--- a/synapse/metrics/homeserver_metrics_manager.py
+++ b/synapse/metrics/homeserver_metrics_manager.py
@@ -32,6 +32,10 @@ class BlockInFlightMetric(Protocol):
 
 
 class BlockMetrics:
+    """
+    Metrics to see the number of and how much time is spend in various blocks of code.
+    """
+
     def __init__(
         self,
         metrics_collector_registry: CollectorRegistry,
@@ -49,6 +53,7 @@ class BlockMetrics:
             ["block_name"],
             registry=metrics_collector_registry,
         )
+        """The cumulative time spent executing this block across all calls, in seconds."""
 
         self.block_ru_utime = Counter(
             "synapse_util_metrics_block_ru_utime_seconds",
@@ -56,6 +61,7 @@ class BlockMetrics:
             ["block_name"],
             registry=metrics_collector_registry,
         )
+        """Resource usage: user CPU time in seconds used in this block"""
 
         self.block_ru_stime = Counter(
             "synapse_util_metrics_block_ru_stime_seconds",
@@ -63,6 +69,7 @@ class BlockMetrics:
             ["block_name"],
             registry=metrics_collector_registry,
         )
+        """Resource usage: system CPU time in seconds used in this block"""
 
         self.block_db_txn_count = Counter(
             "synapse_util_metrics_block_db_txn_count",
@@ -70,6 +77,7 @@ class BlockMetrics:
             ["block_name"],
             registry=metrics_collector_registry,
         )
+        """Number of database transactions completed in this block"""
 
         self.block_db_txn_duration = Counter(
             "synapse_util_metrics_block_db_txn_duration_seconds",
@@ -77,7 +85,7 @@ class BlockMetrics:
             ["block_name"],
             registry=metrics_collector_registry,
         )
-        """seconds spent waiting for db txns, excluding scheduling time, in this block"""
+        """Seconds spent waiting for database txns, excluding scheduling time, in this block"""
 
         self.block_db_sched_duration = Counter(
             "synapse_util_metrics_block_db_sched_duration_seconds",
@@ -85,7 +93,7 @@ class BlockMetrics:
             ["block_name"],
             registry=metrics_collector_registry,
         )
-        """seconds spent waiting for a db connection, in this block"""
+        """Seconds spent waiting for a db connection, in this block"""
 
         self.in_flight: InFlightGauge[BlockInFlightMetric] = InFlightGauge(
             "synapse_util_metrics_block_in_flight",
@@ -94,7 +102,7 @@ class BlockMetrics:
             # Matches the fields in the `BlockInFlightMetric`
             sub_metrics=["real_time_max", "real_time_sum"],
         )
-        """Tracks the number of blocks currently active"""
+        """Tracks the number of blocks currently running and their real time usage."""
 
 
 class HomeserverMetricsManager:

--- a/synapse/metrics/homeserver_metrics_manager.py
+++ b/synapse/metrics/homeserver_metrics_manager.py
@@ -12,7 +12,7 @@
 # <https://www.gnu.org/licenses/agpl-3.0.html>.
 #
 
-from prometheus_client import CollectorRegistry, Counter
+from prometheus_client import REGISTRY, CollectorRegistry, Counter
 
 
 class BlockMetrics:
@@ -80,7 +80,9 @@ class HomeserverMetricsManager:
     """
 
     def __init__(self) -> None:
-        self.metrics_collector_registry = CollectorRegistry(auto_describe=True)
+        # TODO: use `self.metrics_collector_registry = CollectorRegistry(auto_describe=True)`
+        # once we refactor our metrics endpoints to use the specified registry.
+        self.metrics_collector_registry = REGISTRY
 
         self.block_metrics = BlockMetrics(
             metrics_collector_registry=self.metrics_collector_registry,

--- a/synapse/metrics/homeserver_metrics_manager.py
+++ b/synapse/metrics/homeserver_metrics_manager.py
@@ -14,7 +14,7 @@
 
 from typing import Protocol
 
-from prometheus_client import REGISTRY, CollectorRegistry, Counter
+from prometheus_client import CollectorRegistry, Counter
 
 from synapse.metrics import InFlightGauge
 
@@ -113,9 +113,7 @@ class HomeserverMetricsManager:
     """
 
     def __init__(self) -> None:
-        # TODO: use `self.metrics_collector_registry = CollectorRegistry(auto_describe=True)`
-        # once we refactor our metrics endpoints to use the specified registry.
-        self.metrics_collector_registry = REGISTRY
+        self.metrics_collector_registry = CollectorRegistry(auto_describe=True)
 
         self.block_metrics = BlockMetrics(
             metrics_collector_registry=self.metrics_collector_registry,

--- a/synapse/module_api/callbacks/media_repository_callbacks.py
+++ b/synapse/module_api/callbacks/media_repository_callbacks.py
@@ -32,6 +32,7 @@ IS_USER_ALLOWED_TO_UPLOAD_MEDIA_OF_SIZE_CALLBACK = Callable[[str, int], Awaitabl
 class MediaRepositoryModuleApiCallbacks:
     def __init__(self, hs: "HomeServer") -> None:
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         self._get_media_config_for_user_callbacks: List[
             GET_MEDIA_CONFIG_FOR_USER_CALLBACK
         ] = []
@@ -57,7 +58,11 @@ class MediaRepositoryModuleApiCallbacks:
 
     async def get_media_config_for_user(self, user_id: str) -> Optional[JsonDict]:
         for callback in self._get_media_config_for_user_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 res: Optional[JsonDict] = await delay_cancellation(callback(user_id))
             if res:
                 return res
@@ -68,7 +73,11 @@ class MediaRepositoryModuleApiCallbacks:
         self, user_id: str, size: int
     ) -> bool:
         for callback in self._is_user_allowed_to_upload_media_of_size_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 res: bool = await delay_cancellation(callback(user_id, size))
             if not res:
                 return res

--- a/synapse/module_api/callbacks/media_repository_callbacks.py
+++ b/synapse/module_api/callbacks/media_repository_callbacks.py
@@ -32,7 +32,7 @@ IS_USER_ALLOWED_TO_UPLOAD_MEDIA_OF_SIZE_CALLBACK = Callable[[str, int], Awaitabl
 class MediaRepositoryModuleApiCallbacks:
     def __init__(self, hs: "HomeServer") -> None:
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self._get_media_config_for_user_callbacks: List[
             GET_MEDIA_CONFIG_FOR_USER_CALLBACK
         ] = []

--- a/synapse/module_api/callbacks/ratelimit_callbacks.py
+++ b/synapse/module_api/callbacks/ratelimit_callbacks.py
@@ -44,6 +44,7 @@ GET_RATELIMIT_OVERRIDE_FOR_USER_CALLBACK = Callable[
 class RatelimitModuleApiCallbacks:
     def __init__(self, hs: "HomeServer") -> None:
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         self._get_ratelimit_override_for_user_callbacks: List[
             GET_RATELIMIT_OVERRIDE_FOR_USER_CALLBACK
         ] = []
@@ -64,7 +65,11 @@ class RatelimitModuleApiCallbacks:
         self, user_id: str, limiter_name: str
     ) -> Optional[RatelimitOverride]:
         for callback in self._get_ratelimit_override_for_user_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 res: Optional[RatelimitOverride] = await delay_cancellation(
                     callback(user_id, limiter_name)
                 )

--- a/synapse/module_api/callbacks/ratelimit_callbacks.py
+++ b/synapse/module_api/callbacks/ratelimit_callbacks.py
@@ -44,7 +44,7 @@ GET_RATELIMIT_OVERRIDE_FOR_USER_CALLBACK = Callable[
 class RatelimitModuleApiCallbacks:
     def __init__(self, hs: "HomeServer") -> None:
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self._get_ratelimit_override_for_user_callbacks: List[
             GET_RATELIMIT_OVERRIDE_FOR_USER_CALLBACK
         ] = []

--- a/synapse/module_api/callbacks/spamchecker_callbacks.py
+++ b/synapse/module_api/callbacks/spamchecker_callbacks.py
@@ -340,7 +340,7 @@ class SpamCheckerModuleApiCallbacks:
 
     def __init__(self, hs: "synapse.server.HomeServer") -> None:
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
 
         self._check_event_for_spam_callbacks: List[CHECK_EVENT_FOR_SPAM_CALLBACK] = []
         self._should_drop_federated_event_callbacks: List[

--- a/synapse/module_api/callbacks/spamchecker_callbacks.py
+++ b/synapse/module_api/callbacks/spamchecker_callbacks.py
@@ -340,6 +340,7 @@ class SpamCheckerModuleApiCallbacks:
 
     def __init__(self, hs: "synapse.server.HomeServer") -> None:
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
 
         self._check_event_for_spam_callbacks: List[CHECK_EVENT_FOR_SPAM_CALLBACK] = []
         self._should_drop_federated_event_callbacks: List[
@@ -464,7 +465,11 @@ class SpamCheckerModuleApiCallbacks:
                 generally discouraged as it doesn't support internationalization.
         """
         for callback in self._check_event_for_spam_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 res = await delay_cancellation(callback(event))
                 if res is False or res == self.NOT_SPAM:
                     # This spam-checker accepts the event.
@@ -517,7 +522,11 @@ class SpamCheckerModuleApiCallbacks:
             True if the event should be silently dropped
         """
         for callback in self._should_drop_federated_event_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 res: Union[bool, str] = await delay_cancellation(callback(event))
             if res:
                 return res
@@ -539,7 +548,11 @@ class SpamCheckerModuleApiCallbacks:
             NOT_SPAM if the operation is permitted, [Codes, Dict] otherwise.
         """
         for callback in self._user_may_join_room_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 res = await delay_cancellation(callback(user_id, room_id, is_invited))
                 # Normalize return values to `Codes` or `"NOT_SPAM"`.
                 if res is True or res is self.NOT_SPAM:
@@ -578,7 +591,11 @@ class SpamCheckerModuleApiCallbacks:
             NOT_SPAM if the operation is permitted, Codes otherwise.
         """
         for callback in self._user_may_invite_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 res = await delay_cancellation(
                     callback(inviter_userid, invitee_userid, room_id)
                 )
@@ -623,7 +640,11 @@ class SpamCheckerModuleApiCallbacks:
             NOT_SPAM if the operation is permitted, Codes otherwise.
         """
         for callback in self._user_may_send_3pid_invite_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 res = await delay_cancellation(
                     callback(inviter_userid, medium, address, room_id)
                 )
@@ -659,7 +680,11 @@ class SpamCheckerModuleApiCallbacks:
             room_config: The room creation configuration which is the body of the /createRoom request
         """
         for callback in self._user_may_create_room_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 checker_args = inspect.signature(callback)
                 # Also ensure backwards compatibility with spam checker callbacks
                 # that don't expect the room_config argument.
@@ -723,7 +748,11 @@ class SpamCheckerModuleApiCallbacks:
             content: The content of the state event
         """
         for callback in self._user_may_send_state_event_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 # We make a copy of the content to ensure that the spam checker cannot modify it.
                 res = await delay_cancellation(
                     callback(user_id, room_id, event_type, state_key, deepcopy(content))
@@ -751,7 +780,11 @@ class SpamCheckerModuleApiCallbacks:
 
         """
         for callback in self._user_may_create_room_alias_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 res = await delay_cancellation(callback(userid, room_alias))
                 if res is True or res is self.NOT_SPAM:
                     continue
@@ -784,7 +817,11 @@ class SpamCheckerModuleApiCallbacks:
             room_id: The ID of the room that would be published
         """
         for callback in self._user_may_publish_room_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 res = await delay_cancellation(callback(userid, room_id))
                 if res is True or res is self.NOT_SPAM:
                     continue
@@ -826,7 +863,11 @@ class SpamCheckerModuleApiCallbacks:
             True if the user is spammy.
         """
         for callback in self._check_username_for_spam_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 checker_args = inspect.signature(callback)
                 # Make a copy of the user profile object to ensure the spam checker cannot
                 # modify it.
@@ -875,7 +916,11 @@ class SpamCheckerModuleApiCallbacks:
         """
 
         for callback in self._check_registration_for_spam_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 behaviour = await delay_cancellation(
                     callback(email_threepid, username, request_info, auth_provider_id)
                 )
@@ -917,7 +962,11 @@ class SpamCheckerModuleApiCallbacks:
         """
 
         for callback in self._check_media_file_for_spam_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 res = await delay_cancellation(callback(file_wrapper, file_info))
                 # Normalize return values to `Codes` or `"NOT_SPAM"`.
                 if res is False or res is self.NOT_SPAM:
@@ -964,7 +1013,11 @@ class SpamCheckerModuleApiCallbacks:
         """
 
         for callback in self._check_login_for_spam_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                self.metrics_manager,
+                f"{callback.__module__}.{callback.__qualname__}",
+            ):
                 res = await delay_cancellation(
                     callback(
                         user_id,

--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -129,7 +129,10 @@ class BulkPushRuleEvaluator:
     def __init__(self, hs: "HomeServer"):
         self.hs = hs
         self.store = hs.get_datastores().main
-        self.clock = hs.get_clock()
+        self.clock = hs.get_clock()  # nb must be called this for @measure_func
+        self.metrics_manager = (
+            hs.metrics_manager
+        )  # nb must be called this for @measure_func
         self._event_auth_handler = hs.get_event_auth_handler()
         self.should_calculate_push_rules = self.hs.config.push.enable_push
 

--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -131,7 +131,7 @@ class BulkPushRuleEvaluator:
         self.store = hs.get_datastores().main
         self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self.metrics_manager = (
-            hs.metrics_manager
+            hs.get_metrics_manager()
         )  # nb must be called this for @measure_func
         self._event_auth_handler = hs.get_event_auth_handler()
         self.should_calculate_push_rules = self.hs.config.push.enable_push

--- a/synapse/replication/http/federation.py
+++ b/synapse/replication/http/federation.py
@@ -79,7 +79,7 @@ class ReplicationFederationSendEventsRestServlet(ReplicationEndpoint):
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self.federation_event_handler = hs.get_federation_event_handler()
 
     @staticmethod

--- a/synapse/replication/http/federation.py
+++ b/synapse/replication/http/federation.py
@@ -79,6 +79,7 @@ class ReplicationFederationSendEventsRestServlet(ReplicationEndpoint):
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         self.federation_event_handler = hs.get_federation_event_handler()
 
     @staticmethod
@@ -122,7 +123,7 @@ class ReplicationFederationSendEventsRestServlet(ReplicationEndpoint):
     async def _handle_request(  # type: ignore[override]
         self, request: Request, content: JsonDict
     ) -> Tuple[int, JsonDict]:
-        with Measure(self.clock, "repl_fed_send_events_parse"):
+        with Measure(self.clock, self.metrics_manager, "repl_fed_send_events_parse"):
             room_id = content["room_id"]
             backfilled = content["backfilled"]
 

--- a/synapse/replication/http/send_event.py
+++ b/synapse/replication/http/send_event.py
@@ -80,7 +80,7 @@ class ReplicationSendEventRestServlet(ReplicationEndpoint):
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
 
     @staticmethod
     async def _serialize_payload(  # type: ignore[override]

--- a/synapse/replication/http/send_event.py
+++ b/synapse/replication/http/send_event.py
@@ -80,6 +80,7 @@ class ReplicationSendEventRestServlet(ReplicationEndpoint):
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
 
     @staticmethod
     async def _serialize_payload(  # type: ignore[override]
@@ -121,7 +122,7 @@ class ReplicationSendEventRestServlet(ReplicationEndpoint):
     async def _handle_request(  # type: ignore[override]
         self, request: Request, content: JsonDict, event_id: str
     ) -> Tuple[int, JsonDict]:
-        with Measure(self.clock, "repl_send_event_parse"):
+        with Measure(self.clock, self.metrics_manager, "repl_send_event_parse"):
             event_dict = content["event"]
             room_ver = KNOWN_ROOM_VERSIONS[content["room_version"]]
             internal_metadata = content["internal_metadata"]

--- a/synapse/replication/http/send_events.py
+++ b/synapse/replication/http/send_events.py
@@ -81,7 +81,7 @@ class ReplicationSendEventsRestServlet(ReplicationEndpoint):
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
 
     @staticmethod
     async def _serialize_payload(  # type: ignore[override]

--- a/synapse/replication/http/send_events.py
+++ b/synapse/replication/http/send_events.py
@@ -81,6 +81,7 @@ class ReplicationSendEventsRestServlet(ReplicationEndpoint):
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
 
     @staticmethod
     async def _serialize_payload(  # type: ignore[override]
@@ -122,7 +123,7 @@ class ReplicationSendEventsRestServlet(ReplicationEndpoint):
     async def _handle_request(  # type: ignore[override]
         self, request: Request, payload: JsonDict
     ) -> Tuple[int, JsonDict]:
-        with Measure(self.clock, "repl_send_events_parse"):
+        with Measure(self.clock, self.metrics_manager, "repl_send_events_parse"):
             events_and_context = []
             events = payload["events"]
             rooms = set()

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -79,7 +79,7 @@ class ReplicationDataHandler:
         self.notifier = hs.get_notifier()
         self._reactor = hs.get_reactor()
         self._clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self._streams = hs.get_replication_streams()
         self._instance_name = hs.get_instance_name()
         self._typing_handler = hs.get_typing_handler()

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -79,6 +79,7 @@ class ReplicationDataHandler:
         self.notifier = hs.get_notifier()
         self._reactor = hs.get_reactor()
         self._clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         self._streams = hs.get_replication_streams()
         self._instance_name = hs.get_instance_name()
         self._typing_handler = hs.get_typing_handler()
@@ -342,7 +343,9 @@ class ReplicationDataHandler:
         waiting_list.add((position, deferred))
 
         # We measure here to get in flight counts and average waiting time.
-        with Measure(self._clock, "repl.wait_for_stream_position"):
+        with Measure(
+            self._clock, self.metrics_manager, "repl.wait_for_stream_position"
+        ):
             logger.info(
                 "Waiting for repl stream %r to reach %s (%s); currently at: %s",
                 stream_name,

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -80,6 +80,7 @@ class ReplicationStreamer:
     def __init__(self, hs: "HomeServer"):
         self.store = hs.get_datastores().main
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         self.notifier = hs.get_notifier()
         self._instance_name = hs.get_instance_name()
 
@@ -155,7 +156,9 @@ class ReplicationStreamer:
             while self.pending_updates:
                 self.pending_updates = False
 
-                with Measure(self.clock, "repl.stream.get_updates"):
+                with Measure(
+                    self.clock, self.metrics_manager, "repl.stream.get_updates"
+                ):
                     all_streams = self.streams
 
                     if self._replication_torture_level is not None:

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -80,7 +80,7 @@ class ReplicationStreamer:
     def __init__(self, hs: "HomeServer"):
         self.store = hs.get_datastores().main
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self.notifier = hs.get_notifier()
         self._instance_name = hs.get_instance_name()
 

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -129,6 +129,7 @@ from synapse.http.matrixfederationclient import MatrixFederationHttpClient
 from synapse.media.media_repository import MediaRepository
 from synapse.metrics import register_threadpool
 from synapse.metrics.common_usage_metrics import CommonUsageMetricsManager
+from synapse.metrics.homeserver_metrics_manager import HomeserverMetricsManager
 from synapse.module_api import ModuleApi
 from synapse.module_api.callbacks import ModuleApiCallbacks
 from synapse.notifier import Notifier, ReplicationNotifier
@@ -309,6 +310,8 @@ class HomeServer(metaclass=abc.ABCMeta):
 
         # This attribute is set by the free function `refresh_certificate`.
         self.tls_server_context_factory: Optional[IOpenSSLContextFactory] = None
+
+        self.metrics_manager = HomeserverMetricsManager()
 
     def register_module_web_resource(self, path: str, resource: Resource) -> None:
         """Allows a module to register a web resource to be served at the given path.

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -311,8 +311,6 @@ class HomeServer(metaclass=abc.ABCMeta):
         # This attribute is set by the free function `refresh_certificate`.
         self.tls_server_context_factory: Optional[IOpenSSLContextFactory] = None
 
-        self.metrics_manager = HomeserverMetricsManager()
-
     def register_module_web_resource(self, path: str, resource: Resource) -> None:
         """Allows a module to register a web resource to be served at the given path.
 
@@ -416,6 +414,10 @@ class HomeServer(metaclass=abc.ABCMeta):
     @cache_in_self
     def get_clock(self) -> Clock:
         return Clock(self._reactor)
+
+    @cache_in_self
+    def get_metrics_manager(self) -> HomeserverMetricsManager:
+        return HomeserverMetricsManager()
 
     def get_datastores(self) -> Databases:
         if not self.datastores:

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -632,6 +632,7 @@ class StateResolutionHandler:
 
     def __init__(self, hs: "HomeServer"):
         self.clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
 
         self.resolve_linearizer = Linearizer(name="state_resolve_lock")
 
@@ -747,7 +748,7 @@ class StateResolutionHandler:
             # which will be used as a cache key for future resolutions, but
             # not get persisted.
 
-            with Measure(self.clock, "state.create_group_ids"):
+            with Measure(self.clock, self.metrics_manager, "state.create_group_ids"):
                 cache = _make_state_cache_entry(new_state, state_groups_ids)
 
             self._state_cache[group_names] = cache
@@ -785,7 +786,9 @@ class StateResolutionHandler:
             a map from (type, state_key) to event_id.
         """
         try:
-            with Measure(self.clock, "state._resolve_events") as m:
+            with Measure(
+                self.clock, self.metrics_manager, "state._resolve_events"
+            ) as m:
                 room_version_obj = KNOWN_ROOM_VERSIONS[room_version]
                 if room_version_obj.state_res == StateResolutionVersions.V1:
                     return await v1.resolve_events_with_store(

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -194,7 +194,7 @@ class StateHandler:
         self._state_storage_controller = hs.get_storage_controllers().state
         self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self.metrics_manager = (
-            hs.metrics_manager
+            hs.get_metrics_manager()
         )  # nb must be called this for @measure_func
         self._state_resolution_handler = hs.get_state_resolution_handler()
         self._storage_controllers = hs.get_storage_controllers()
@@ -635,7 +635,7 @@ class StateResolutionHandler:
 
     def __init__(self, hs: "HomeServer"):
         self.clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
 
         self.resolve_linearizer = Linearizer(name="state_resolve_lock")
 

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -189,10 +189,13 @@ class StateHandler:
     """
 
     def __init__(self, hs: "HomeServer"):
-        self.clock = hs.get_clock()
+        self.hs = hs
         self.store = hs.get_datastores().main
         self._state_storage_controller = hs.get_storage_controllers().state
-        self.hs = hs
+        self.clock = hs.get_clock()  # nb must be called this for @measure_func
+        self.metrics_manager = (
+            hs.metrics_manager
+        )  # nb must be called this for @measure_func
         self._state_resolution_handler = hs.get_state_resolution_handler()
         self._storage_controllers = hs.get_storage_controllers()
         self._events_shard_config = hs.config.worker.events_shard_config

--- a/synapse/storage/controllers/persist_events.py
+++ b/synapse/storage/controllers/persist_events.py
@@ -338,7 +338,7 @@ class EventsPersistenceStorageController:
         self.persist_events_store = stores.persist_events
 
         self._clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self._instance_name = hs.get_instance_name()
         self.is_mine_id = hs.is_mine_id
         self._event_persist_queue = _EventPeristenceQueue(

--- a/synapse/storage/controllers/persist_events.py
+++ b/synapse/storage/controllers/persist_events.py
@@ -338,6 +338,7 @@ class EventsPersistenceStorageController:
         self.persist_events_store = stores.persist_events
 
         self._clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         self._instance_name = hs.get_instance_name()
         self.is_mine_id = hs.is_mine_id
         self._event_persist_queue = _EventPeristenceQueue(
@@ -616,7 +617,9 @@ class EventsPersistenceStorageController:
             state_delta_for_room = None
 
             if not backfilled:
-                with Measure(self._clock, "_calculate_state_and_extrem"):
+                with Measure(
+                    self._clock, self.metrics_manager, "_calculate_state_and_extrem"
+                ):
                     # Work out the new "current state" for the room.
                     # We do this by working out what the new extremities are and then
                     # calculating the state from that.
@@ -627,7 +630,11 @@ class EventsPersistenceStorageController:
                         room_id, chunk
                     )
 
-            with Measure(self._clock, "calculate_chain_cover_index_for_events"):
+            with Measure(
+                self._clock,
+                self.metrics_manager,
+                "calculate_chain_cover_index_for_events",
+            ):
                 # We now calculate chain ID/sequence numbers for any state events we're
                 # persisting. We ignore out of band memberships as we're not in the room
                 # and won't have their auth chain (we'll fix it up later if we join the
@@ -719,7 +726,11 @@ class EventsPersistenceStorageController:
                     break
 
         logger.debug("Calculating state delta for room %s", room_id)
-        with Measure(self._clock, "persist_events.get_new_state_after_events"):
+        with Measure(
+            self._clock,
+            self.metrics_manager,
+            "persist_events.get_new_state_after_events",
+        ):
             res = await self._get_new_state_after_events(
                 room_id,
                 ev_ctx_rm,
@@ -746,7 +757,11 @@ class EventsPersistenceStorageController:
             # removed keys entirely.
             delta = DeltaState([], delta_ids)
         elif current_state is not None:
-            with Measure(self._clock, "persist_events.calculate_state_delta"):
+            with Measure(
+                self._clock,
+                self.metrics_manager,
+                "persist_events.calculate_state_delta",
+            ):
                 delta = await self._calculate_state_delta(room_id, current_state)
 
         if delta:

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -70,7 +70,7 @@ class StateStorageController:
     def __init__(self, hs: "HomeServer", stores: "Databases"):
         self._is_mine_id = hs.is_mine_id
         self._clock = hs.get_clock()
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
         self.stores = stores
         self._partial_state_events_tracker = PartialStateEventsTracker(stores.main)
         self._partial_state_room_tracker = PartialCurrentStateTracker(stores.main)

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -70,6 +70,7 @@ class StateStorageController:
     def __init__(self, hs: "HomeServer", stores: "Databases"):
         self._is_mine_id = hs.is_mine_id
         self._clock = hs.get_clock()
+        self.metrics_manager = hs.metrics_manager
         self.stores = stores
         self._partial_state_events_tracker = PartialStateEventsTracker(stores.main)
         self._partial_state_room_tracker = PartialCurrentStateTracker(stores.main)
@@ -812,7 +813,7 @@ class StateStorageController:
             state_group = object()
 
         assert state_group is not None
-        with Measure(self._clock, "get_joined_hosts"):
+        with Measure(self._clock, self.metrics_manager, "get_joined_hosts"):
             return await self._get_joined_hosts(
                 room_id, state_group, state_entry=state_entry
             )

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -226,6 +226,7 @@ class EventsWorkerStore(SQLBaseStore):
         hs: "HomeServer",
     ):
         super().__init__(database, db_conn, hs)
+        self.metrics_manager = hs.metrics_manager
 
         self._stream_id_gen: MultiWriterIdGenerator
         self._backfill_id_gen: MultiWriterIdGenerator
@@ -1233,7 +1234,7 @@ class EventsWorkerStore(SQLBaseStore):
                 to event row. Note that it may well contain additional events that
                 were not part of this request.
         """
-        with Measure(self._clock, "_fetch_event_list"):
+        with Measure(self._clock, self.metrics_manager, "_fetch_event_list"):
             try:
                 events_to_fetch = {
                     event_id for events, _ in event_list for event_id in events

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -226,7 +226,7 @@ class EventsWorkerStore(SQLBaseStore):
         hs: "HomeServer",
     ):
         super().__init__(database, db_conn, hs)
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
 
         self._stream_id_gen: MultiWriterIdGenerator
         self._backfill_id_gen: MultiWriterIdGenerator

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -100,7 +100,7 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
         hs: "HomeServer",
     ):
         super().__init__(database, db_conn, hs)
-        self.metrics_manager = hs.metrics_manager
+        self.metrics_manager = hs.get_metrics_manager()
 
         self._server_notices_mxid = hs.config.servernotices.server_notices_mxid
 

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -100,6 +100,7 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
         hs: "HomeServer",
     ):
         super().__init__(database, db_conn, hs)
+        self.metrics_manager = hs.metrics_manager
 
         self._server_notices_mxid = hs.config.servernotices.server_notices_mxid
 
@@ -983,7 +984,9 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
         `_get_user_ids_from_membership_event_ids` for any uncached events.
         """
 
-        with Measure(self._clock, "get_joined_user_ids_from_state"):
+        with Measure(
+            self._clock, self.metrics_manager, "get_joined_user_ids_from_state"
+        ):
             users_in_room = set()
             member_event_ids = [
                 e_id for key, e_id in state.items() if key[0] == EventTypes.Member

--- a/synapse/util/metrics.py
+++ b/synapse/util/metrics.py
@@ -66,8 +66,9 @@ def measure_func(
 ) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
     """Decorate an async method with a `Measure` context manager.
 
-    The Measure is created using `self.clock`; it should only be used to decorate
-    methods in classes defining an instance-level `clock` and `metrics_manager` attribute.
+    The Measure is created using `self.clock` and `self.metrics_manager`; it should only
+    be used to decorate methods in classes defining an instance-level `clock` and
+    `metrics_manager` attribute.
 
     Usage:
 

--- a/synapse/util/metrics.py
+++ b/synapse/util/metrics.py
@@ -64,7 +64,7 @@ def measure_func(
     """Decorate an async method with a `Measure` context manager.
 
     The Measure is created using `self.clock`; it should only be used to decorate
-    methods in classes defining an instance-level `clock` attribute.
+    methods in classes defining an instance-level `clock` and `metrics_manager` attribute.
 
     Usage:
 
@@ -87,7 +87,7 @@ def measure_func(
 
         @wraps(func)
         async def measured_func(self: HasClock, *args: P.args, **kwargs: P.kwargs) -> R:
-            with Measure(self.clock, block_name):
+            with Measure(self.clock, self.metrics_manager, block_name):
                 r = await func(self, *args, **kwargs)
             return r
 
@@ -110,7 +110,10 @@ class Measure:
     ]
 
     def __init__(
-        self, clock: Clock, name: str, metrics_manager: HomeserverMetricsManager
+        self,
+        clock: Clock,
+        metrics_manager: HomeserverMetricsManager,
+        name: str,
     ) -> None:
         """
         Args:

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -84,14 +84,6 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
 
         # we mock out the federation client too
         self.mock_federation_client = AsyncMock(spec=["put_json"])
-        self.mock_federation_client.put_json.return_value = (200, "OK")
-        self.mock_federation_client.agent = MatrixFederationAgent(
-            reactor,
-            tls_client_options_factory=None,
-            user_agent=b"SynapseInTrialTest/0.0.0",
-            ip_allowlist=None,
-            ip_blocklist=IPSet(),
-        )
 
         # the tests assume that we are starting at unix time 1000
         reactor.pump((1000,))
@@ -102,6 +94,18 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
             federation_http_client=self.mock_federation_client,
             keyring=mock_keyring,
             replication_streams={},
+        )
+
+        # Finish off mocking the federation client
+        self.mock_federation_client.put_json.return_value = (200, "OK")
+        self.mock_federation_client.agent = MatrixFederationAgent(
+            reactor=reactor,
+            # After we get access to the `hs` homeserver instance, we can replace the federation agent
+            metrics_manager=hs.metrics_manager,
+            tls_client_options_factory=None,
+            user_agent=b"SynapseInTrialTest/0.0.0",
+            ip_allowlist=None,
+            ip_blocklist=IPSet(),
         )
 
         return hs

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -101,7 +101,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
         self.mock_federation_client.agent = MatrixFederationAgent(
             reactor=reactor,
             # After we get access to the `hs` homeserver instance, we can replace the federation agent
-            metrics_manager=hs.metrics_manager,
+            metrics_manager=hs.get_metrics_manager(),
             tls_client_options_factory=None,
             user_agent=b"SynapseInTrialTest/0.0.0",
             ip_allowlist=None,

--- a/tests/replication/test_federation_sender_shard.py
+++ b/tests/replication/test_federation_sender_shard.py
@@ -36,6 +36,7 @@ from synapse.crypto.event_signing import add_hashes_and_signatures
 from synapse.events import EventBase, make_event_from_dict
 from synapse.handlers.typing import TypingWriterHandler
 from synapse.http.federation.matrix_federation_agent import MatrixFederationAgent
+from synapse.metrics.homeserver_metrics_manager import HomeserverMetricsManager
 from synapse.rest.admin import register_servlets_for_client_rest_resource
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
@@ -69,6 +70,7 @@ class FederationSenderTestCase(BaseMultiWorkerStreamTestCase):
         reactor, _ = get_clock()
         self.matrix_federation_agent = MatrixFederationAgent(
             reactor,
+            metrics_manager=HomeserverMetricsManager(),
             tls_client_options_factory=None,
             user_agent=b"SynapseInTrialTest/0.0.0",
             ip_allowlist=None,

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -239,6 +239,7 @@ class StateTestCase(unittest.TestCase):
                 "get_auth",
                 "get_state_handler",
                 "get_clock",
+                "get_metrics_manager",
                 "get_state_resolution_handler",
                 "get_account_validity_handler",
                 "get_macaroon_generator",


### PR DESCRIPTION
Refactor `Measure` block metrics to be homeserver-scoped.

Spawning from https://github.com/element-hq/synapse/pull/18443

Part of https://github.com/element-hq/synapse/issues/18592


### Testing strategy

#### See behavior of previous `metrics` listener

 1. Add the `metrics` listener in your `homeserver.yaml`
    ```yaml
    listeners:
      - port: 9323
        type: metrics
        bind_addresses: ['127.0.0.1']
    ```
 1. Start the homeserver: `poetry run synapse_homeserver --config-path homeserver.yaml`
 1. Fetch `http://localhost:9323/metrics`
 1. Observe response includes the block metrics (`synapse_util_metrics_block_count`, `synapse_util_metrics_block_in_flight`, etc)


#### See behavior of the `http` `metrics` resource

 1. Add the `metrics` resource to a new or existing `http` listeners in your `homeserver.yaml`
    ```yaml
    listeners:
      - port: 9322
        type: http
        bind_addresses: ['127.0.0.1']
        resources:
          - names: [metrics]
            compress: false
    ```
 1. Start the homeserver: `poetry run synapse_homeserver --config-path homeserver.yaml`
 1. Fetch `http://localhost:9322/_synapse/metrics` (it's just a `GET` request so you can even do in the browser)
 1. Observe response includes the block metrics (`synapse_util_metrics_block_count`, `synapse_util_metrics_block_in_flight`, etc)


### Dev notes

`HomeserverMetricsManager`

### Todo

 - [x] Fix the usages of `Measure`

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
