### PR TITLE
Refactor `Measure` block metrics to be homeserver-scoped (v2)

### DIFF
--- a/changelog.d/18601.misc
+++ b/changelog.d/18601.misc
@@ -1,0 +1,1 @@
+Refactor `Measure` block metrics to be homeserver-scoped.

--- a/synapse/federation/send_queue.py
+++ b/synapse/federation/send_queue.py
@@ -156,7 +156,9 @@ class FederationRemoteSendQueue(AbstractFederationSender):
 
     def _clear_queue_before_pos(self, position_to_delete: int) -> None:
         """Clear all the queues from before a given position"""
-        with Measure(self.clock, "send_queue._clear"):
+        with Measure(
+            self.clock, name="send_queue._clear", server_name=self.server_name
+        ):
             # Delete things out of presence maps
             keys = self.presence_destinations.keys()
             i = self.presence_destinations.bisect_left(position_to_delete)

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -657,7 +657,11 @@ class FederationSender(AbstractFederationSender):
                     logger.debug(
                         "Handling %i events in room %s", len(events), events[0].room_id
                     )
-                    with Measure(self.clock, "handle_room_events"):
+                    with Measure(
+                        self.clock,
+                        name="handle_room_events",
+                        server_name=self.server_name,
+                    ):
                         for event in events:
                             await handle_event(event)
 

