### PR TITLE
Add `.zed/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ __pycache__/
 /.idea/
 /.ropeproject/
 /.vscode/
+/.zed/
 
 # build products
 !/.coveragerc

--- a/changelog.d/18623.misc
+++ b/changelog.d/18623.misc
@@ -1,0 +1,1 @@
+Add `.zed/` directory to `.gitignore`.


### PR DESCRIPTION
Prevents local modifications to [the Zed Editor](https://zed.dev/) from appearing in unstaged git changes.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
