### PR TITLE
Update `latest_deps` workflow to migrate `poetry --no-dev` -> `--without dev`

### DIFF
--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -55,7 +55,7 @@ jobs:
       - run: poetry run pip list > before.txt
       # Upgrade all runtime dependencies only. This is intended to mimic a fresh
       # `pip install matrix-synapse[all]` as closely as possible.
-      - run: poetry update --no-dev
+      - run: poetry update --without dev
       - run: poetry run pip list > after.txt && (diff -u before.txt after.txt || true)
       - name: Remove unhelpful options from mypy config
         run: sed -e '/warn_unused_ignores = True/d' -e '/warn_redundant_casts = True/d' -i mypy.ini

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,7 +224,7 @@ pydantic = ">=1.7.4, <3"
 # https://github.com/python-poetry/poetry/issues/6154). Both `pip install` and
 # `poetry build` do the right thing without this explicit dependency.
 #
-# This isn't really a dev-dependency, as `poetry install --no-dev` will fail,
+# This isn't really a dev-dependency, as `poetry install --without dev` will fail,
 # but the alternative is to add it to the main list of deps where it isn't
 # needed.
 setuptools_rust = ">=1.3"

--- a/synapse/util/check_dependencies.py
+++ b/synapse/util/check_dependencies.py
@@ -74,7 +74,7 @@ def _is_dev_dependency(req: Requirement) -> bool:
 def _should_ignore_runtime_requirement(req: Requirement) -> bool:
     # This is a build-time dependency. Irritatingly, `poetry build` ignores the
     # requirements listed in the [build-system] section of pyproject.toml, so in order
-    # to support `poetry install --no-dev` we have to mark it as a runtime dependency.
+    # to support `poetry install --without dev` we have to mark it as a runtime dependency.
     # See discussion on https://github.com/python-poetry/poetry/issues/6154 (it sounds
     # like the poetry authors don't consider this a bug?)
     #


### PR DESCRIPTION
poetry dropped the `--no-dev` cli option in recent poetry versions. This was causing the nightly latest deps CI workflow to fail: https://github.com/element-hq/synapse/issues/16083

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
