### PR TITLE
Refactor cache metrics to be homeserver-scoped

### DIFF
--- a/synapse/api/auth/msc3861_delegated.py
+++ b/synapse/api/auth/msc3861_delegated.py
@@ -176,6 +176,7 @@ class MSC3861DelegatedAuth(BaseAuth):
         assert self._config.client_id, "No client_id provided"
         assert auth_method is not None, "Invalid client_auth_method provided"
 
+        self.server_name = hs.hostname
         self._clock = hs.get_clock()
         self._http_client = hs.get_proxied_http_client()
         self._hostname = hs.hostname
@@ -206,8 +207,9 @@ class MSC3861DelegatedAuth(BaseAuth):
         #   In this case, the device still exists and it's not the end of the world for
         #   the old access token to continue working for a short time.
         self._introspection_cache: ResponseCache[str] = ResponseCache(
-            self._clock,
-            "token_introspection",
+            clock=self._clock,
+            name="token_introspection",
+            server_name=self.server_name,
             timeout_ms=120_000,
             # don't log because the keys are access tokens
             enable_logging=False,

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -126,11 +126,15 @@ class ApplicationServiceApi(SimpleHttpClient):
 
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
+        self.server_name = hs.hostname
         self.clock = hs.get_clock()
         self.config = hs.config.appservice
 
         self.protocol_meta_cache: ResponseCache[Tuple[str, str]] = ResponseCache(
-            hs.get_clock(), "as_protocol_meta", timeout_ms=HOUR_IN_MS
+            clock=hs.get_clock(),
+            name="as_protocol_meta",
+            server_name=self.server_name,
+            timeout_ms=HOUR_IN_MS,
         )
 
     def _get_headers(self, service: "ApplicationService") -> Dict[bytes, List[bytes]]:

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -137,7 +137,7 @@ class FederationClient(FederationBase):
         self.state = hs.get_state_handler()
         self.transport_layer = hs.get_federation_transport_client()
 
-        self.hostname = hs.hostname
+        self.server_name = hs.hostname
         self.signing_key = hs.signing_key
 
         # Cache mapping `event_id` to a tuple of the event itself and the `pull_origin`
@@ -162,6 +162,7 @@ class FederationClient(FederationBase):
             Tuple[JsonDict, Sequence[JsonDict], Sequence[JsonDict], Sequence[str]],
         ] = ExpiringCache(
             cache_name="get_room_hierarchy_cache",
+            server_name=self.server_name,
             clock=self._clock,
             max_len=1000,
             expiry_ms=5 * 60 * 1000,
@@ -1068,7 +1069,7 @@ class FederationClient(FederationBase):
             # there's some we never care about
             ev = builder.create_local_event_from_event_dict(
                 self._clock,
-                self.hostname,
+                self.server_name,
                 self.signing_key,
                 room_version=room_version,
                 event_dict=pdu_dict,

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -160,7 +160,10 @@ class FederationServer(FederationBase):
 
         # We cache results for transaction with the same ID
         self._transaction_resp_cache: ResponseCache[Tuple[str, str]] = ResponseCache(
-            hs.get_clock(), "fed_txn_handler", timeout_ms=30000
+            clock=hs.get_clock(),
+            name="fed_txn_handler",
+            server_name=self.server_name,
+            timeout_ms=30000,
         )
 
         self.transaction_actions = TransactionActions(self.store)
@@ -170,10 +173,18 @@ class FederationServer(FederationBase):
         # We cache responses to state queries, as they take a while and often
         # come in waves.
         self._state_resp_cache: ResponseCache[Tuple[str, Optional[str]]] = (
-            ResponseCache(hs.get_clock(), "state_resp", timeout_ms=30000)
+            ResponseCache(
+                clock=hs.get_clock(),
+                name="state_resp",
+                server_name=self.server_name,
+                timeout_ms=30000,
+            )
         )
         self._state_ids_resp_cache: ResponseCache[Tuple[str, str]] = ResponseCache(
-            hs.get_clock(), "state_ids_resp", timeout_ms=30000
+            clock=hs.get_clock(),
+            name="state_ids_resp",
+            server_name=self.server_name,
+            timeout_ms=30000,
         )
 
         self._federation_metrics_domains = (

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -1212,6 +1212,7 @@ class DeviceListUpdater(DeviceListWorkerUpdater):
     "Handles incoming device list updates from federation and updates the DB"
 
     def __init__(self, hs: "HomeServer", device_handler: DeviceHandler):
+        self.server_name = hs.hostname
         self.store = hs.get_datastores().main
         self.federation = hs.get_federation_client()
         self.clock = hs.get_clock()
@@ -1231,6 +1232,7 @@ class DeviceListUpdater(DeviceListWorkerUpdater):
         # resyncs.
         self._seen_updates: ExpiringCache[str, Set[str]] = ExpiringCache(
             cache_name="device_update_edu",
+            server_name=self.server_name,
             clock=self.clock,
             max_len=10000,
             expiry_ms=30 * 60 * 1000,

--- a/synapse/handlers/initial_sync.py
+++ b/synapse/handlers/initial_sync.py
@@ -60,6 +60,7 @@ logger = logging.getLogger(__name__)
 
 class InitialSyncHandler:
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
         self.store = hs.get_datastores().main
         self.auth = hs.get_auth()
         self.state_handler = hs.get_state_handler()
@@ -77,7 +78,11 @@ class InitialSyncHandler:
                 bool,
                 bool,
             ]
-        ] = ResponseCache(hs.get_clock(), "initial_sync_cache")
+        ] = ResponseCache(
+            clock=hs.get_clock(),
+            name="initial_sync_cache",
+            server_name=self.server_name,
+        )
         self._event_serializer = hs.get_event_client_serializer()
         self._storage_controllers = hs.get_storage_controllers()
         self._state_storage_controller = self._storage_controllers.state

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -558,8 +558,9 @@ class EventCreationHandler:
         self._external_cache_joined_hosts_updates: Optional[ExpiringCache] = None
         if self._external_cache.is_enabled():
             self._external_cache_joined_hosts_updates = ExpiringCache(
-                "_external_cache_joined_hosts_updates",
-                self.clock,
+                cache_name="_external_cache_joined_hosts_updates",
+                server_name=self.server_name,
+                clock=self.clock,
                 expiry_ms=30 * 60 * 1000,
             )
 

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -118,6 +118,7 @@ class EventContext:
 
 class RoomCreationHandler:
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self.auth = hs.get_auth()
@@ -174,7 +175,10 @@ class RoomCreationHandler:
         # succession, only process the first attempt and return its result to
         # subsequent requests
         self._upgrade_response_cache: ResponseCache[Tuple[str, str]] = ResponseCache(
-            hs.get_clock(), "room_upgrade", timeout_ms=FIVE_MINUTES_IN_MS
+            clock=hs.get_clock(),
+            name="room_upgrade",
+            server_name=self.server_name,
+            timeout_ms=FIVE_MINUTES_IN_MS,
         )
         self._server_notices_mxid = hs.config.servernotices.server_notices_mxid
 

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -61,16 +61,26 @@ MAX_PUBLIC_ROOMS_IN_RESPONSE = 100
 
 class RoomListHandler:
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
         self.hs = hs
         self.enable_room_list_search = hs.config.roomdirectory.enable_room_list_search
         self.response_cache: ResponseCache[
             Tuple[Optional[int], Optional[str], Optional[ThirdPartyInstanceID]]
-        ] = ResponseCache(hs.get_clock(), "room_list")
+        ] = ResponseCache(
+            clock=hs.get_clock(),
+            name="room_list",
+            server_name=self.server_name,
+        )
         self.remote_response_cache: ResponseCache[
             Tuple[str, Optional[int], Optional[str], bool, Optional[str]]
-        ] = ResponseCache(hs.get_clock(), "remote_room_list", timeout_ms=30 * 1000)
+        ] = ResponseCache(
+            clock=hs.get_clock(),
+            name="remote_room_list",
+            server_name=self.server_name,
+            timeout_ms=30 * 1000,
+        )
 
     async def get_local_public_room_list(
         self,

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -96,6 +96,7 @@ class RoomSummaryHandler:
     _PAGINATION_SESSION_VALIDITY_PERIOD_MS = 5 * 60 * 1000
 
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
         self._event_auth_handler = hs.get_event_auth_handler()
         self._store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()
@@ -113,8 +114,9 @@ class RoomSummaryHandler:
         self._pagination_response_cache: ResponseCache[
             Tuple[str, str, bool, Optional[int], Optional[int], Optional[str]]
         ] = ResponseCache(
-            hs.get_clock(),
-            "get_room_hierarchy",
+            clock=hs.get_clock(),
+            name="get_room_hierarchy",
+            server_name=self.server_name,
         )
         self._msc3266_enabled = hs.config.experimental.msc3266_enabled
 

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -353,8 +353,9 @@ class SyncHandler:
         #    cached result any more, and we could flush the entry from the cache to save
         #    memory.
         self.response_cache: ResponseCache[SyncRequestKey] = ResponseCache(
-            hs.get_clock(),
-            "sync",
+            clock=hs.get_clock(),
+            name="sync",
+            server_name=self.server_name,
             timeout_ms=hs.config.caches.sync_response_cache_duration,
         )
 

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1132,7 +1132,7 @@ class SyncHandler:
         )
         if cache is None:
             logger.debug("creating LruCache for %r", cache_key)
