### PR TITLE
Update URL Preview code to work with `lxml` 6.0.0

### DIFF
--- a/changelog.d/18622.misc
+++ b/changelog.d/18622.misc
@@ -1,0 +1,1 @@
+Update URL Preview code to work with `lxml` 6.0.0+.


### PR DESCRIPTION
Addresses https://github.com/element-hq/synapse/issues/16083.

Updates `decode_body` in the URL previewing code to support the new behaviour of lxml, where if `etree.fromstring` fails to decode an HTML page, it now returns an empty HTML Tree instead of `None`.

That "empty" HTML tree contains a single `<body>` tag that contains the content that it failed to parse (i.e. `�` characters).

Tests now pass on both `lxml` 5.4.0 and 6.0.0. Annoyingly [the changelog](https://lxml.de/6.0/changes-6.0.0.html) didn't mention this behaviour change, and there doesn't appear to be an option to restore the previous functionality.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