--- a/synapse/federation/sender/transaction_manager.py
+++ b/synapse/federation/sender/transaction_manager.py
@@ -58,7 +58,7 @@ class TransactionManager:
     """
 
     def __init__(self, hs: "synapse.server.HomeServer"):
-        self._server_name = hs.hostname
+        self.server_name = hs.hostname  # nb must be called this for @measure_func
         self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self._store = hs.get_datastores().main
         self._transaction_actions = TransactionActions(self._store)
@@ -116,7 +116,7 @@ class TransactionManager:
             transaction = Transaction(
                 origin_server_ts=int(self.clock.time_msec()),
                 transaction_id=txn_id,
-                origin=self._server_name,
+                origin=self.server_name,
                 destination=destination,
                 pdus=[p.get_pdu_json() for p in pdus],
                 edus=[edu.get_dict() for edu in edus],

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -73,6 +73,7 @@ events_processed_counter = Counter("synapse_handlers_appservice_events_processed
 
 class ApplicationServicesHandler:
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
         self.store = hs.get_datastores().main
         self.is_mine_id = hs.is_mine_id
         self.appservice_api = hs.get_application_service_api()
@@ -120,7 +121,9 @@ class ApplicationServicesHandler:
 
     @wrap_as_background_process("notify_interested_services")
     async def _notify_interested_services(self, max_token: RoomStreamToken) -> None:
-        with Measure(self.clock, "notify_interested_services"):
+        with Measure(
+            self.clock, name="notify_interested_services", server_name=self.server_name
+        ):
             self.is_processing = True
             try:
                 upper_bound = -1
@@ -329,7 +332,11 @@ class ApplicationServicesHandler:
         users: Collection[Union[str, UserID]],
     ) -> None:
         logger.debug("Checking interested services for %s", stream_key)
-        with Measure(self.clock, "notify_interested_services_ephemeral"):
+        with Measure(
+            self.clock,
+            name="notify_interested_services_ephemeral",
+            server_name=self.server_name,
+        ):
             for service in services:
                 if stream_key == StreamKeyType.TYPING:
                     # Note that we don't persist the token (via set_appservice_stream_type_pos)

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -54,6 +54,7 @@ logger = logging.getLogger(__name__)
 
 class DelayedEventsHandler:
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
         self._store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self._config = hs.config
@@ -159,7 +160,9 @@ class DelayedEventsHandler:
 
         # Loop round handling deltas until we're up to date
         while True:
-            with Measure(self._clock, "delayed_events_delta"):
+            with Measure(
+                self._clock, name="delayed_events_delta", server_name=self.server_name
+            ):
                 room_max_stream_ordering = self._store.get_room_max_stream_ordering()
                 if self._event_pos == room_max_stream_ordering:
                     return

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -526,6 +526,8 @@ class DeviceHandler(DeviceWorkerHandler):
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
 
+        self.server_name = hs.hostname  # nb must be called this for @measure_func
+        self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self.federation_sender = hs.get_federation_sender()
         self._account_data_handler = hs.get_account_data_handler()
         self._storage_controllers = hs.get_storage_controllers()
@@ -1214,7 +1216,8 @@ class DeviceListUpdater(DeviceListWorkerUpdater):
     def __init__(self, hs: "HomeServer", device_handler: DeviceHandler):
         self.store = hs.get_datastores().main
         self.federation = hs.get_federation_client()
-        self.clock = hs.get_clock()
+        self.server_name = hs.hostname  # nb must be called this for @measure_func
+        self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self.device_handler = device_handler
         self._notifier = hs.get_notifier()
 

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -476,16 +476,16 @@ _DUMMY_EVENT_ROOM_EXCLUSION_EXPIRY = 7 * 24 * 60 * 60 * 1000
 class EventCreationHandler:
     def __init__(self, hs: "HomeServer"):
         self.hs = hs
+        self.server_name = hs.hostname  # nb must be called this for @measure_func
+        self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self.auth_blocking = hs.get_auth_blocking()
         self._event_auth_handler = hs.get_event_auth_handler()
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self.state = hs.get_state_handler()
-        self.clock = hs.get_clock()
         self.validator = EventValidator()
         self.profile_handler = hs.get_profile_handler()
         self.event_builder_factory = hs.get_event_builder_factory()
-        self.server_name = hs.hostname
         self.notifier = hs.get_notifier()
         self.config = hs.config
         self.require_membership_for_aliases = (

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -476,6 +476,8 @@ _DUMMY_EVENT_ROOM_EXCLUSION_EXPIRY = 7 * 24 * 60 * 60 * 1000
 class EventCreationHandler:
     def __init__(self, hs: "HomeServer"):
         self.hs = hs
+        self.validator = EventValidator()
+        self.event_builder_factory = hs.get_event_builder_factory()
         self.server_name = hs.hostname  # nb must be called this for @measure_func
         self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self.auth_blocking = hs.get_auth_blocking()
@@ -483,9 +485,7 @@ class EventCreationHandler:
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self.state = hs.get_state_handler()
-        self.validator = EventValidator()
         self.profile_handler = hs.get_profile_handler()
-        self.event_builder_factory = hs.get_event_builder_factory()
         self.notifier = hs.get_notifier()
         self.config = hs.config
         self.require_membership_for_aliases = (

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -747,6 +747,7 @@ class WorkerPresenceHandler(BasePresenceHandler):
 class PresenceHandler(BasePresenceHandler):
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
+        self.server_name = hs.hostname
         self.wheel_timer: WheelTimer[str] = WheelTimer()
         self.notifier = hs.get_notifier()
 
@@ -941,7 +942,9 @@ class PresenceHandler(BasePresenceHandler):
 
         now = self.clock.time_msec()
 
-        with Measure(self.clock, "presence_update_states"):
+        with Measure(
+            self.clock, name="presence_update_states", server_name=self.server_name
+        ):
             # NOTE: We purposefully don't await between now and when we've
             # calculated what we want to do with the new states, to avoid races.
 
@@ -1497,7 +1500,9 @@ class PresenceHandler(BasePresenceHandler):
     async def _unsafe_process(self) -> None:
         # Loop round handling deltas until we're up to date
         while True:
-            with Measure(self.clock, "presence_delta"):
+            with Measure(
+                self.clock, name="presence_delta", server_name=self.server_name
+            ):
                 room_max_stream_ordering = self.store.get_room_max_stream_ordering()
                 if self._event_pos == room_max_stream_ordering:
                     return
@@ -1759,6 +1764,7 @@ class PresenceEventSource(EventSource[int, UserPresenceState]):
         # Same with get_presence_router:
         #
         #   AuthHandler -> Notifier -> PresenceEventSource -> ModuleApi -> AuthHandler
+        self.server_name = hs.hostname
         self.get_presence_handler = hs.get_presence_handler
         self.get_presence_router = hs.get_presence_router
         self.clock = hs.get_clock()
@@ -1792,7 +1798,9 @@ class PresenceEventSource(EventSource[int, UserPresenceState]):
         user_id = user.to_string()
         stream_change_cache = self.store.presence_stream_cache
 
-        with Measure(self.clock, "presence.get_new_events"):
+        with Measure(
+            self.clock, name="presence.get_new_events", server_name=self.server_name
+        ):
             if from_key is not None:
                 from_key = int(from_key)
 

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -329,6 +329,7 @@ class E2eeSyncResult:
 
 class SyncHandler:
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
         self.hs_config = hs.config
         self.store = hs.get_datastores().main
         self.notifier = hs.get_notifier()
@@ -710,7 +711,9 @@ class SyncHandler:
 
         sync_config = sync_result_builder.sync_config
 
-        with Measure(self.clock, "ephemeral_by_room"):
+        with Measure(
+            self.clock, name="ephemeral_by_room", server_name=self.server_name
+        ):
             typing_key = since_token.typing_key if since_token else 0
 
             room_ids = sync_result_builder.joined_room_ids
@@ -783,7 +786,9 @@ class SyncHandler:
                 and current token to send down to clients.
             newly_joined_room
         """
