### PR TITLE
Skip processing policy server events through policy server

### DIFF
--- a/synapse/handlers/room_policy.py
+++ b/synapse/handlers/room_policy.py
@@ -54,6 +54,9 @@ class RoomPolicyHandler:
         Returns:
             bool: True if the event is allowed in the room, False otherwise.
         """
+        if event.type == "org.matrix.msc4284.policy":
+            return True  # always allow policy server change events
+
         policy_event = await self._storage_controllers.state.get_current_state_event(
             event.room_id, "org.matrix.msc4284.policy", ""
         )


### PR DESCRIPTION
This is to (primarily) allow a room to disable the policy server while it is down.

See https://github.com/matrix-org/matrix-spec-proposals/pull/4284/files#r2070860418 for related thoughts.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