-            cache = LruCache(LAZY_LOADED_MEMBERS_CACHE_MAX_SIZE)
+            cache = LruCache(max_size=LAZY_LOADED_MEMBERS_CACHE_MAX_SIZE)
             self.lazy_loaded_members_cache[cache_key] = cache
         else:
             logger.debug("found LruCache for %r", cache_key)

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -329,6 +329,7 @@ class E2eeSyncResult:
 
 class SyncHandler:
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
         self.hs_config = hs.config
         self.store = hs.get_datastores().main
         self.notifier = hs.get_notifier()
@@ -361,8 +362,9 @@ class SyncHandler:
         self.lazy_loaded_members_cache: ExpiringCache[
             Tuple[str, Optional[str]], LruCache[str, str]
         ] = ExpiringCache(
-            "lazy_loaded_members_cache",
-            self.clock,
+            cache_name="lazy_loaded_members_cache",
+            server_name=self.server_name,
+            clock=self.clock,
             max_len=0,
             expiry_ms=LAZY_LOADED_MEMBERS_CACHE_MAX_AGE,
         )

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -263,6 +263,7 @@ class TypingWriterHandler(FollowerTypingHandler):
 
         assert hs.get_instance_name() in hs.config.worker.writers.typing
 
+        self.server_name = hs.hostname
         self.auth = hs.get_auth()
         self.notifier = hs.get_notifier()
         self.event_auth_handler = hs.get_event_auth_handler()
@@ -280,7 +281,9 @@ class TypingWriterHandler(FollowerTypingHandler):
 
         # caches which room_ids changed at which serials
         self._typing_stream_change_cache = StreamChangeCache(
-            "TypingStreamChangeCache", self._latest_room_serial
+            name="TypingStreamChangeCache",
+            server_name=self.server_name,
+            current_stream_pos=self._latest_room_serial,
         )
 
     def _handle_timeout_for_member(self, now: int, member: RoomMember) -> None:

--- a/synapse/http/federation/matrix_federation_agent.py
+++ b/synapse/http/federation/matrix_federation_agent.py
@@ -97,9 +97,23 @@ class MatrixFederationAgent:
         user_agent: bytes,
         ip_allowlist: Optional[IPSet],
         ip_blocklist: IPSet,
+        server_name: str,
         _srv_resolver: Optional[SrvResolver] = None,
         _well_known_resolver: Optional[WellKnownResolver] = None,
     ):
+        """
+        Args:
+            reactor
+            tls_client_options_factory
+            user_agent
+            ip_allowlist
+            ip_blocklist
+            server_name: The homeserver name running this resolver
+                (used to label metrics) (`hs.hostname`).
+            _srv_resolver
+            _well_known_resolver
+        """
+
         # proxy_reactor is not blocklisting reactor
         proxy_reactor = reactor
 
@@ -139,6 +153,7 @@ class MatrixFederationAgent:
                     ip_blocklist=ip_blocklist,
                 ),
                 user_agent=self.user_agent,
+                server_name=server_name,
             )
 
         self._well_known_resolver = _well_known_resolver

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -422,6 +422,7 @@ class MatrixFederationHttpClient:
                 user_agent.encode("ascii"),
                 hs.config.server.federation_ip_range_allowlist,
                 hs.config.server.federation_ip_range_blocklist,
+                server_name=self.server_name,
             )
         else:
             proxy_authorization_secret = hs.config.worker.worker_replication_secret

