### PR TITLE
Don't allow tagnames longer than 255 bytes

### DIFF
--- a/synapse/rest/client/tags.py
+++ b/synapse/rest/client/tags.py
@@ -20,9 +20,10 @@
 #
 
 import logging
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Tuple
 
-from synapse.api.errors import AuthError
+from synapse.api.errors import AuthError, Codes, SynapseError
 from synapse.http.server import HttpServer
 from synapse.http.servlet import RestServlet, parse_json_object_from_request
 from synapse.http.site import SynapseRequest
@@ -86,6 +87,16 @@ class TagServlet(RestServlet):
         requester = await self.auth.get_user_by_req(request)
         if user_id != requester.user.to_string():
             raise AuthError(403, "Cannot add tags for other users.")
+
+        # check if the tag exceeds the length allowed by the matrix-specification
+        # as defined in: https://spec.matrix.org/v1.15/client-server-api/#events-14
+        if len(tag) > 255:
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST,
+                "tag parameter's length is over 255 bytes",
+                errcode=Codes.INVALID_PARAM,
+            )
+
         # Check if the user has any membership in the room and raise error if not.
         # Although it's not harmful for users to tag random rooms, it's just superfluous
         # data we don't need to track or allow.

--- a/tests/rest/client/test_tags.py
+++ b/tests/rest/client/test_tags.py
@@ -93,3 +93,24 @@ class RoomTaggingTestCase(unittest.HomeserverTestCase):
         )
         # Check that the request failed with the correct error
         self.assertEqual(channel.code, HTTPStatus.FORBIDDEN, channel.result)
+
+    def test_put_tag_fails_if_tag_is_too_long(self) -> None:
+        """
+        Test that a user cannot add a tag to a room that is longer than allowed by the
+        matrix specification.
+        """
+        user1_id = self.register_user("user1", "pass")
+        user1_tok = self.login(user1_id, "pass")
+        room_id = self.helper.create_room_as(user1_id, tok=user1_tok)
+        # create a string which is larger than 255 bytes
+        tag = "X" * 300
+
+        # Make the request
+        channel = self.make_request(
+            "PUT",
+            f"/user/{user1_id}/rooms/{room_id}/tags/{tag}",
+            content={"order": 0.5},
+            access_token=user1_tok,
+        )
+        # Check that the request failed
+        self.assertEqual(channel.code, HTTPStatus.BAD_REQUEST, channel.result)


### PR DESCRIPTION
If a user tries to add a tag with a length of over 255 bytes return BAD_REQUEST, since this is not allowed by the matrix specification.
(see: https://spec.matrix.org/v1.15/client-server-api/#events-14)

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
