### PR TITLE
Track local users from deleted rooms and send synthentic leaves after room purge

### DIFF
--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -27,6 +27,7 @@ from typing import (
     Any,
     Dict,
     FrozenSet,
+    Iterable,
     List,
     Literal,
     Mapping,
@@ -51,8 +52,8 @@ from synapse.api.constants import (
 )
 from synapse.api.filtering import FilterCollection
 from synapse.api.presence import UserPresenceState
-from synapse.api.room_versions import KNOWN_ROOM_VERSIONS
-from synapse.events import EventBase
+from synapse.api.room_versions import KNOWN_ROOM_VERSIONS, RoomVersions
+from synapse.events import EventBase, FrozenEventV3
 from synapse.handlers.relations import BundledAggregations
 from synapse.logging import issue9533_logger
 from synapse.logging.context import current_context
@@ -235,7 +236,7 @@ class _RoomChanges:
     invited: List[InvitedSyncResult]
     knocked: List[KnockedSyncResult]
     newly_joined_rooms: List[str]
-    newly_left_rooms: List[str]
+    newly_left_rooms: set[str]
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
@@ -1829,7 +1830,7 @@ class SyncHandler:
             full_state,
         )
 
-        logger.debug(
+        logger.info(
             "Calculating sync response for %r between %s and %s",
             sync_config.user,
             sync_result_builder.since_token,
@@ -2386,6 +2387,7 @@ class SyncHandler:
 
         since_token = sync_result_builder.since_token
         user_id = sync_result_builder.sync_config.user.to_string()
+        logger.info("Generating _generate_sync_entry_for_rooms for %s %s", user_id, since_token)
 
         blocks_all_rooms = (
             sync_result_builder.sync_config.filter_collection.blocks_all_rooms()
@@ -2427,19 +2429,20 @@ class SyncHandler:
         # no point in going further.
         if not sync_result_builder.full_state:
             if since_token and not ephemeral_by_room and not account_data_by_room:
-                have_changed = await self._have_rooms_changed(sync_result_builder)
+                have_changed = await self._have_rooms_changed(sync_result_builder, user_id)
                 log_kv({"rooms_have_changed": have_changed})
                 if not have_changed:
                     tags_by_room = await self.store.get_updated_tags(
                         user_id, since_token.account_data_key
                     )
                     if not tags_by_room:
-                        logger.debug("no-oping sync")
+                        logger.info("no-oping sync")
                         return set(), set()
 
         # 3. Work out which rooms need reporting in the sync response.
         ignored_users = await self.store.ignored_users(user_id)
         if since_token:
+            logger.info("With since_token %s %s", user_id, since_token)
             room_changes = await self._get_room_changes_for_incremental_sync(
                 sync_result_builder, ignored_users
             )
@@ -2481,10 +2484,10 @@ class SyncHandler:
         sync_result_builder.invited.extend(invited)
         sync_result_builder.knocked.extend(knocked)
 
-        return set(newly_joined_rooms), set(newly_left_rooms)
+        return set(newly_joined_rooms), newly_left_rooms
 
     async def _have_rooms_changed(
-        self, sync_result_builder: "SyncResultBuilder"
+        self, sync_result_builder: "SyncResultBuilder", user_id: str
     ) -> bool:
         """Returns whether there may be any new events that should be sent down
         the sync. Returns True if there are.
@@ -2497,6 +2500,10 @@ class SyncHandler:
         assert since_token
 
         if membership_change_events or sync_result_builder.forced_newly_joined_room_ids:
+            return True
+
+        # TODO: Hack to check if we have any deleted rooms
+        if len(await self.store.get_deleted_rooms_for_user(user_id, since_token.room_key.stream)):
             return True
 
         stream_id = since_token.room_key.stream
@@ -2536,6 +2543,7 @@ class SyncHandler:
         now_token = sync_result_builder.now_token
         sync_config = sync_result_builder.sync_config
         membership_change_events = sync_result_builder.membership_change_events
+        logger.info("Generating _get_room_changes_for_incremental_sync for %s", user_id)
 
         assert since_token
 
@@ -2756,6 +2764,46 @@ class SyncHandler:
                 )
 
             room_entries.append(entry)
+
+        deleted_left_rooms = await self.store.get_deleted_rooms_for_user(user_id, since_token.room_key.stream)
+
+        for room_id, deleted_stream_id in deleted_left_rooms:
+            if room_id in newly_left_rooms:
+                continue
+            logger.info("Generating synthetic leave for %s in %s as room was deleted.", user_id, room_id)
+            # Synthetic leaves for deleted rooms
+            leave_evt = FrozenEventV3({
+                    "state_key": user_id,
+                    "sender": "@server:patroclus",
+                    "room_id": room_id,
+                    "type": "m.room.member",
+                    "depth": 1,
+                    "content": {
+                        "membership": "leave",
+                        "reason": "Room has been deleted"
+                    }
+                },
+                RoomVersions.V10, # TODO: Fetch this!
+            )
+            leave_evt.internal_metadata.outlier = True
+            leave_evt.internal_metadata.out_of_band_membership = True
+            leave_evt.internal_metadata.stream_ordering = deleted_stream_id
+            
+            room_entries.append(
+                RoomSyncResultBuilder(
+                    room_id=room_id,
+                    rtype="archived",
+                    events=[leave_evt],
+                    newly_joined=False,
+                    full_state=False,
+                    # TODO: THESE ARE ALL LIES, DAMNED LIES
+                    since_token=since_token,
+                    upto_token=since_token,
+                    end_token=since_token,
+                    out_of_band=True
+                )
+            )
+            newly_left_rooms.append(room_id)
 
         return _RoomChanges(
             room_entries,

--- a/synapse/storage/schema/main/delta/93/01_add_deleted_room_memebers.sql
+++ b/synapse/storage/schema/main/delta/93/01_add_deleted_room_memebers.sql
@@ -1,0 +1,19 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2025 New Vector, Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+CREATE TABLE deleted_room_members (
+    room_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    deleted_at_stream_id bigint NOT NULL
+);
+CREATE UNIQUE INDEX deleted_room_member_idx ON deleted_room_members(room_id, user_id);


### PR DESCRIPTION
Fixes #18599 

This adds a new table to track local users who were part of a locally deleted room, to preserve the information needed to send a leave down sync so that the client can remove the room locally.

- [x] Database design
- [x] Storage of members
- [In Progress] Handle down legacy sync
- [ ] Handle down sliding sync
- [ ] Tests
