### PR TITLE
Speed up inserting into stream_positions

### DIFF
--- a/changelog.d/18672.misc
+++ b/changelog.d/18672.misc
@@ -1,0 +1,1 @@
+Minor speed up of insertion into `stream_positions` table.

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -794,20 +794,16 @@ class MultiWriterIdGenerator(AbstractStreamIdGenerator):
 
         # We upsert the value, ensuring on conflict that we always increase the
         # value (or decrease if stream goes backwards).
-        if isinstance(self._db.engine, PostgresEngine):
-            agg = "GREATEST" if self._positive else "LEAST"
-        else:
-            agg = "MAX" if self._positive else "MIN"
+        cmp = "<" if self._positive else ">"
 
-        sql = """
+        sql = f"""
             INSERT INTO stream_positions (stream_name, instance_name, stream_id)
             VALUES (?, ?, ?)
             ON CONFLICT (stream_name, instance_name)
             DO UPDATE SET
-                stream_id = %(agg)s(stream_positions.stream_id, EXCLUDED.stream_id)
-        """ % {
-            "agg": agg,
-        }
+                stream_id = EXCLUDED.stream_id
+                WHERE stream_positions.stream_id {cmp} EXCLUDED.stream_id
+        """
 
         pos = self.get_current_token_for_writer(self._instance_name)
         txn.execute(sql, (self._stream_name, self._instance_name, pos))


### PR DESCRIPTION
By ensuring we don't do a no-op `UPDATE`, as this causes new tuples to be written in postgres.