-        with Measure(self.clock, "load_filtered_recents"):
+        with Measure(
+            self.clock, name="load_filtered_recents", server_name=self.server_name
+        ):
             timeline_limit = sync_config.filter_collection.timeline_limit()
             block_all_timeline = (
                 sync_config.filter_collection.blocks_all_room_timeline()
@@ -1174,7 +1179,9 @@ class SyncHandler:
         # updates even if they occurred logically before the previous event.
         # TODO(mjark) Check for new redactions in the state events.
 
-        with Measure(self.clock, "compute_state_delta"):
+        with Measure(
+            self.clock, name="compute_state_delta", server_name=self.server_name
+        ):
             # The memberships needed for events in the timeline.
             # Only calculated when `lazy_load_members` is on.
             members_to_fetch: Optional[Set[str]] = None
@@ -1791,7 +1798,9 @@ class SyncHandler:
             # the DB.
             return RoomNotifCounts.empty()
 
-        with Measure(self.clock, "unread_notifs_for_room_id"):
+        with Measure(
+            self.clock, name="unread_notifs_for_room_id", server_name=self.server_name
+        ):
             return await self.store.get_unread_event_push_actions_by_room_for_user(
                 room_id,
                 sync_config.user.to_string(),

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -503,6 +503,7 @@ class TypingWriterHandler(FollowerTypingHandler):
 
 class TypingNotificationEventSource(EventSource[int, JsonMapping]):
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
         self._main_store = hs.get_datastores().main
         self.clock = hs.get_clock()
         # We can't call get_typing_handler here because there's a cycle:
@@ -535,7 +536,9 @@ class TypingNotificationEventSource(EventSource[int, JsonMapping]):
                   appservice may be interested in.
                 * The latest known room serial.
         """
-        with Measure(self.clock, "typing.get_new_events_as"):
+        with Measure(
+            self.clock, name="typing.get_new_events_as", server_name=self.server_name
+        ):
             handler = self.get_typing_handler()
 
             events = []
@@ -571,7 +574,9 @@ class TypingNotificationEventSource(EventSource[int, JsonMapping]):
         Find typing notifications for given rooms (> `from_token` and <= `to_token`)
         """
 
-        with Measure(self.clock, "typing.get_new_events"):
+        with Measure(
+            self.clock, name="typing.get_new_events", server_name=self.server_name
+        ):
             from_key = int(from_key)
             handler = self.get_typing_handler()
 

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -237,7 +237,9 @@ class UserDirectoryHandler(StateDeltasHandler):
 
         # Loop round handling deltas until we're up to date
         while True:
-            with Measure(self.clock, "user_dir_delta"):
+            with Measure(
+                self.clock, name="user_dir_delta", server_name=self.server_name
+            ):
                 room_max_stream_ordering = self.store.get_room_max_stream_ordering()
                 if self.pos == room_max_stream_ordering:
                     return

--- a/synapse/http/federation/matrix_federation_agent.py
+++ b/synapse/http/federation/matrix_federation_agent.py
@@ -92,6 +92,7 @@ class MatrixFederationAgent:
 
     def __init__(
         self,
+        server_name: str,
         reactor: ISynapseReactor,
         tls_client_options_factory: Optional[FederationPolicyForHTTPS],
         user_agent: bytes,
@@ -100,6 +101,11 @@ class MatrixFederationAgent:
         _srv_resolver: Optional[SrvResolver] = None,
         _well_known_resolver: Optional[WellKnownResolver] = None,
     ):
+        """
+        Args:
+            server_name: Our homeserver name (used to label metrics) (`hs.hostname`).
+        """
+
         # proxy_reactor is not blocklisting reactor
         proxy_reactor = reactor
 
@@ -127,6 +133,7 @@ class MatrixFederationAgent:
 
         if _well_known_resolver is None:
             _well_known_resolver = WellKnownResolver(
+                server_name,
                 reactor,
                 agent=BlocklistingAgentWrapper(
                     ProxyAgent(

--- a/synapse/http/federation/well_known_resolver.py
+++ b/synapse/http/federation/well_known_resolver.py
@@ -91,12 +91,19 @@ class WellKnownResolver:
 
     def __init__(
         self,
+        server_name: str,
         reactor: IReactorTime,
         agent: IAgent,
         user_agent: bytes,
         well_known_cache: Optional[TTLCache[bytes, Optional[bytes]]] = None,
         had_well_known_cache: Optional[TTLCache[bytes, bool]] = None,
     ):
+        """
+        Args:
+            server_name: Our homeserver name (used to label metrics) (`hs.hostname`).
+        """
+
+        self.server_name = server_name
         self._reactor = reactor
         self._clock = Clock(reactor)
 
@@ -135,7 +142,11 @@ class WellKnownResolver:
         # requests for the same server in parallel?
         try:
             with Measure(
-                self._clock, name="get_well_known", server_name=self.server_name
+                self._clock,
+                name="get_well_known",
+                # This should be our homeserver where the the code is running (used to
+                # label metrics)
+                server_name=self.server_name,
             ):
                 result: Optional[bytes]
                 cache_period: float

--- a/synapse/http/federation/well_known_resolver.py
+++ b/synapse/http/federation/well_known_resolver.py
@@ -134,7 +134,9 @@ class WellKnownResolver:
         # TODO: should we linearise so that we don't end up doing two .well-known
         # requests for the same server in parallel?
         try:
-            with Measure(self._clock, "get_well_known"):
+            with Measure(
+                self._clock, name="get_well_known", server_name=self.server_name
+            ):
                 result: Optional[bytes]
                 cache_period: float
 

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -697,7 +697,11 @@ class MatrixFederationHttpClient:
                     outgoing_requests_counter.labels(request.method).inc()
 
                     try:
-                        with Measure(self.clock, "outbound_request"):
+                        with Measure(
+                            self.clock,
+                            name="outbound_request",
+                            server_name=self.server_name,
+                        ):
                             # we don't want all the fancy cookie and redirect handling
                             # that treq.request gives: just use the raw Agent.
 

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -417,6 +417,7 @@ class MatrixFederationHttpClient:
         if hs.get_instance_name() in outbound_federation_restricted_to:
             # Talk to federation directly
             federation_agent: IAgent = MatrixFederationAgent(
+                self.server_name,
                 self.reactor,
                 tls_client_options_factory,
                 user_agent.encode("ascii"),

--- a/synapse/module_api/callbacks/ratelimit_callbacks.py
+++ b/synapse/module_api/callbacks/ratelimit_callbacks.py
@@ -43,6 +43,7 @@ GET_RATELIMIT_OVERRIDE_FOR_USER_CALLBACK = Callable[
 
 class RatelimitModuleApiCallbacks:
     def __init__(self, hs: "HomeServer") -> None:
+        self.server_name = hs.hostname
         self.clock = hs.get_clock()
         self._get_ratelimit_override_for_user_callbacks: List[
             GET_RATELIMIT_OVERRIDE_FOR_USER_CALLBACK
@@ -64,7 +65,11 @@ class RatelimitModuleApiCallbacks:
         self, user_id: str, limiter_name: str
     ) -> Optional[RatelimitOverride]:
         for callback in self._get_ratelimit_override_for_user_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 res: Optional[RatelimitOverride] = await delay_cancellation(
                     callback(user_id, limiter_name)
                 )

--- a/synapse/module_api/callbacks/spamchecker_callbacks.py
+++ b/synapse/module_api/callbacks/spamchecker_callbacks.py
@@ -356,6 +356,7 @@ class SpamCheckerModuleApiCallbacks:
     NOT_SPAM: Literal["NOT_SPAM"] = "NOT_SPAM"
 
     def __init__(self, hs: "synapse.server.HomeServer") -> None:
+        self.server_name = hs.hostname
         self.clock = hs.get_clock()
 
         self._check_event_for_spam_callbacks: List[CHECK_EVENT_FOR_SPAM_CALLBACK] = []
@@ -490,7 +491,11 @@ class SpamCheckerModuleApiCallbacks:
                 generally discouraged as it doesn't support internationalization.
         """
         for callback in self._check_event_for_spam_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 res = await delay_cancellation(callback(event))
                 if res is False or res == self.NOT_SPAM:
                     # This spam-checker accepts the event.
@@ -543,7 +548,11 @@ class SpamCheckerModuleApiCallbacks:
             True if the event should be silently dropped
         """
         for callback in self._should_drop_federated_event_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 res: Union[bool, str] = await delay_cancellation(callback(event))
             if res:
                 return res
@@ -565,7 +574,11 @@ class SpamCheckerModuleApiCallbacks:
             NOT_SPAM if the operation is permitted, [Codes, Dict] otherwise.
         """
         for callback in self._user_may_join_room_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 res = await delay_cancellation(callback(user_id, room_id, is_invited))
                 # Normalize return values to `Codes` or `"NOT_SPAM"`.
                 if res is True or res is self.NOT_SPAM:
@@ -604,7 +617,11 @@ class SpamCheckerModuleApiCallbacks:
             NOT_SPAM if the operation is permitted, Codes otherwise.
         """
         for callback in self._user_may_invite_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 res = await delay_cancellation(
                     callback(inviter_userid, invitee_userid, room_id)
                 )
@@ -643,7 +660,11 @@ class SpamCheckerModuleApiCallbacks:
             NOT_SPAM if the operation is permitted, Codes otherwise.
         """
         for callback in self._federated_user_may_invite_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 res = await delay_cancellation(callback(event))
                 # Normalize return values to `Codes` or `"NOT_SPAM"`.
                 if res is True or res is self.NOT_SPAM:
@@ -686,7 +707,11 @@ class SpamCheckerModuleApiCallbacks:
             NOT_SPAM if the operation is permitted, Codes otherwise.
         """
         for callback in self._user_may_send_3pid_invite_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 res = await delay_cancellation(
                     callback(inviter_userid, medium, address, room_id)
                 )
@@ -722,7 +747,11 @@ class SpamCheckerModuleApiCallbacks:
             room_config: The room creation configuration which is the body of the /createRoom request
         """
         for callback in self._user_may_create_room_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 checker_args = inspect.signature(callback)
                 # Also ensure backwards compatibility with spam checker callbacks
                 # that don't expect the room_config argument.
@@ -786,7 +815,11 @@ class SpamCheckerModuleApiCallbacks:
             content: The content of the state event
         """
         for callback in self._user_may_send_state_event_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 # We make a copy of the content to ensure that the spam checker cannot modify it.
                 res = await delay_cancellation(
                     callback(user_id, room_id, event_type, state_key, deepcopy(content))
@@ -814,7 +847,11 @@ class SpamCheckerModuleApiCallbacks:
 
         """
         for callback in self._user_may_create_room_alias_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 res = await delay_cancellation(callback(userid, room_alias))
                 if res is True or res is self.NOT_SPAM:
                     continue
@@ -847,7 +884,11 @@ class SpamCheckerModuleApiCallbacks:
             room_id: The ID of the room that would be published
         """
         for callback in self._user_may_publish_room_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 res = await delay_cancellation(callback(userid, room_id))
                 if res is True or res is self.NOT_SPAM:
                     continue
@@ -889,7 +930,11 @@ class SpamCheckerModuleApiCallbacks:
             True if the user is spammy.
         """
         for callback in self._check_username_for_spam_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 checker_args = inspect.signature(callback)
                 # Make a copy of the user profile object to ensure the spam checker cannot
                 # modify it.
@@ -938,7 +983,11 @@ class SpamCheckerModuleApiCallbacks:
         """
 
         for callback in self._check_registration_for_spam_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 behaviour = await delay_cancellation(
                     callback(email_threepid, username, request_info, auth_provider_id)
                 )
@@ -980,7 +1029,11 @@ class SpamCheckerModuleApiCallbacks:
         """
 
         for callback in self._check_media_file_for_spam_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 res = await delay_cancellation(callback(file_wrapper, file_info))
                 # Normalize return values to `Codes` or `"NOT_SPAM"`.
                 if res is False or res is self.NOT_SPAM:
@@ -1027,7 +1080,11 @@ class SpamCheckerModuleApiCallbacks:
         """
 
         for callback in self._check_login_for_spam_callbacks:
-            with Measure(self.clock, f"{callback.__module__}.{callback.__qualname__}"):
+            with Measure(
+                self.clock,
+                name=f"{callback.__module__}.{callback.__qualname__}",
+                server_name=self.server_name,
+            ):
                 res = await delay_cancellation(
                     callback(
                         user_id,

--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -129,7 +129,8 @@ class BulkPushRuleEvaluator:
     def __init__(self, hs: "HomeServer"):
         self.hs = hs
         self.store = hs.get_datastores().main
-        self.clock = hs.get_clock()
+        self.server_name = hs.hostname  # nb must be called this for @measure_func
+        self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self._event_auth_handler = hs.get_event_auth_handler()
         self.should_calculate_push_rules = self.hs.config.push.enable_push
 

--- a/synapse/replication/http/federation.py
+++ b/synapse/replication/http/federation.py
@@ -76,6 +76,7 @@ class ReplicationFederationSendEventsRestServlet(ReplicationEndpoint):
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
 
+        self.server_name = hs.hostname
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self.clock = hs.get_clock()
@@ -122,7 +123,9 @@ class ReplicationFederationSendEventsRestServlet(ReplicationEndpoint):
     async def _handle_request(  # type: ignore[override]
         self, request: Request, content: JsonDict
     ) -> Tuple[int, JsonDict]:
-        with Measure(self.clock, "repl_fed_send_events_parse"):
+        with Measure(
+            self.clock, name="repl_fed_send_events_parse", server_name=self.server_name
+        ):
             room_id = content["room_id"]
             backfilled = content["backfilled"]
 

--- a/synapse/replication/http/send_event.py
+++ b/synapse/replication/http/send_event.py
@@ -76,6 +76,7 @@ class ReplicationSendEventRestServlet(ReplicationEndpoint):
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
 
+        self.server_name = hs.hostname
         self.event_creation_handler = hs.get_event_creation_handler()
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
@@ -121,7 +122,9 @@ class ReplicationSendEventRestServlet(ReplicationEndpoint):
     async def _handle_request(  # type: ignore[override]
         self, request: Request, content: JsonDict, event_id: str
     ) -> Tuple[int, JsonDict]:
-        with Measure(self.clock, "repl_send_event_parse"):
+        with Measure(
+            self.clock, name="repl_send_event_parse", server_name=self.server_name
+        ):
             event_dict = content["event"]
             room_ver = KNOWN_ROOM_VERSIONS[content["room_version"]]
             internal_metadata = content["internal_metadata"]

--- a/synapse/replication/http/send_events.py
+++ b/synapse/replication/http/send_events.py
@@ -77,6 +77,7 @@ class ReplicationSendEventsRestServlet(ReplicationEndpoint):
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
 
+        self.server_name = hs.hostname
         self.event_creation_handler = hs.get_event_creation_handler()
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
@@ -122,7 +123,9 @@ class ReplicationSendEventsRestServlet(ReplicationEndpoint):
     async def _handle_request(  # type: ignore[override]
         self, request: Request, payload: JsonDict
     ) -> Tuple[int, JsonDict]:
-        with Measure(self.clock, "repl_send_events_parse"):
+        with Measure(
+            self.clock, name="repl_send_events_parse", server_name=self.server_name
+        ):
             events_and_context = []
             events = payload["events"]
             rooms = set()

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -75,6 +75,7 @@ class ReplicationDataHandler:
     """
 
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
         self.store = hs.get_datastores().main
         self.notifier = hs.get_notifier()
         self._reactor = hs.get_reactor()
@@ -342,7 +343,11 @@ class ReplicationDataHandler:
         waiting_list.add((position, deferred))
 
         # We measure here to get in flight counts and average waiting time.
-        with Measure(self._clock, "repl.wait_for_stream_position"):
+        with Measure(
+            self._clock,
+            name="repl.wait_for_stream_position",
+            server_name=self.server_name,
+        ):
             logger.info(
                 "Waiting for repl stream %r to reach %s (%s); currently at: %s",
                 stream_name,

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -78,6 +78,7 @@ class ReplicationStreamer:
     """
 
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
         self.store = hs.get_datastores().main
         self.clock = hs.get_clock()
         self.notifier = hs.get_notifier()
@@ -155,7 +156,11 @@ class ReplicationStreamer:
             while self.pending_updates:
                 self.pending_updates = False
 
-                with Measure(self.clock, "repl.stream.get_updates"):
+                with Measure(
+                    self.clock,
+                    name="repl.stream.get_updates",
+                    server_name=self.server_name,
+                ):
                     all_streams = self.streams
 
                     if self._replication_torture_level is not None:

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -189,7 +189,8 @@ class StateHandler:
     """
 
     def __init__(self, hs: "HomeServer"):
-        self.clock = hs.get_clock()
+        self.server_name = hs.hostname  # nb must be called this for @measure_func
+        self.clock = hs.get_clock()  # nb must be called this for @measure_func
         self.store = hs.get_datastores().main
         self._state_storage_controller = hs.get_storage_controllers().state
         self.hs = hs

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -631,6 +631,7 @@ class StateResolutionHandler:
     """
 
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
         self.clock = hs.get_clock()
 
         self.resolve_linearizer = Linearizer(name="state_resolve_lock")
@@ -747,7 +748,9 @@ class StateResolutionHandler:
             # which will be used as a cache key for future resolutions, but
             # not get persisted.
 
-            with Measure(self.clock, "state.create_group_ids"):
+            with Measure(
+                self.clock, name="state.create_group_ids", server_name=self.server_name
+            ):
                 cache = _make_state_cache_entry(new_state, state_groups_ids)
 
             self._state_cache[group_names] = cache
@@ -785,7 +788,9 @@ class StateResolutionHandler:
             a map from (type, state_key) to event_id.
         """
         try:
-            with Measure(self.clock, "state._resolve_events") as m:
+            with Measure(
+                self.clock, name="state._resolve_events", server_name=self.server_name
+            ) as m:
                 room_version_obj = KNOWN_ROOM_VERSIONS[room_version]
                 if room_version_obj.state_res == StateResolutionVersions.V1:
                     return await v1.resolve_events_with_store(

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -55,6 +55,7 @@ class SQLBaseStore(metaclass=ABCMeta):
         hs: "HomeServer",
     ):
         self.hs = hs
+        self.server_name = hs.hostname
         self._clock = hs.get_clock()
         self.database_engine = database.engine
         self.db_pool = database

--- a/synapse/storage/controllers/persist_events.py
+++ b/synapse/storage/controllers/persist_events.py
@@ -337,6 +337,7 @@ class EventsPersistenceStorageController:
         assert stores.persist_events
         self.persist_events_store = stores.persist_events
 
+        self.server_name = hs.hostname
         self._clock = hs.get_clock()
         self._instance_name = hs.get_instance_name()
         self.is_mine_id = hs.is_mine_id
@@ -616,7 +617,11 @@ class EventsPersistenceStorageController:
             state_delta_for_room = None
 
             if not backfilled:
-                with Measure(self._clock, "_calculate_state_and_extrem"):
+                with Measure(
+                    self._clock,
+                    name="_calculate_state_and_extrem",
+                    server_name=self.server_name,
+                ):
                     # Work out the new "current state" for the room.
                     # We do this by working out what the new extremities are and then
                     # calculating the state from that.
@@ -627,7 +632,11 @@ class EventsPersistenceStorageController:
                         room_id, chunk
                     )
 
-            with Measure(self._clock, "calculate_chain_cover_index_for_events"):
+            with Measure(
+                self._clock,
+                name="calculate_chain_cover_index_for_events",
+                server_name=self.server_name,
+            ):
                 # We now calculate chain ID/sequence numbers for any state events we're
                 # persisting. We ignore out of band memberships as we're not in the room
                 # and won't have their auth chain (we'll fix it up later if we join the
@@ -719,7 +728,11 @@ class EventsPersistenceStorageController:
                     break
 
         logger.debug("Calculating state delta for room %s", room_id)
-        with Measure(self._clock, "persist_events.get_new_state_after_events"):
+        with Measure(
+            self._clock,
+            name="persist_events.get_new_state_after_events",
+            server_name=self.server_name,
+        ):
             res = await self._get_new_state_after_events(
                 room_id,
                 ev_ctx_rm,
@@ -746,7 +759,11 @@ class EventsPersistenceStorageController:
             # removed keys entirely.
             delta = DeltaState([], delta_ids)
         elif current_state is not None:
-            with Measure(self._clock, "persist_events.calculate_state_delta"):
+            with Measure(
+                self._clock,
+                name="persist_events.calculate_state_delta",
+                server_name=self.server_name,
+            ):
                 delta = await self._calculate_state_delta(room_id, current_state)
 
         if delta:

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -68,6 +68,7 @@ class StateStorageController:
     """
 
     def __init__(self, hs: "HomeServer", stores: "Databases"):
+        self.server_name = hs.hostname
         self._is_mine_id = hs.is_mine_id
         self._clock = hs.get_clock()
         self.stores = stores
@@ -812,7 +813,9 @@ class StateStorageController:
             state_group = object()
 
         assert state_group is not None
-        with Measure(self._clock, "get_joined_hosts"):
+        with Measure(
+            self._clock, name="get_joined_hosts", server_name=self.server_name
+        ):
             return await self._get_joined_hosts(
                 room_id, state_group, state_entry=state_entry
             )

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -1233,7 +1233,9 @@ class EventsWorkerStore(SQLBaseStore):
                 to event row. Note that it may well contain additional events that
                 were not part of this request.
         """
-        with Measure(self._clock, "_fetch_event_list"):
+        with Measure(
+            self._clock, name="_fetch_event_list", server_name=self.server_name
+        ):
             try:
                 events_to_fetch = {
                     event_id for events, _ in event_list for event_id in events

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -983,7 +983,11 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
         `_get_user_ids_from_membership_event_ids` for any uncached events.
         """
 
-        with Measure(self._clock, "get_joined_user_ids_from_state"):
+        with Measure(
+            self._clock,
+            name="get_joined_user_ids_from_state",
+            server_name=self.server_name,
+        ):
             users_in_room = set()
             member_event_ids = [
                 e_id for key, e_id in state.items() if key[0] == EventTypes.Member

--- a/synapse/util/metrics.py
+++ b/synapse/util/metrics.py
@@ -251,29 +251,16 @@ class Measure:
         self._logging_context.__exit__(exc_type, exc_val, exc_tb)
 
         try:
-            block_counter.labels(
-                block_name=self.name, INSTANCE_LABEL_NAME=self.server_name
-            ).inc()
-            block_timer.labels(
-                block_name=self.name, INSTANCE_LABEL_NAME=self.server_name
-            ).inc(duration)
-            block_ru_utime.labels(
-                block_name=self.name, INSTANCE_LABEL_NAME=self.server_name
-            ).inc(usage.ru_utime)
-            block_ru_stime.labels(
-                block_name=self.name, INSTANCE_LABEL_NAME=self.server_name
-            ).inc(usage.ru_stime)
-            block_db_txn_count.labels(
-                block_name=self.name, INSTANCE_LABEL_NAME=self.server_name
-            ).inc(usage.db_txn_count)
-            block_db_txn_duration.labels(
-                block_name=self.name, INSTANCE_LABEL_NAME=self.server_name
-            ).inc(usage.db_txn_duration_sec)
-            block_db_sched_duration.labels(
-                block_name=self.name, INSTANCE_LABEL_NAME=self.server_name
-            ).inc(usage.db_sched_duration_sec)
-        except ValueError:
-            logger.warning("Failed to save metrics! Usage: %s", usage)
+            labels = {"block_name": self.name, INSTANCE_LABEL_NAME: self.server_name}
+            block_counter.labels(**labels).inc()
+            block_timer.labels(**labels).inc(duration)
+            block_ru_utime.labels(**labels).inc(usage.ru_utime)
+            block_ru_stime.labels(**labels).inc(usage.ru_stime)
+            block_db_txn_count.labels(**labels).inc(usage.db_txn_count)
+            block_db_txn_duration.labels(**labels).inc(usage.db_txn_duration_sec)
+            block_db_sched_duration.labels(**labels).inc(usage.db_sched_duration_sec)
+        except ValueError as exc:
+            logger.warning("Failed to save metrics! Usage: %s Error: %s", usage, exc)
 
     def get_resource_usage(self) -> ContextResourceUsage:
         """Get the resources used within this Measure block

--- a/synapse/util/metrics.py
+++ b/synapse/util/metrics.py
@@ -46,6 +46,8 @@ from synapse.util import Clock
 
 logger = logging.getLogger(__name__)
 
+# Metrics to see the number of and how much time is spend in various blocks of code.
+#
 block_counter = Counter(
     "synapse_util_metrics_block_count",
     "",

--- a/synapse/util/metrics.py
+++ b/synapse/util/metrics.py
@@ -92,16 +92,23 @@ block_db_sched_duration = Counter(
 
 
 # This is dynamically created in InFlightGauge.__init__.
-class _InFlightMetric(Protocol):
+class _BlockInFlightMetric(Protocol):
+    """
+    Sub-metrics used for the `InFlightGauge` for blocks.
+    """
+
     real_time_max: float
+    """The longest observed duration of any single execution of this block, in seconds."""
     real_time_sum: float
+    """The cumulative time spent executing this block across all calls, in seconds."""
 
 
 # Tracks the number of blocks currently active
-in_flight: InFlightGauge[_InFlightMetric] = InFlightGauge(
+in_flight: InFlightGauge[_BlockInFlightMetric] = InFlightGauge(
     "synapse_util_metrics_block_in_flight",
     "",
     labels=["block_name", INSTANCE_LABEL_NAME],
+    # Matches the fields in the `_BlockInFlightMetric`
     sub_metrics=["real_time_max", "real_time_sum"],
 )
 
@@ -266,7 +273,7 @@ class Measure:
         """
         return self._logging_context.get_resource_usage()
 
-    def _update_in_flight(self, metrics: _InFlightMetric) -> None:
+    def _update_in_flight(self, metrics: _BlockInFlightMetric) -> None:
         """Gets called when processing in flight metrics"""
         assert self.start is not None
         duration = self.clock.time() - self.start

--- a/synapse/util/metrics.py
+++ b/synapse/util/metrics.py
@@ -51,30 +51,35 @@ block_counter = Counter(
     "",
     labelnames=["block_name", INSTANCE_LABEL_NAME],
 )
+"""The number of times this block has been called."""
 
 block_timer = Counter(
     "synapse_util_metrics_block_time_seconds",
     "",
     labelnames=["block_name", INSTANCE_LABEL_NAME],
 )
+"""The cumulative time spent executing this block across all calls, in seconds."""
 
 block_ru_utime = Counter(
     "synapse_util_metrics_block_ru_utime_seconds",
     "",
     labelnames=["block_name", INSTANCE_LABEL_NAME],
 )
+"""Resource usage: user CPU time in seconds used in this block"""
 
 block_ru_stime = Counter(
     "synapse_util_metrics_block_ru_stime_seconds",
     "",
     labelnames=["block_name", INSTANCE_LABEL_NAME],
 )
+"""Resource usage: system CPU time in seconds used in this block"""
 
 block_db_txn_count = Counter(
     "synapse_util_metrics_block_db_txn_count",
     "",
     labelnames=["block_name", INSTANCE_LABEL_NAME],
 )
+"""Number of database transactions completed in this block"""
 
 # seconds spent waiting for db txns, excluding scheduling time, in this block
 block_db_txn_duration = Counter(
@@ -82,6 +87,7 @@ block_db_txn_duration = Counter(
     "",
     labelnames=["block_name", INSTANCE_LABEL_NAME],
 )
+"""Seconds spent waiting for database txns, excluding scheduling time, in this block"""
 
 # seconds spent waiting for a db connection, in this block
 block_db_sched_duration = Counter(
@@ -89,6 +95,7 @@ block_db_sched_duration = Counter(
     "",
     labelnames=["block_name", INSTANCE_LABEL_NAME],
 )
+"""Seconds spent waiting for a db connection, in this block"""
 
 
 # This is dynamically created in InFlightGauge.__init__.

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -86,6 +86,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
         self.mock_federation_client = AsyncMock(spec=["put_json"])
         self.mock_federation_client.put_json.return_value = (200, "OK")
         self.mock_federation_client.agent = MatrixFederationAgent(
+            "OUR_STUB_HOMESERVER_NAME",
             reactor,
             tls_client_options_factory=None,
             user_agent=b"SynapseInTrialTest/0.0.0",

--- a/tests/http/federation/test_matrix_federation_agent.py
+++ b/tests/http/federation/test_matrix_federation_agent.py
@@ -91,6 +91,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
             "test_cache", timer=self.reactor.seconds
         )
         self.well_known_resolver = WellKnownResolver(
+            "OUR_STUB_HOMESERVER_NAME",
             self.reactor,
             Agent(self.reactor, contextFactory=self.tls_factory),
             b"test-agent",
@@ -269,6 +270,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
         because it is created too early during setUp
         """
         return MatrixFederationAgent(
+            "OUR_STUB_HOMESERVER_NAME",
             reactor=cast(ISynapseReactor, self.reactor),
             tls_client_options_factory=self.tls_factory,
             user_agent=b"test-agent",  # Note that this is unused since _well_known_resolver is provided.
@@ -1011,6 +1013,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # Build a new agent and WellKnownResolver with a different tls factory
         tls_factory = FederationPolicyForHTTPS(config)
         agent = MatrixFederationAgent(
+            "OUR_STUB_HOMESERVER_NAME",
             reactor=self.reactor,
             tls_client_options_factory=tls_factory,
             user_agent=b"test-agent",  # This is unused since _well_known_resolver is passed below.
@@ -1018,6 +1021,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
             ip_blocklist=IPSet(),
             _srv_resolver=self.mock_resolver,
             _well_known_resolver=WellKnownResolver(
+                "OUR_STUB_HOMESERVER_NAME",
                 cast(ISynapseReactor, self.reactor),
                 Agent(self.reactor, contextFactory=tls_factory),
                 b"test-agent",

--- a/tests/replication/test_federation_sender_shard.py
+++ b/tests/replication/test_federation_sender_shard.py
@@ -68,6 +68,7 @@ class FederationSenderTestCase(BaseMultiWorkerStreamTestCase):
 
         reactor, _ = get_clock()
         self.matrix_federation_agent = MatrixFederationAgent(
+            "OUR_STUB_HOMESERVER_NAME",
             reactor,
             tls_client_options_factory=None,
             user_agent=b"SynapseInTrialTest/0.0.0",


### PR DESCRIPTION
Refactor `Measure` block metrics to be homeserver-scoped

Part of https://github.com/element-hq/synapse/issues/18592

This is an alternative PR to https://github.com/element-hq/synapse/pull/18591 (used homeserver-scoped `CollectorRegistry`) vs this PR which adds `instance` labels to the metrics. See https://github.com/element-hq/synapse/issues/18592 for more context. 


### Testing strategy

#### See behavior of previous `metrics` listener

 1. Add the `metrics` listener in your `homeserver.yaml`
    ```yaml
    listeners:
      - port: 9323
        type: metrics
        bind_addresses: ['127.0.0.1']
    ```
 1. Start the homeserver: `poetry run synapse_homeserver --config-path homeserver.yaml`
 1. Fetch `http://localhost:9323/metrics`
 1. Observe response includes the block metrics (`synapse_util_metrics_block_count`, `synapse_util_metrics_block_in_flight`, etc)


#### See behavior of the `http` `metrics` resource

 1. Add the `metrics` resource to a new or existing `http` listeners in your `homeserver.yaml`
    ```yaml
    listeners:
      - port: 9322
        type: http
        bind_addresses: ['127.0.0.1']
        resources:
          - names: [metrics]
            compress: false
    ```
 1. Start the homeserver: `poetry run synapse_homeserver --config-path homeserver.yaml`
 1. Fetch `http://localhost:9322/_synapse/metrics` (it's just a `GET` request so you can even do in the browser)
 1. Observe response includes the block metrics (`synapse_util_metrics_block_count`, `synapse_util_metrics_block_in_flight`, etc):  [example](https://gist.github.com/MadLittleMods/6a1319ac3aefb76ef95856af5af3bba2), [example from `develop`](https://gist.github.com/MadLittleMods/d28a06377600cdb6d26d21c7b8fd690e)

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
