### PR TITLE
Fix GET /_matrix/federation/v1/query/profile response

### DIFF
--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -539,11 +539,17 @@ class ProfileHandler:
         response: JsonDict = {}
         try:
             if just_field is None or just_field == ProfileFields.DISPLAYNAME:
-                response["displayname"] = await self.store.get_profile_displayname(user)
-
+                displayname = await self.store.get_profile_displayname(user)
+                # do not set the displayname field if it is None,
+                # since then we send a null in the JSON response
+                if displayname is not None:
+                    response["displayname"] = displayname
             if just_field is None or just_field == ProfileFields.AVATAR_URL:
-                response["avatar_url"] = await self.store.get_profile_avatar_url(user)
-
+                avatar_url = await self.store.get_profile_avatar_url(user)
+                # do not set the avatar_url field if it is None,
+                # since then we send a null in the JSON response
+                if avatar_url is not None:
+                    response["avatar_url"] = avatar_url
             if self.hs.config.experimental.msc4133_enabled:
                 if just_field is None:
                     response.update(await self.store.get_profile_fields(user))


### PR DESCRIPTION
Don't send the fields `avatar_url` and `displayname` when they are not defined for the queried user.

Before this change they would be sent and set to null in the JSON response object, which would violate the OpenAPI definitions
(c.f. https://spec.matrix.org/v1.11/server-server-api/#get_matrixfederationv1queryprofile).

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
