### PR TITLE
Document config file merge behavior

### DIFF
--- a/changelog.d/18664.misc
+++ b/changelog.d/18664.misc
@@ -1,0 +1,1 @@
+Add doc comment explaining that config files are shallowly merged.

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -909,7 +909,10 @@ class RootConfig:
 
 
 def read_config_files(config_files: Iterable[str]) -> Dict[str, Any]:
-    """Read the config files into a dict
+    """Read the config files and shallowly merge them into a dict.
+
+    Successive configurations are shallowly merged into ones provided earlier,
+    i.e., entirely replacing top-level sections of the configuration.
 
     Args:
         config_files: A list of the config files to read


### PR DESCRIPTION
Explains in the doc comment of `synapse.config._base.read_config_file` how config files are merged.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