--- a/synapse/media/url_previewer.py
+++ b/synapse/media/url_previewer.py
@@ -200,6 +200,7 @@ class UrlPreviewer:
         # JSON-encoded OG metadata
         self._cache: ExpiringCache[str, ObservableDeferred] = ExpiringCache(
             cache_name="url_previews",
+            server_name=self.server_name,
             clock=self.clock,
             # don't spider URLs more often than once an hour
             expiry_ms=ONE_HOUR,

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -66,6 +66,17 @@ all_gauges: Dict[str, Collector] = {}
 
 HAVE_PROC_SELF_STAT = os.path.exists("/proc/self/stat")
 
+INSTANCE_LABEL_NAME = "instance"
+"""
+The standard Prometheus label name used to identify which server instance the metrics
+came from.
+In the case of a Synapse homeserver, this should be set to the homeserver name
+(`hs.hostname`).
+Normally, this would be set automatically by the Prometheus server scraping the data but
+since we support multiple instances of Synapse running in the same process and all
+metrics are in a single global `REGISTRY`, we need to manually label any metrics.
+"""
+
 
 class _RegistryProxy:
     @staticmethod

--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -136,8 +136,8 @@ class BulkPushRuleEvaluator:
         self._related_event_match_enabled = self.hs.config.experimental.msc3664_enabled
 
         self.room_push_rule_cache_metrics = register_cache(
-            "cache",
-            "room_push_rule_cache",
+            cache_type="cache",
+            cache_name="room_push_rule_cache",
             cache=[],  # Meaningless size, as this isn't a cache that stores values,
             resizable=False,
         )

--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -128,6 +128,7 @@ class BulkPushRuleEvaluator:
 
     def __init__(self, hs: "HomeServer"):
         self.hs = hs
+        self.server_name = hs.hostname
         self.store = hs.get_datastores().main
         self.clock = hs.get_clock()
         self._event_auth_handler = hs.get_event_auth_handler()
@@ -140,6 +141,7 @@ class BulkPushRuleEvaluator:
             cache_name="room_push_rule_cache",
             cache=[],  # Meaningless size, as this isn't a cache that stores values,
             resizable=False,
+            server_name=self.server_name,
         )
 
     async def _get_rules_for_event(

--- a/synapse/replication/http/_base.py
+++ b/synapse/replication/http/_base.py
@@ -121,9 +121,14 @@ class ReplicationEndpoint(metaclass=abc.ABCMeta):
     WAIT_FOR_STREAMS: ClassVar[bool] = True
 
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
+
         if self.CACHE:
             self.response_cache: ResponseCache[str] = ResponseCache(
-                hs.get_clock(), "repl." + self.NAME, timeout_ms=30 * 60 * 1000
+                clock=hs.get_clock(),
+                name="repl." + self.NAME,
+                server_name=self.server_name,
+                timeout_ms=30 * 60 * 1000,
             )
 
         # We reserve `instance_name` as a parameter to sending requests, so we

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -111,6 +111,7 @@ class SyncRestServlet(RestServlet):
     def __init__(self, hs: "HomeServer"):
         super().__init__()
         self.hs = hs
+        self.server_name = hs.hostname
         self.auth = hs.get_auth()
         self.store = hs.get_datastores().main
         self.sync_handler = hs.get_sync_handler()
@@ -125,6 +126,7 @@ class SyncRestServlet(RestServlet):
         self._json_filter_cache: LruCache[str, bool] = LruCache(
             max_size=1000,
             cache_name="sync_valid_filter",
+            server_name=self.server_name,
         )
 
         # Ratelimiter for presence updates, keyed by requester.

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -631,6 +631,7 @@ class StateResolutionHandler:
     """
 
     def __init__(self, hs: "HomeServer"):
+        self.server_name = hs.hostname
         self.clock = hs.get_clock()
 
         self.resolve_linearizer = Linearizer(name="state_resolve_lock")
@@ -639,6 +640,7 @@ class StateResolutionHandler:
         self._state_cache: ExpiringCache[FrozenSet[int], _StateCacheEntry] = (
             ExpiringCache(
                 cache_name="state_cache",
+                server_name=self.server_name,
                 clock=self.clock,
                 max_len=100000,
                 expiry_ms=EVICTION_TIMEOUT_SECONDS * 1000,

--- a/synapse/storage/databases/main/account_data.py
+++ b/synapse/storage/databases/main/account_data.py
@@ -66,6 +66,8 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
     ):
         super().__init__(database, db_conn, hs)
 
+        self.server_name = hs.hostname
+
         self._can_write_to_account_data = (
             self._instance_name in hs.config.worker.writers.account_data
         )
@@ -89,7 +91,9 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
 
         account_max = self.get_max_account_data_stream_id()
         self._account_data_stream_cache = StreamChangeCache(
-            "AccountDataAndTagsChangeCache", account_max
+            name="AccountDataAndTagsChangeCache",
+            server_name=self.server_name,
+            current_stream_pos=account_max,
         )
 
         self.db_pool.updates.register_background_index_update(

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -128,8 +128,9 @@ class DeviceInboxWorkerStore(SQLBaseStore):
             limit=1000,
         )
         self._device_inbox_stream_cache = StreamChangeCache(
-            "DeviceInboxStreamChangeCache",
-            min_device_inbox_id,
+            name="DeviceInboxStreamChangeCache",
+            server_name=self.server_name,
+            current_stream_pos=min_device_inbox_id,
             prefilled_cache=device_inbox_prefill,
         )
 
@@ -144,8 +145,9 @@ class DeviceInboxWorkerStore(SQLBaseStore):
             limit=1000,
         )
         self._device_federation_outbox_stream_cache = StreamChangeCache(
-            "DeviceFederationOutboxStreamChangeCache",
-            min_device_outbox_id,
+            name="DeviceFederationOutboxStreamChangeCache",
+            server_name=self.server_name,
+            current_stream_pos=min_device_outbox_id,
             prefilled_cache=device_outbox_prefill,
         )
 

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -85,6 +85,7 @@ class DeviceInboxWorkerStore(SQLBaseStore):
     ):
         super().__init__(database, db_conn, hs)
 
+        self.server_name = hs.hostname
         self._instance_name = hs.get_instance_name()
 
         # Map of (user_id, device_id) to the last stream_id that has been
@@ -93,6 +94,7 @@ class DeviceInboxWorkerStore(SQLBaseStore):
             Tuple[str, Optional[str]], int
         ] = ExpiringCache(
             cache_name="last_device_delete_cache",
+            server_name=self.server_name,
             clock=self._clock,
             max_len=10000,
             expiry_ms=30 * 60 * 1000,

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -1774,11 +1774,16 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
         hs: "HomeServer",
     ):
         super().__init__(database, db_conn, hs)
+        self.server_name = hs.hostname
 
         # Map of (user_id, device_id) -> bool. If there is an entry that implies
         # the device exists.
         self.device_id_exists_cache: LruCache[Tuple[str, str], Literal[True]] = (
-            LruCache(cache_name="device_id_exists", max_size=10000)
+            LruCache(
+                cache_name="device_id_exists",
+                server_name=self.server_name,
+                max_size=10000,
+            )
         )
 
     async def store_device(

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -93,6 +93,7 @@ class DeviceWorkerStore(RoomMemberWorkerStore, EndToEndKeyWorkerStore):
         hs: "HomeServer",
     ):
         super().__init__(database, db_conn, hs)
+        self.server_name = hs.hostname
 
         # In the worker store this is an ID tracker which we overwrite in the non-worker
         # class below that is used on the main process.
@@ -128,8 +129,9 @@ class DeviceWorkerStore(RoomMemberWorkerStore, EndToEndKeyWorkerStore):
             limit=10000,
         )
         self._device_list_stream_cache = StreamChangeCache(
-            "DeviceListStreamChangeCache",
-            min_device_list_id,
+            name="DeviceListStreamChangeCache",
+            server_name=self.server_name,
+            current_stream_pos=min_device_list_id,
             prefilled_cache=device_list_prefill,
         )
 
@@ -142,8 +144,9 @@ class DeviceWorkerStore(RoomMemberWorkerStore, EndToEndKeyWorkerStore):
             limit=10000,
         )
         self._device_list_room_stream_cache = StreamChangeCache(
-            "DeviceListRoomStreamChangeCache",
-            min_device_list_room_id,
+            name="DeviceListRoomStreamChangeCache",
+            server_name=self.server_name,
+            current_stream_pos=min_device_list_room_id,
             prefilled_cache=device_list_room_prefill,
         )
 
@@ -159,8 +162,9 @@ class DeviceWorkerStore(RoomMemberWorkerStore, EndToEndKeyWorkerStore):
             limit=1000,
         )
         self._user_signature_stream_cache = StreamChangeCache(
-            "UserSignatureStreamChangeCache",
-            user_signature_stream_list_id,
+            name="UserSignatureStreamChangeCache",
+            server_name=self.server_name,
+            current_stream_pos=user_signature_stream_list_id,
             prefilled_cache=user_signature_stream_prefill,
         )
 
@@ -178,8 +182,9 @@ class DeviceWorkerStore(RoomMemberWorkerStore, EndToEndKeyWorkerStore):
                 limit=10000,
             )
             self._device_list_federation_stream_cache = StreamChangeCache(
-                "DeviceListFederationStreamChangeCache",
-                device_list_federation_list_id,
+                name="DeviceListFederationStreamChangeCache",
+                server_name=self.server_name,
+                current_stream_pos=device_list_federation_list_id,
                 prefilled_cache=device_list_federation_prefill,
             )
 

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -137,6 +137,7 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
         super().__init__(database, db_conn, hs)
 
         self.hs = hs
+        self.server_name = hs.hostname
 
         if hs.config.worker.run_background_tasks:
             hs.get_clock().looping_call(
@@ -145,7 +146,10 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
 
         # Cache of event ID to list of auth event IDs and their depths.
         self._event_auth_cache: LruCache[str, List[Tuple[str, int]]] = LruCache(
-            500000, "_event_auth_cache", size_callback=len
+            max_size=500000,
+            server_name=self.server_name,
+            cache_name="_event_auth_cache",
+            size_callback=len,
         )
 
         # Flag used by unit tests to disable fallback when there is no chain cover

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -286,6 +286,7 @@ class EventsWorkerStore(SQLBaseStore):
 
         self._get_event_cache: AsyncLruCache[Tuple[str], EventCacheEntry] = (
             AsyncLruCache(
+                server_name=self.server_name,
                 cache_name="*getEvent*",
                 max_size=hs.config.caches.event_cache_size,
                 # `extra_index_cb` Returns a tuple as that is the key type

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -227,6 +227,8 @@ class EventsWorkerStore(SQLBaseStore):
     ):
         super().__init__(database, db_conn, hs)
 
+        self.server_name = hs.hostname
+
         self._stream_id_gen: MultiWriterIdGenerator
         self._backfill_id_gen: MultiWriterIdGenerator
 
@@ -269,8 +271,9 @@ class EventsWorkerStore(SQLBaseStore):
             limit=1000,
         )
         self._curr_state_delta_stream_cache: StreamChangeCache = StreamChangeCache(
-            "_curr_state_delta_stream_cache",
-            min_curr_state_delta_id,
+            name="_curr_state_delta_stream_cache",
+            server_name=self.server_name,
+            current_stream_pos=min_curr_state_delta_id,
             prefilled_cache=curr_state_delta_prefill,
         )
 

--- a/synapse/storage/databases/main/presence.py
+++ b/synapse/storage/databases/main/presence.py
@@ -79,6 +79,7 @@ class PresenceStore(PresenceBackgroundUpdateStore, CacheInvalidationWorkerStore)
     ) -> None:
         super().__init__(database, db_conn, hs)
 
+        self.server_name = hs.hostname
         self._instance_name = hs.get_instance_name()
         self._presence_id_gen: MultiWriterIdGenerator
 
@@ -108,8 +109,9 @@ class PresenceStore(PresenceBackgroundUpdateStore, CacheInvalidationWorkerStore)
             max_value=self._presence_id_gen.get_current_token(),
         )
         self.presence_stream_cache = StreamChangeCache(
-            "PresenceStreamChangeCache",
-            min_presence_val,
+            name="PresenceStreamChangeCache",
+            server_name=self.server_name,
+            current_stream_pos=min_presence_val,
             prefilled_cache=presence_cache_prefill,
         )
 

--- a/synapse/storage/databases/main/push_rule.py
+++ b/synapse/storage/databases/main/push_rule.py
@@ -163,8 +163,9 @@ class PushRulesWorkerStore(
         )
 
         self.push_rules_stream_cache = StreamChangeCache(
-            "PushRulesStreamChangeCache",
-            push_rules_id,
+            name="PushRulesStreamChangeCache",
+            server_name=self.server_name,
+            current_stream_pos=push_rules_id,
             prefilled_cache=push_rules_prefill,
         )
 

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -125,6 +125,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
         db_conn: LoggingDatabaseConnection,
         hs: "HomeServer",
     ):
+        self.server_name = hs.hostname
         self._instance_name = hs.get_instance_name()
 
         # In the worker store this is an ID tracker which we overwrite in the non-worker
@@ -158,8 +159,9 @@ class ReceiptsWorkerStore(SQLBaseStore):
             limit=10000,
         )
         self._receipts_stream_cache = StreamChangeCache(
-            "ReceiptsRoomChangeCache",
-            min_receipts_stream_id,
+            name="ReceiptsRoomChangeCache",
+            server_name=self.server_name,
+            current_stream_pos=min_receipts_stream_id,
             prefilled_cache=receipts_stream_prefill,
         )
 

--- a/synapse/storage/databases/main/stream.py
+++ b/synapse/storage/databases/main/stream.py
@@ -617,12 +617,15 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
             max_value=events_max,
         )
         self._events_stream_cache = StreamChangeCache(
-            "EventsRoomStreamChangeCache",
-            min_event_val,
+            name="EventsRoomStreamChangeCache",
+            server_name=self.server_name,
+            current_stream_pos=min_event_val,
             prefilled_cache=event_cache_prefill,
         )
         self._membership_stream_cache = StreamChangeCache(
-            "MembershipStreamChangeCache", events_max
+            name="MembershipStreamChangeCache",
+            server_name=self.server_name,
+            current_stream_pos=events_max,
         )
 
         self._stream_order_on_start = self.get_room_max_stream_ordering()

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -92,6 +92,7 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
     ):
         super().__init__(database, db_conn, hs)
         self._state_deletion_store = state_deletion_store
+        self.server_name = hs.hostname
 
         # Originally the state store used a single DictionaryCache to cache the
         # event IDs for the state types in a given state group to avoid hammering
@@ -123,14 +124,16 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
         # vast majority of state in Matrix (today) is member events.
 
         self._state_group_cache: DictionaryCache[int, StateKey, str] = DictionaryCache(
-            "*stateGroupCache*",
+            name="*stateGroupCache*",
+            server_name=self.server_name,
             # TODO: this hasn't been tuned yet
-            50000,
+            max_entries=50000,
         )
         self._state_group_members_cache: DictionaryCache[int, StateKey, str] = (
             DictionaryCache(
-                "*stateGroupMembersCache*",
-                500000,
+                name="*stateGroupMembersCache*",
+                server_name=self.server_name,
+                max_entries=500000,
             )
         )
 

--- a/synapse/util/caches/__init__.py
+++ b/synapse/util/caches/__init__.py
@@ -31,6 +31,7 @@ from prometheus_client import REGISTRY
 from prometheus_client.core import Gauge
 
 from synapse.config.cache import add_resizable_cache
+from synapse.metrics import INSTANCE_LABEL_NAME
 from synapse.util.metrics import DynamicCollectorRegistry
 
 logger = logging.getLogger(__name__)
@@ -46,50 +47,65 @@ CACHE_METRIC_REGISTRY = DynamicCollectorRegistry()
 caches_by_name: Dict[str, Sized] = {}
 
 cache_size = Gauge(
-    "synapse_util_caches_cache_size", "", ["name"], registry=CACHE_METRIC_REGISTRY
+    "synapse_util_caches_cache_size",
+    "",
+    labelnames=["name", INSTANCE_LABEL_NAME],
+    registry=CACHE_METRIC_REGISTRY,
 )
 cache_hits = Gauge(
-    "synapse_util_caches_cache_hits", "", ["name"], registry=CACHE_METRIC_REGISTRY
+    "synapse_util_caches_cache_hits",
+    "",
+    labelnames=["name", INSTANCE_LABEL_NAME],
+    registry=CACHE_METRIC_REGISTRY,
 )
 cache_evicted = Gauge(
     "synapse_util_caches_cache_evicted_size",
     "",
-    ["name", "reason"],
+    labelnames=["name", "reason", INSTANCE_LABEL_NAME],
     registry=CACHE_METRIC_REGISTRY,
 )
 cache_total = Gauge(
-    "synapse_util_caches_cache", "", ["name"], registry=CACHE_METRIC_REGISTRY
+    "synapse_util_caches_cache",
+    "",
+    labelnames=["name", INSTANCE_LABEL_NAME],
+    registry=CACHE_METRIC_REGISTRY,
 )
 cache_max_size = Gauge(
-    "synapse_util_caches_cache_max_size", "", ["name"], registry=CACHE_METRIC_REGISTRY
+    "synapse_util_caches_cache_max_size",
+    "",
+    labelnames=["name", INSTANCE_LABEL_NAME],
+    registry=CACHE_METRIC_REGISTRY,
 )
 cache_memory_usage = Gauge(
     "synapse_util_caches_cache_size_bytes",
     "Estimated memory usage of the caches",
-    ["name"],
+    labelnames=["name", INSTANCE_LABEL_NAME],
     registry=CACHE_METRIC_REGISTRY,
 )
 
 response_cache_size = Gauge(
     "synapse_util_caches_response_cache_size",
     "",
-    ["name"],
+    labelnames=["name", INSTANCE_LABEL_NAME],
     registry=CACHE_METRIC_REGISTRY,
 )
 response_cache_hits = Gauge(
     "synapse_util_caches_response_cache_hits",
     "",
-    ["name"],
+    labelnames=["name", INSTANCE_LABEL_NAME],
     registry=CACHE_METRIC_REGISTRY,
 )
 response_cache_evicted = Gauge(
     "synapse_util_caches_response_cache_evicted_size",
     "",
-    ["name", "reason"],
+    labelnames=["name", "reason", INSTANCE_LABEL_NAME],
     registry=CACHE_METRIC_REGISTRY,
 )
 response_cache_total = Gauge(
-    "synapse_util_caches_response_cache", "", ["name"], registry=CACHE_METRIC_REGISTRY
+    "synapse_util_caches_response_cache",
+    "",
+    labelnames=["name", INSTANCE_LABEL_NAME],
+    registry=CACHE_METRIC_REGISTRY,
 )
 
 
@@ -103,12 +119,13 @@ class EvictionReason(Enum):
     invalidation = auto()
 
 
-@attr.s(slots=True, auto_attribs=True)
+@attr.s(slots=True, auto_attribs=True, kw_only=True)
 class CacheMetric:
     _cache: Sized
     _cache_type: str
     _cache_name: str
     _collect_callback: Optional[Callable]
+    _server_name: str
 
     hits: int = 0
     misses: int = 0
@@ -145,34 +162,34 @@ class CacheMetric:
 
     def collect(self) -> None:
         try:
+            labels_base = {
+                "name": self._cache_name,
+                INSTANCE_LABEL_NAME: self._server_name,
+            }
             if self._cache_type == "response_cache":
-                response_cache_size.labels(self._cache_name).set(len(self._cache))
-                response_cache_hits.labels(self._cache_name).set(self.hits)
+                response_cache_size.labels(**labels_base).set(len(self._cache))
+                response_cache_hits.labels(**labels_base).set(self.hits)
                 for reason in EvictionReason:
-                    response_cache_evicted.labels(self._cache_name, reason.name).set(
-                        self.eviction_size_by_reason[reason]
-                    )
-                response_cache_total.labels(self._cache_name).set(
-                    self.hits + self.misses
-                )
+                    response_cache_evicted.labels(
+                        {**labels_base, "reason": reason.name}
+                    ).set(self.eviction_size_by_reason[reason])
+                response_cache_total.labels(**labels_base).set(self.hits + self.misses)
             else:
-                cache_size.labels(self._cache_name).set(len(self._cache))
-                cache_hits.labels(self._cache_name).set(self.hits)
+                cache_size.labels(**labels_base).set(len(self._cache))
+                cache_hits.labels(**labels_base).set(self.hits)
                 for reason in EvictionReason:
-                    cache_evicted.labels(self._cache_name, reason.name).set(
+                    cache_evicted.labels({**labels_base, "reason": reason.name}).set(
                         self.eviction_size_by_reason[reason]
                     )
-                cache_total.labels(self._cache_name).set(self.hits + self.misses)
+                cache_total.labels(**labels_base).set(self.hits + self.misses)
                 max_size = getattr(self._cache, "max_size", None)
                 if max_size:
-                    cache_max_size.labels(self._cache_name).set(max_size)
+                    cache_max_size.labels(**labels_base).set(max_size)
 
                 if TRACK_MEMORY_USAGE:
                     # self.memory_usage can be None if nothing has been inserted
                     # into the cache yet.
-                    cache_memory_usage.labels(self._cache_name).set(
-                        self.memory_usage or 0
-                    )
+                    cache_memory_usage.labels(**labels_base).set(self.memory_usage or 0)
             if self._collect_callback:
                 self._collect_callback()
         except Exception as e:
@@ -181,9 +198,11 @@ class CacheMetric:
 
 
 def register_cache(
+    *,
     cache_type: str,
     cache_name: str,
     cache: Sized,
+    server_name: str,
     collect_callback: Optional[Callable] = None,
     resizable: bool = True,
     resize_callback: Optional[Callable] = None,
@@ -196,6 +215,8 @@ def register_cache(
         cache_name: name of the cache
         cache: cache itself, which must implement __len__(), and may optionally implement
              a max_size property
+        server_name: server_name: The homeserver name that this cache is associated with
+            (used to label the metric) (`hs.hostname`).
         collect_callback: If given, a function which is called during metric
             collection to update additional metrics.
         resizable: Whether this cache supports being resized, in which case either
@@ -210,7 +231,13 @@ def register_cache(
             resize_callback = cache.set_cache_factor  # type: ignore
         add_resizable_cache(cache_name, resize_callback)
 
-    metric = CacheMetric(cache, cache_type, cache_name, collect_callback)
+    metric = CacheMetric(
+        cache=cache,
+        cache_type=cache_type,
+        cache_name=cache_name,
+        server_name=server_name,
+        collect_callback=collect_callback,
+    )
     metric_name = "cache_%s_%s" % (cache_type, cache_name)
     caches_by_name[cache_name] = cache
     CACHE_METRIC_REGISTRY.register_hook(metric_name, metric.collect)

--- a/synapse/util/caches/__init__.py
+++ b/synapse/util/caches/__init__.py
@@ -121,6 +121,10 @@ class EvictionReason(Enum):
 
 @attr.s(slots=True, auto_attribs=True, kw_only=True)
 class CacheMetric:
+    """
+    Used to track cache metrics
+    """
+
     _cache: Sized
     _cache_type: str
     _cache_name: str

--- a/synapse/util/caches/__init__.py
+++ b/synapse/util/caches/__init__.py
@@ -219,7 +219,7 @@ def register_cache(
         cache_name: name of the cache
         cache: cache itself, which must implement __len__(), and may optionally implement
              a max_size property
-        server_name: server_name: The homeserver name that this cache is associated with
+        server_name: The homeserver name that this cache is associated with
             (used to label the metric) (`hs.hostname`).
         collect_callback: If given, a function which is called during metric
             collection to update additional metrics.

--- a/synapse/util/caches/deferred_cache.py
+++ b/synapse/util/caches/deferred_cache.py
@@ -79,7 +79,9 @@ class DeferredCache(Generic[KT, VT]):
 
     def __init__(
         self,
+        *,
         name: str,
+        server_name: str,
         max_entries: int = 1000,
         tree: bool = False,
         iterable: bool = False,
@@ -89,6 +91,8 @@ class DeferredCache(Generic[KT, VT]):
         """
         Args:
             name: The name of the cache
+            server_name: server_name: The homeserver name that this cache is associated with
+                (used to label the metric) (`hs.hostname`).
             max_entries: Maximum amount of entries that the cache will hold
             tree: Use a TreeCache instead of a dict as the underlying cache type
             iterable: If True, count each item in the cached object as an entry,
@@ -113,6 +117,7 @@ class DeferredCache(Generic[KT, VT]):
         # a Deferred.
         self.cache: LruCache[KT, VT] = LruCache(
             max_size=max_entries,
+            server_name=server_name,
             cache_name=name,
             cache_type=cache_type,
             size_callback=(

--- a/synapse/util/caches/descriptors.py
+++ b/synapse/util/caches/descriptors.py
@@ -200,6 +200,8 @@ class DeferredCacheDescriptor(_CacheDescriptorBase):
 
     def __init__(
         self,
+        *,
+        server_name: str,
         orig: Callable[..., Any],
         max_entries: int = 1000,
         num_args: Optional[int] = None,
@@ -217,6 +219,7 @@ class DeferredCacheDescriptor(_CacheDescriptorBase):
             cache_context=cache_context,
             name=name,
         )
+        self.server_name = server_name
 
         if tree and self.num_args < 2:
             raise RuntimeError(
@@ -233,6 +236,7 @@ class DeferredCacheDescriptor(_CacheDescriptorBase):
     ) -> Callable[..., "defer.Deferred[Any]"]:
         cache: DeferredCache[CacheKey, Any] = DeferredCache(
             name=self.name,
+            server_name=self.server_name,
             max_entries=self.max_entries,
             tree=self.tree,
             iterable=self.iterable,
@@ -479,6 +483,7 @@ class _CachedFunctionDescriptor:
     """Helper for `@cached`, we name it so that we can hook into it with mypy
     plugin."""
 
+    server_name: str
     max_entries: int
     num_args: Optional[int]
     uncached_args: Optional[Collection[str]]
@@ -490,7 +495,8 @@ class _CachedFunctionDescriptor:
 
     def __call__(self, orig: F) -> CachedFunction[F]:
         d = DeferredCacheDescriptor(
-            orig,
+            server_name=self.server_name,
+            orig=orig,
             max_entries=self.max_entries,
             num_args=self.num_args,
             uncached_args=self.uncached_args,

--- a/synapse/util/caches/dictionary_cache.py
+++ b/synapse/util/caches/dictionary_cache.py
@@ -127,7 +127,15 @@ class DictionaryCache(Generic[KT, DKT, DV]):
     for the '2' dict key.
     """
 
-    def __init__(self, name: str, max_entries: int = 1000):
+    def __init__(self, *, name: str, server_name: str, max_entries: int = 1000):
+        """
+        Args:
+            name
+            server_name: The homeserver name that this cache is associated with
+                (used to label the metric) (`hs.hostname`).
+            max_entries
+        """
+
         # We use a single LruCache to store two different types of entries:
         #   1. Map from (key, dict_key) -> dict value (or sentinel, indicating
         #      the key doesn't exist in the dict); and
@@ -152,6 +160,7 @@ class DictionaryCache(Generic[KT, DKT, DV]):
             Union[_PerKeyValue, Dict[DKT, DV]],
         ] = LruCache(
             max_size=max_entries,
+            server_name=server_name,
             cache_name=name,
             cache_type=TreeCache,
             size_callback=len,

--- a/synapse/util/caches/expiringcache.py
+++ b/synapse/util/caches/expiringcache.py
@@ -83,7 +83,9 @@ class ExpiringCache(Generic[KT, VT]):
 
         self.iterable = iterable
 
-        self.metrics = register_cache("expiring", cache_name, self)
+        self.metrics = register_cache(
+            cache_type="expiring", cache_name=cache_name, cache=self
+        )
 
         if not self._expiry_ms:
             # Don't bother starting the loop if things never expire

--- a/synapse/util/caches/expiringcache.py
+++ b/synapse/util/caches/expiringcache.py
@@ -58,6 +58,8 @@ class ExpiringCache(Generic[KT, VT]):
         """
         Args:
             cache_name: Name of this cache, used for logging.
+            server_name: server_name: The homeserver name that this cache is associated
+                with (used to label the metric) (`hs.hostname`).
             clock
             max_len: Max size of dict. If the dict grows larger than this
                 then the oldest items get automatically evicted. Default is 0,

--- a/synapse/util/caches/expiringcache.py
+++ b/synapse/util/caches/expiringcache.py
@@ -46,7 +46,9 @@ VT = TypeVar("VT")
 class ExpiringCache(Generic[KT, VT]):
     def __init__(
         self,
+        *,
         cache_name: str,
+        server_name: str,
         clock: Clock,
         max_len: int = 0,
         expiry_ms: int = 0,
@@ -84,7 +86,10 @@ class ExpiringCache(Generic[KT, VT]):
         self.iterable = iterable
 
         self.metrics = register_cache(
-            cache_type="expiring", cache_name=cache_name, cache=self
+            cache_type="expiring",
+            cache_name=cache_name,
+            cache=self,
+            server_name=server_name,
         )
 
         if not self._expiry_ms:

--- a/synapse/util/caches/expiringcache.py
+++ b/synapse/util/caches/expiringcache.py
@@ -58,7 +58,7 @@ class ExpiringCache(Generic[KT, VT]):
         """
         Args:
             cache_name: Name of this cache, used for logging.
-            server_name: server_name: The homeserver name that this cache is associated
+            server_name: The homeserver name that this cache is associated
                 with (used to label the metric) (`hs.hostname`).
             clock
             max_len: Max size of dict. If the dict grows larger than this

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -376,9 +376,43 @@ class LruCache(Generic[KT, VT]):
     If cache_type=TreeCache, all keys must be tuples.
     """
 
+    @overload
     def __init__(
         self,
+        *,
         max_size: int,
+        server_name: str,
+        cache_name: str,
+        cache_type: Type[Union[dict, TreeCache]] = dict,
+        size_callback: Optional[Callable[[VT], int]] = None,
+        metrics_collection_callback: Optional[Callable[[], None]] = None,
+        apply_cache_factor_from_config: bool = True,
+        clock: Optional[Clock] = None,
+        prune_unread_entries: bool = True,
+        extra_index_cb: Optional[Callable[[KT, VT], KT]] = None,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        max_size: int,
+        server_name: Literal[None] = None,
+        cache_name: Literal[None] = None,
+        cache_type: Type[Union[dict, TreeCache]] = dict,
+        size_callback: Optional[Callable[[VT], int]] = None,
+        metrics_collection_callback: Optional[Callable[[], None]] = None,
+        apply_cache_factor_from_config: bool = True,
+        clock: Optional[Clock] = None,
+        prune_unread_entries: bool = True,
+        extra_index_cb: Optional[Callable[[KT, VT], KT]] = None,
+    ): ...
+
+    def __init__(
+        self,
+        *,
+        max_size: int,
+        server_name: Optional[str] = None,
         cache_name: Optional[str] = None,
         cache_type: Type[Union[dict, TreeCache]] = dict,
         size_callback: Optional[Callable[[VT], int]] = None,
@@ -392,8 +426,13 @@ class LruCache(Generic[KT, VT]):
         Args:
             max_size: The maximum amount of entries the cache can hold
 
-            cache_name: The name of this cache, for the prometheus metrics. If unset,
-                no metrics will be reported on this cache.
+            server_name: The homeserver name that this cache is associated with
+                (used to label the metric) (`hs.hostname`). Must be set if `cache_name` is
+                set. If unset, no metrics will be reported on this cache.
+
+            cache_name: The name of this cache, for the prometheus metrics. Must be set
+                if `server_name` is set. If unset, no metrics will be reported on this
+                cache.
 
             cache_type:
                 type of underlying cache to be used. Typically one of dict
@@ -457,11 +496,12 @@ class LruCache(Generic[KT, VT]):
         # do yet when we get resized.
         self._on_resize: Optional[Callable[[], None]] = None
 
-        if cache_name is not None:
+        if cache_name is not None and server_name is not None:
             metrics: Optional[CacheMetric] = register_cache(
                 cache_type="lru_cache",
                 cache_name=cache_name,
                 cache=self,
+                server_name=server_name,
                 collect_callback=metrics_collection_callback,
             )
         else:

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -459,9 +459,9 @@ class LruCache(Generic[KT, VT]):
 
         if cache_name is not None:
             metrics: Optional[CacheMetric] = register_cache(
-                "lru_cache",
-                cache_name,
-                self,
+                cache_type="lru_cache",
+                cache_name=cache_name,
+                cache=self,
                 collect_callback=metrics_collection_callback,
             )
         else:

--- a/synapse/util/caches/response_cache.py
+++ b/synapse/util/caches/response_cache.py
@@ -103,11 +103,22 @@ class ResponseCache(Generic[KV]):
 
     def __init__(
         self,
+        *,
         clock: Clock,
         name: str,
+        server_name: str,
         timeout_ms: float = 0,
         enable_logging: bool = True,
     ):
+        """
+        Args:
+            clock
+            name
+            server_name: server_name: The homeserver name that this cache is associated
+                with (used to label the metric) (`hs.hostname`).
+            timeout_ms
+            enable_logging
+        """
         self._result_cache: Dict[KV, ResponseCacheEntry] = {}
 
         self.clock = clock
@@ -115,7 +126,11 @@ class ResponseCache(Generic[KV]):
 
         self._name = name
         self._metrics = register_cache(
-            cache_type="response_cache", cache_name=name, cache=self, resizable=False
+            cache_type="response_cache",
+            cache_name=name,
+            cache=self,
+            server_name=server_name,
+            resizable=False,
         )
         self._enable_logging = enable_logging
 

--- a/synapse/util/caches/response_cache.py
+++ b/synapse/util/caches/response_cache.py
@@ -114,7 +114,9 @@ class ResponseCache(Generic[KV]):
         self.timeout_sec = timeout_ms / 1000.0
 
         self._name = name
-        self._metrics = register_cache("response_cache", name, self, resizable=False)
+        self._metrics = register_cache(
+            cache_type="response_cache", cache_name=name, cache=self, resizable=False
+        )
         self._enable_logging = enable_logging
 
     def size(self) -> int:

--- a/synapse/util/caches/response_cache.py
+++ b/synapse/util/caches/response_cache.py
@@ -114,7 +114,7 @@ class ResponseCache(Generic[KV]):
         Args:
             clock
             name
-            server_name: server_name: The homeserver name that this cache is associated
+            server_name: The homeserver name that this cache is associated
                 with (used to label the metric) (`hs.hostname`).
             timeout_ms
             enable_logging

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -96,7 +96,10 @@ class StreamChangeCache:
 
         self.name = name
         self.metrics = caches.register_cache(
-            "cache", self.name, self._cache, resize_callback=self.set_cache_factor
+            cache_type="cache",
+            cache_name=self.name,
+            cache=self._cache,
+            resize_callback=self.set_cache_factor,
         )
 
         if prefilled_cache:

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -83,7 +83,7 @@ class StreamChangeCache:
         """
         Args:
             name
-            server_name: server_name: The homeserver name that this cache is associated with
+            server_name: The homeserver name that this cache is associated with
                 (used to label the metric) (`hs.hostname`).
             current_stream_pos
             max_size

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -73,11 +73,23 @@ class StreamChangeCache:
 
     def __init__(
         self,
+        *,
         name: str,
+        server_name: str,
         current_stream_pos: int,
         max_size: int = 10000,
         prefilled_cache: Optional[Mapping[EntityType, int]] = None,
     ) -> None:
+        """
+        Args:
+            name
+            server_name: server_name: The homeserver name that this cache is associated with
+                (used to label the metric) (`hs.hostname`).
+            current_stream_pos
+            max_size
+            prefilled_cache
+        """
+
         self._original_max_size: int = max_size
         self._max_size = math.floor(max_size)
 
@@ -98,6 +110,7 @@ class StreamChangeCache:
         self.metrics = caches.register_cache(
             cache_type="cache",
             cache_name=self.name,
+            server_name=server_name,
             cache=self._cache,
             resize_callback=self.set_cache_factor,
         )

--- a/synapse/util/caches/ttlcache.py
+++ b/synapse/util/caches/ttlcache.py
@@ -49,7 +49,9 @@ class TTLCache(Generic[KT, VT]):
 
         self._timer = timer
 
-        self._metrics = register_cache("ttl", cache_name, self, resizable=False)
+        self._metrics = register_cache(
+            cache_type="ttl", cache_name=cache_name, cache=self, resizable=False
+        )
 
     def set(self, key: KT, value: VT, ttl: float) -> None:
         """Add/update an entry in the cache

--- a/synapse/util/caches/ttlcache.py
+++ b/synapse/util/caches/ttlcache.py
@@ -50,7 +50,7 @@ class TTLCache(Generic[KT, VT]):
         """
         Args:
             cache_name
-            server_name: server_name: The homeserver name that this cache is associated with
+            server_name: The homeserver name that this cache is associated with
                 (used to label the metric) (`hs.hostname`).
             timer: Function used to get the current time in seconds since the epoch.
         """

--- a/synapse/util/caches/ttlcache.py
+++ b/synapse/util/caches/ttlcache.py
@@ -40,7 +40,21 @@ VT = TypeVar("VT")
 class TTLCache(Generic[KT, VT]):
     """A key/value cache implementation where each entry has its own TTL"""
 
-    def __init__(self, cache_name: str, timer: Callable[[], float] = time.time):
+    def __init__(
+        self,
+        *,
+        cache_name: str,
+        server_name: str,
+        timer: Callable[[], float] = time.time,
+    ):
+        """
+        Args:
+            cache_name
+            server_name: server_name: The homeserver name that this cache is associated with
+                (used to label the metric) (`hs.hostname`).
+            timer: Function used to get the current time in seconds since the epoch.
+        """
+
         # map from key to _CacheEntry
         self._data: Dict[KT, _CacheEntry[KT, VT]] = {}
 
@@ -50,7 +64,11 @@ class TTLCache(Generic[KT, VT]):
         self._timer = timer
 
         self._metrics = register_cache(
-            cache_type="ttl", cache_name=cache_name, cache=self, resizable=False
+            cache_type="ttl",
+            cache_name=cache_name,
+            cache=self,
+            server_name=server_name,
+            resizable=False,
         )
 
     def set(self, key: KT, value: VT, ttl: float) -> None:

--- a/synmark/suites/lrucache.py
+++ b/synmark/suites/lrucache.py
@@ -29,7 +29,7 @@ async def main(reactor: ISynapseReactor, loops: int) -> float:
     """
     Benchmark `loops` number of insertions into LruCache without eviction.
     """
-    cache: LruCache[int, bool] = LruCache(loops)
+    cache: LruCache[int, bool] = LruCache(max_size=loops)
 
     start = perf_counter()
 

--- a/synmark/suites/lrucache_evict.py
+++ b/synmark/suites/lrucache_evict.py
@@ -30,7 +30,7 @@ async def main(reactor: ISynapseReactor, loops: int) -> float:
     Benchmark `loops` number of insertions into LruCache where half of them are
     evicted.
     """
-    cache: LruCache[int, bool] = LruCache(loops // 2)
+    cache: LruCache[int, bool] = LruCache(max_size=loops // 2)
 
     start = perf_counter()
 

--- a/tests/config/test_cache.py
+++ b/tests/config/test_cache.py
@@ -75,7 +75,7 @@ class CacheConfigTests(TestCase):
         the default cache size in the interim, and then resized once the config
         is loaded.
         """
-        cache: LruCache = LruCache(100)
+        cache: LruCache = LruCache(max_size=100)
 
         add_resizable_cache("foo", cache_resize_callback=cache.set_cache_factor)
         self.assertEqual(cache.max_size, 50)
@@ -96,7 +96,7 @@ class CacheConfigTests(TestCase):
         self.config.read_config(config, config_dir_path="", data_dir_path="")
         self.config.resize_all_caches()
 
-        cache: LruCache = LruCache(100)
+        cache: LruCache = LruCache(max_size=100)
         add_resizable_cache("foo", cache_resize_callback=cache.set_cache_factor)
         self.assertEqual(cache.max_size, 200)
 
@@ -106,7 +106,7 @@ class CacheConfigTests(TestCase):
         the default cache size in the interim, and then resized to the new
         default cache size once the config is loaded.
         """
-        cache: LruCache = LruCache(100)
+        cache: LruCache = LruCache(max_size=100)
         add_resizable_cache("foo", cache_resize_callback=cache.set_cache_factor)
         self.assertEqual(cache.max_size, 50)
 
@@ -126,7 +126,7 @@ class CacheConfigTests(TestCase):
         self.config.read_config(config, config_dir_path="", data_dir_path="")
         self.config.resize_all_caches()
 
-        cache: LruCache = LruCache(100)
+        cache: LruCache = LruCache(max_size=100)
         add_resizable_cache("foo", cache_resize_callback=cache.set_cache_factor)
         self.assertEqual(cache.max_size, 150)
 
@@ -145,15 +145,15 @@ class CacheConfigTests(TestCase):
         self.config.read_config(config, config_dir_path="", data_dir_path="")
         self.config.resize_all_caches()
 
-        cache_a: LruCache = LruCache(100)
+        cache_a: LruCache = LruCache(max_size=100)
         add_resizable_cache("*cache_a*", cache_resize_callback=cache_a.set_cache_factor)
         self.assertEqual(cache_a.max_size, 200)
 
-        cache_b: LruCache = LruCache(100)
+        cache_b: LruCache = LruCache(max_size=100)
         add_resizable_cache("*Cache_b*", cache_resize_callback=cache_b.set_cache_factor)
         self.assertEqual(cache_b.max_size, 300)
 
-        cache_c: LruCache = LruCache(100)
+        cache_c: LruCache = LruCache(max_size=100)
         add_resizable_cache("*cache_c*", cache_resize_callback=cache_c.set_cache_factor)
         self.assertEqual(cache_c.max_size, 200)
 

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -91,6 +91,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
             user_agent=b"SynapseInTrialTest/0.0.0",
             ip_allowlist=None,
             ip_blocklist=IPSet(),
+            server_name="test_server",
         )
 
         # the tests assume that we are starting at unix time 1000

--- a/tests/http/federation/test_matrix_federation_agent.py
+++ b/tests/http/federation/test_matrix_federation_agent.py
@@ -85,15 +85,20 @@ class MatrixFederationAgentTests(unittest.TestCase):
         self.tls_factory = FederationPolicyForHTTPS(config)
 
         self.well_known_cache: TTLCache[bytes, Optional[bytes]] = TTLCache(
-            "test_cache", timer=self.reactor.seconds
+            cache_name="test_cache",
+            server_name="test_server",
+            timer=self.reactor.seconds,
         )
         self.had_well_known_cache: TTLCache[bytes, bool] = TTLCache(
-            "test_cache", timer=self.reactor.seconds
+            cache_name="test_cache",
+            server_name="test_server",
+            timer=self.reactor.seconds,
         )
         self.well_known_resolver = WellKnownResolver(
             self.reactor,
             Agent(self.reactor, contextFactory=self.tls_factory),
             b"test-agent",
+            server_name="test_server",
             well_known_cache=self.well_known_cache,
             had_well_known_cache=self.had_well_known_cache,
         )
@@ -274,6 +279,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
             user_agent=b"test-agent",  # Note that this is unused since _well_known_resolver is provided.
             ip_allowlist=IPSet(),
             ip_blocklist=IPSet(),
+            server_name="test_server",
             _srv_resolver=self.mock_resolver,
             _well_known_resolver=self.well_known_resolver,
         )
@@ -1016,11 +1022,13 @@ class MatrixFederationAgentTests(unittest.TestCase):
             user_agent=b"test-agent",  # This is unused since _well_known_resolver is passed below.
             ip_allowlist=IPSet(),
             ip_blocklist=IPSet(),
+            server_name="test_server",
             _srv_resolver=self.mock_resolver,
             _well_known_resolver=WellKnownResolver(
                 cast(ISynapseReactor, self.reactor),
                 Agent(self.reactor, contextFactory=tls_factory),
                 b"test-agent",
+                server_name="test_server",
                 well_known_cache=self.well_known_cache,
                 had_well_known_cache=self.had_well_known_cache,
             ),

--- a/tests/replication/tcp/streams/test_typing.py
+++ b/tests/replication/tcp/streams/test_typing.py
@@ -139,7 +139,9 @@ class TypingStreamTestCase(BaseStreamTestCase):
         self.hs.get_replication_command_handler()._streams["typing"].last_token = 0
         typing._latest_room_serial = 0
         typing._typing_stream_change_cache = StreamChangeCache(
-            "TypingStreamChangeCache", typing._latest_room_serial
+            name="TypingStreamChangeCache",
+            server_name=self.hs.hostname,
+            current_stream_pos=typing._latest_room_serial,
         )
         typing._reset()
 

--- a/tests/replication/test_federation_sender_shard.py
+++ b/tests/replication/test_federation_sender_shard.py
@@ -73,6 +73,7 @@ class FederationSenderTestCase(BaseMultiWorkerStreamTestCase):
             user_agent=b"SynapseInTrialTest/0.0.0",
             ip_allowlist=None,
             ip_blocklist=IPSet(),
+            server_name="test_server",
         )
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:

--- a/tests/util/caches/test_response_cache.py
+++ b/tests/util/caches/test_response_cache.py
@@ -46,7 +46,9 @@ class ResponseCacheTestCase(TestCase):
         self.reactor, self.clock = get_clock()
 
     def with_cache(self, name: str, ms: int = 0) -> ResponseCache:
-        return ResponseCache(self.clock, name, timeout_ms=ms)
+        return ResponseCache(
+            clock=self.clock, name=name, server_name="test_server", timeout_ms=ms
+        )
 
     @staticmethod
     async def instant_return(o: str) -> str:

--- a/tests/util/caches/test_ttlcache.py
+++ b/tests/util/caches/test_ttlcache.py
@@ -28,7 +28,9 @@ from tests import unittest
 class CacheTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.mock_timer = Mock(side_effect=lambda: 100.0)
-        self.cache: TTLCache[str, str] = TTLCache("test_cache", self.mock_timer)
+        self.cache: TTLCache[str, str] = TTLCache(
+            cache_name="test_cache", server_name="test_server", timer=self.mock_timer
+        )
 
     def test_get(self) -> None:
         """simple set/get tests"""

--- a/tests/util/test_dict_cache.py
+++ b/tests/util/test_dict_cache.py
@@ -28,7 +28,7 @@ from tests import unittest
 class DictCacheTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.cache: DictionaryCache[str, str, str] = DictionaryCache(
-            "foobar", max_entries=10
+            name="foobar", server_name="test_server", max_entries=10
         )
 
     def test_simple_cache_hit_full(self) -> None:

--- a/tests/util/test_expiring_cache.py
+++ b/tests/util/test_expiring_cache.py
@@ -33,7 +33,10 @@ class ExpiringCacheTestCase(unittest.HomeserverTestCase):
     def test_get_set(self) -> None:
         clock = MockClock()
         cache: ExpiringCache[str, str] = ExpiringCache(
-            "test", cast(Clock, clock), max_len=1
+            cache_name="test",
+            server_name="testserver",
+            clock=cast(Clock, clock),
+            max_len=1,
         )
 
         cache["key"] = "value"
@@ -43,7 +46,10 @@ class ExpiringCacheTestCase(unittest.HomeserverTestCase):
     def test_eviction(self) -> None:
         clock = MockClock()
         cache: ExpiringCache[str, str] = ExpiringCache(
-            "test", cast(Clock, clock), max_len=2
+            cache_name="test",
+            server_name="testserver",
+            clock=cast(Clock, clock),
+            max_len=2,
         )
 
         cache["key"] = "value"
@@ -59,7 +65,11 @@ class ExpiringCacheTestCase(unittest.HomeserverTestCase):
     def test_iterable_eviction(self) -> None:
         clock = MockClock()
         cache: ExpiringCache[str, List[int]] = ExpiringCache(
-            "test", cast(Clock, clock), max_len=5, iterable=True
+            cache_name="test",
+            server_name="testserver",
+            clock=cast(Clock, clock),
+            max_len=5,
+            iterable=True,
         )
 
         cache["key"] = [1]
@@ -79,7 +89,10 @@ class ExpiringCacheTestCase(unittest.HomeserverTestCase):
     def test_time_eviction(self) -> None:
         clock = MockClock()
         cache: ExpiringCache[str, int] = ExpiringCache(
-            "test", cast(Clock, clock), expiry_ms=1000
+            cache_name="test",
+            server_name="testserver",
+            clock=cast(Clock, clock),
+            expiry_ms=1000,
         )
 
         cache["key"] = 1

--- a/tests/util/test_lrucache.py
+++ b/tests/util/test_lrucache.py
@@ -34,13 +34,13 @@ from tests.unittest import override_config
 
 class LruCacheTestCase(unittest.HomeserverTestCase):
     def test_get_set(self) -> None:
-        cache: LruCache[str, str] = LruCache(1)
+        cache: LruCache[str, str] = LruCache(max_size=1)
         cache["key"] = "value"
         self.assertEqual(cache.get("key"), "value")
         self.assertEqual(cache["key"], "value")
 
     def test_eviction(self) -> None:
-        cache: LruCache[int, int] = LruCache(2)
+        cache: LruCache[int, int] = LruCache(max_size=2)
         cache[1] = 1
         cache[2] = 2
 
@@ -54,7 +54,7 @@ class LruCacheTestCase(unittest.HomeserverTestCase):
         self.assertEqual(cache.get(3), 3)
 
     def test_setdefault(self) -> None:
-        cache: LruCache[str, int] = LruCache(1)
+        cache: LruCache[str, int] = LruCache(max_size=1)
         self.assertEqual(cache.setdefault("key", 1), 1)
         self.assertEqual(cache.get("key"), 1)
         self.assertEqual(cache.setdefault("key", 2), 1)
@@ -63,14 +63,14 @@ class LruCacheTestCase(unittest.HomeserverTestCase):
         self.assertEqual(cache.get("key"), 2)
 
     def test_pop(self) -> None:
-        cache: LruCache[str, int] = LruCache(1)
+        cache: LruCache[str, int] = LruCache(max_size=1)
         cache["key"] = 1
         self.assertEqual(cache.pop("key"), 1)
         self.assertEqual(cache.pop("key"), None)
 
     def test_del_multi(self) -> None:
         # The type here isn't quite correct as they don't handle TreeCache well.
-        cache: LruCache[Tuple[str, str], str] = LruCache(4, cache_type=TreeCache)
+        cache: LruCache[Tuple[str, str], str] = LruCache(max_size=4, cache_type=TreeCache)
         cache[("animal", "cat")] = "mew"
         cache[("animal", "dog")] = "woof"
         cache[("vehicles", "car")] = "vroom"
@@ -89,21 +89,21 @@ class LruCacheTestCase(unittest.HomeserverTestCase):
         # Man from del_multi say "Yes".
 
     def test_clear(self) -> None:
-        cache: LruCache[str, int] = LruCache(1)
+        cache: LruCache[str, int] = LruCache(max_size=1)
         cache["key"] = 1
         cache.clear()
         self.assertEqual(len(cache), 0)
 
     @override_config({"caches": {"per_cache_factors": {"mycache": 10}}})
     def test_special_size(self) -> None:
-        cache: LruCache = LruCache(10, "mycache")
+        cache: LruCache = LruCache(max_size=10, "mycache")
         self.assertEqual(cache.max_size, 100)
 
 
 class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
     def test_get(self) -> None:
         m = Mock()
-        cache: LruCache[str, str] = LruCache(1)
+        cache: LruCache[str, str] = LruCache(max_size=1)
 
         cache.set("key", "value")
         self.assertFalse(m.called)
@@ -122,7 +122,7 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
 
     def test_multi_get(self) -> None:
         m = Mock()
-        cache: LruCache[str, str] = LruCache(1)
+        cache: LruCache[str, str] = LruCache(max_size=1)
 
         cache.set("key", "value")
         self.assertFalse(m.called)
@@ -141,7 +141,7 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
 
     def test_set(self) -> None:
         m = Mock()
-        cache: LruCache[str, str] = LruCache(1)
+        cache: LruCache[str, str] = LruCache(max_size=1)
 
         cache.set("key", "value", callbacks=[m])
         self.assertFalse(m.called)
@@ -157,7 +157,7 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
 
     def test_pop(self) -> None:
         m = Mock()
-        cache: LruCache[str, str] = LruCache(1)
+        cache: LruCache[str, str] = LruCache(max_size=1)
 
         cache.set("key", "value", callbacks=[m])
         self.assertFalse(m.called)
@@ -177,7 +177,7 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
         m3 = Mock()
         m4 = Mock()
         # The type here isn't quite correct as they don't handle TreeCache well.
-        cache: LruCache[Tuple[str, str], str] = LruCache(4, cache_type=TreeCache)
+        cache: LruCache[Tuple[str, str], str] = LruCache(max_size=4, cache_type=TreeCache)
 
         cache.set(("a", "1"), "value", callbacks=[m1])
         cache.set(("a", "2"), "value", callbacks=[m2])
@@ -199,7 +199,7 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
     def test_clear(self) -> None:
         m1 = Mock()
         m2 = Mock()
-        cache: LruCache[str, str] = LruCache(5)
+        cache: LruCache[str, str] = LruCache(max_size=5)
 
         cache.set("key1", "value", callbacks=[m1])
         cache.set("key2", "value", callbacks=[m2])
@@ -216,7 +216,7 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
         m1 = Mock(name="m1")
         m2 = Mock(name="m2")
         m3 = Mock(name="m3")
-        cache: LruCache[str, str] = LruCache(2)
+        cache: LruCache[str, str] = LruCache(max_size=2)
 
         cache.set("key1", "value", callbacks=[m1])
         cache.set("key2", "value", callbacks=[m2])
@@ -252,7 +252,7 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
 
 class LruCacheSizedTestCase(unittest.HomeserverTestCase):
     def test_evict(self) -> None:
-        cache: LruCache[str, List[int]] = LruCache(5, size_callback=len)
+        cache: LruCache[str, List[int]] = LruCache(max_size=5, size_callback=len)
         cache["key1"] = [0]
         cache["key2"] = [1, 2]
         cache["key3"] = [3]
@@ -275,7 +275,7 @@ class LruCacheSizedTestCase(unittest.HomeserverTestCase):
 
     def test_zero_size_drop_from_cache(self) -> None:
         """Test that `drop_from_cache` works correctly with 0-sized entries."""
-        cache: LruCache[str, List[int]] = LruCache(5, size_callback=lambda x: 0)
+        cache: LruCache[str, List[int]] = LruCache(max_size=5, size_callback=lambda x: 0)
         cache["key1"] = []
 
         self.assertEqual(len(cache), 0)
@@ -299,7 +299,7 @@ class TimeEvictionTestCase(unittest.HomeserverTestCase):
     def test_evict(self) -> None:
         setup_expire_lru_cache_entries(self.hs)
 
-        cache: LruCache[str, int] = LruCache(5, clock=self.hs.get_clock())
+        cache: LruCache[str, int] = LruCache(max_size=5, clock=self.hs.get_clock())
 
         # Check that we evict entries we haven't accessed for 30 minutes.
         cache["key1"] = 1
@@ -351,7 +351,7 @@ class MemoryEvictionTestCase(unittest.HomeserverTestCase):
         mock_jemalloc_class.get_stat.return_value = 924288000
 
         setup_expire_lru_cache_entries(self.hs)
-        cache: LruCache[str, int] = LruCache(4, clock=self.hs.get_clock())
+        cache: LruCache[str, int] = LruCache(max_size=4, clock=self.hs.get_clock())
 
         cache["key1"] = 1
         cache["key2"] = 2
@@ -387,7 +387,7 @@ class MemoryEvictionTestCase(unittest.HomeserverTestCase):
 
 class ExtraIndexLruCacheTestCase(unittest.HomeserverTestCase):
     def test_invalidate_simple(self) -> None:
-        cache: LruCache[str, int] = LruCache(10, extra_index_cb=lambda k, v: str(v))
+        cache: LruCache[str, int] = LruCache(max_size=10, extra_index_cb=lambda k, v: str(v))
         cache["key1"] = 1
         cache["key2"] = 2
 
@@ -400,7 +400,7 @@ class ExtraIndexLruCacheTestCase(unittest.HomeserverTestCase):
         self.assertEqual(cache.get("key2"), 2)
 
     def test_invalidate_multi(self) -> None:
-        cache: LruCache[str, int] = LruCache(10, extra_index_cb=lambda k, v: str(v))
+        cache: LruCache[str, int] = LruCache(max_size=10, extra_index_cb=lambda k, v: str(v))
         cache["key1"] = 1
         cache["key2"] = 1
         cache["key3"] = 2

--- a/tests/util/test_stream_change_cache.py
+++ b/tests/util/test_stream_change_cache.py
@@ -15,7 +15,12 @@ class StreamChangeCacheTests(unittest.HomeserverTestCase):
         Providing a prefilled cache to StreamChangeCache will result in a cache
         with the prefilled-cache entered in.
         """
-        cache = StreamChangeCache("#test", 1, prefilled_cache={"user@foo.com": 2})
+        cache = StreamChangeCache(
+            name="#test",
+            server_name=self.hs.hostname,
+            current_stream_pos=1,
+            prefilled_cache={"user@foo.com": 2},
+        )
         self.assertTrue(cache.has_entity_changed("user@foo.com", 1))
 
     def test_has_entity_changed(self) -> None:
@@ -23,7 +28,9 @@ class StreamChangeCacheTests(unittest.HomeserverTestCase):
         StreamChangeCache.entity_has_changed will mark entities as changed, and
         has_entity_changed will observe the changed entities.
         """
-        cache = StreamChangeCache("#test", 3)
+        cache = StreamChangeCache(
+            name="#test", server_name=self.hs.hostname, current_stream_pos=3
+        )
 
         cache.entity_has_changed("user@foo.com", 6)
         cache.entity_has_changed("bar@baz.net", 7)
@@ -61,7 +68,9 @@ class StreamChangeCacheTests(unittest.HomeserverTestCase):
         StreamChangeCache.entity_has_changed will respect the max size and
         purge the oldest items upon reaching that max size.
         """
-        cache = StreamChangeCache("#test", 1, max_size=2)
+        cache = StreamChangeCache(
+            name="#test", server_name=self.hs.hostname, current_stream_pos=1, max_size=2
+        )
 
         cache.entity_has_changed("user@foo.com", 2)
         cache.entity_has_changed("bar@baz.net", 3)
@@ -100,7 +109,9 @@ class StreamChangeCacheTests(unittest.HomeserverTestCase):
         entities since the given position.  If the position is before the start
         of the known stream, it returns None instead.
         """
-        cache = StreamChangeCache("#test", 1)
+        cache = StreamChangeCache(
+            name="#test", server_name=self.hs.hostname, current_stream_pos=1
+        )
 
         cache.entity_has_changed("user@foo.com", 2)
         cache.entity_has_changed("bar@baz.net", 3)
@@ -148,7 +159,9 @@ class StreamChangeCacheTests(unittest.HomeserverTestCase):
         stream position is before it, it will return True, otherwise False if
         the cache has no entries.
         """
-        cache = StreamChangeCache("#test", 1)
+        cache = StreamChangeCache(
+            name="#test", server_name=self.hs.hostname, current_stream_pos=1
+        )
 
         # With no entities, it returns True for the past, present, and False for
         # the future.
@@ -175,7 +188,9 @@ class StreamChangeCacheTests(unittest.HomeserverTestCase):
         stream position is earlier than the earliest known position, it will
         return all of the entities queried for.
         """
-        cache = StreamChangeCache("#test", 1)
+        cache = StreamChangeCache(
+            name="#test", server_name=self.hs.hostname, current_stream_pos=1
+        )
 
         cache.entity_has_changed("user@foo.com", 2)
         cache.entity_has_changed("bar@baz.net", 3)
@@ -242,7 +257,9 @@ class StreamChangeCacheTests(unittest.HomeserverTestCase):
         recent point where the entity could have changed.  If the entity is not
         known, the stream start is provided instead.
         """
-        cache = StreamChangeCache("#test", 1)
+        cache = StreamChangeCache(
+            name="#test", server_name=self.hs.hostname, current_stream_pos=1
+        )
 
         cache.entity_has_changed("user@foo.com", 2)
         cache.entity_has_changed("bar@baz.net", 3)
@@ -260,7 +277,12 @@ class StreamChangeCacheTests(unittest.HomeserverTestCase):
         """
         `StreamChangeCache.all_entities_changed(...)` will mark all entites as changed.
         """
-        cache = StreamChangeCache("#test", 1, max_size=10)
+        cache = StreamChangeCache(
+            name="#test",
+            server_name=self.hs.hostname,
+            current_stream_pos=1,
+            max_size=10,
+        )
 
         cache.entity_has_changed("user@foo.com", 2)
         cache.entity_has_changed("bar@baz.net", 3)


### PR DESCRIPTION
Refactor cache metrics to be homeserver-scoped

Part of https://github.com/element-hq/synapse/issues/18592



### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
