### PR TITLE
Remove `allow_no_prev_events` option

### DIFF
--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -568,7 +568,6 @@ class EventCreationHandler:
         requester: Requester,
         event_dict: dict,
         txn_id: Optional[str] = None,
-        allow_no_prev_events: bool = False,
         prev_event_ids: Optional[List[str]] = None,
         auth_event_ids: Optional[List[str]] = None,
         state_event_ids: Optional[List[str]] = None,
@@ -594,10 +593,6 @@ class EventCreationHandler:
             requester
             event_dict: An entire event
             txn_id
-            allow_no_prev_events: Whether to allow this event to be created an empty
-                list of prev_events. Normally this is prohibited just because most
-                events should have a prev_event and we should only use this in special
-                cases (previously useful for MSC2716).
             prev_event_ids:
                 the forward extremities to use as the prev_events for the
                 new event.
@@ -717,7 +712,6 @@ class EventCreationHandler:
         event, unpersisted_context = await self.create_new_client_event(
             builder=builder,
             requester=requester,
-            allow_no_prev_events=allow_no_prev_events,
             prev_event_ids=prev_event_ids,
             auth_event_ids=auth_event_ids,
             state_event_ids=state_event_ids,
@@ -945,7 +939,6 @@ class EventCreationHandler:
         self,
         requester: Requester,
         event_dict: dict,
-        allow_no_prev_events: bool = False,
         prev_event_ids: Optional[List[str]] = None,
         state_event_ids: Optional[List[str]] = None,
         ratelimit: bool = True,
@@ -962,10 +955,6 @@ class EventCreationHandler:
         Args:
             requester: The requester sending the event.
             event_dict: An entire event.
-            allow_no_prev_events: Whether to allow this event to be created an empty
-                list of prev_events. Normally this is prohibited just because most
-                events should have a prev_event and we should only use this in special
-                cases (previously useful for MSC2716).
             prev_event_ids:
                 The event IDs to use as the prev events.
                 Should normally be left as None to automatically request them
@@ -1051,7 +1040,6 @@ class EventCreationHandler:
             return await self._create_and_send_nonmember_event_locked(
                 requester=requester,
                 event_dict=event_dict,
-                allow_no_prev_events=allow_no_prev_events,
                 prev_event_ids=prev_event_ids,
                 state_event_ids=state_event_ids,
                 ratelimit=ratelimit,
@@ -1065,7 +1053,6 @@ class EventCreationHandler:
         self,
         requester: Requester,
         event_dict: dict,
-        allow_no_prev_events: bool = False,
         prev_event_ids: Optional[List[str]] = None,
         state_event_ids: Optional[List[str]] = None,
         ratelimit: bool = True,
@@ -1097,7 +1084,6 @@ class EventCreationHandler:
                     requester,
                     event_dict,
                     txn_id=txn_id,
-                    allow_no_prev_events=allow_no_prev_events,
                     prev_event_ids=prev_event_ids,
                     state_event_ids=state_event_ids,
                     outlier=outlier,
@@ -1180,7 +1166,6 @@ class EventCreationHandler:
         self,
         builder: EventBuilder,
         requester: Optional[Requester] = None,
-        allow_no_prev_events: bool = False,
         prev_event_ids: Optional[List[str]] = None,
         auth_event_ids: Optional[List[str]] = None,
         state_event_ids: Optional[List[str]] = None,
@@ -1200,10 +1185,6 @@ class EventCreationHandler:
         Args:
             builder:
             requester:
-            allow_no_prev_events: Whether to allow this event to be created an empty
-                list of prev_events. Normally this is prohibited just because most
-                events should have a prev_event and we should only use this in special
-                cases (previously useful for MSC2716).
             prev_event_ids:
                 the forward extremities to use as the prev_events for the
                 new event.
@@ -1269,24 +1250,14 @@ class EventCreationHandler:
         else:
             prev_event_ids = await self.store.get_prev_events_for_room(builder.room_id)
 
+        # We now ought to have some `prev_events` (unless it's a create event).
+        #
         # Do a quick sanity check here, rather than waiting until we've created the
         # event and then try to auth it (which fails with a somewhat confusing "No
         # create event in auth events")
-        if allow_no_prev_events:
-            # We allow events with no `prev_events` but it better have some `auth_events`
-            assert (
-                builder.type == EventTypes.Create
-                # Allow an event to have empty list of prev_event_ids
-                # only if it has auth_event_ids.
-                or auth_event_ids
-            ), (
-                "Attempting to create a non-m.room.create event with no prev_events or auth_event_ids"
-            )
-        else:
-            # we now ought to have some prev_events (unless it's a create event).
-            assert builder.type == EventTypes.Create or prev_event_ids, (
-                "Attempting to create a non-m.room.create event with no prev_events"
-            )
+        assert builder.type == EventTypes.Create or len(prev_event_ids) > 0, (
+            "Attempting to create an event with no prev_events"
+        )
 
         if for_batch:
             assert prev_event_ids is not None

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -388,11 +388,11 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
 
     async def _local_membership_update(
         self,
+        *,
         requester: Requester,
         target: UserID,
         room_id: str,
         membership: str,
-        allow_no_prev_events: bool = False,
         prev_event_ids: Optional[List[str]] = None,
         state_event_ids: Optional[List[str]] = None,
         depth: Optional[int] = None,
@@ -414,11 +414,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                 desired membership event.
             room_id:
             membership:
-
-            allow_no_prev_events: Whether to allow this event to be created an empty
-                list of prev_events. Normally this is prohibited just because most
-                events should have a prev_event and we should only use this in special
-                cases (previously useful for MSC2716).
             prev_event_ids: The event IDs to use as the prev events
             state_event_ids:
                 The full state at a given event. This was previously used particularly
@@ -486,7 +481,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                         "origin_server_ts": origin_server_ts,
                     },
                     txn_id=txn_id,
-                    allow_no_prev_events=allow_no_prev_events,
                     prev_event_ids=prev_event_ids,
                     state_event_ids=state_event_ids,
                     depth=depth,
@@ -583,7 +577,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         new_room: bool = False,
         require_consent: bool = True,
         outlier: bool = False,
-        allow_no_prev_events: bool = False,
         prev_event_ids: Optional[List[str]] = None,
         state_event_ids: Optional[List[str]] = None,
         depth: Optional[int] = None,
@@ -607,10 +600,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             outlier: Indicates whether the event is an `outlier`, i.e. if
                 it's from an arbitrary point and floating in the DAG as
                 opposed to being inline with the current DAG.
-            allow_no_prev_events: Whether to allow this event to be created an empty
-                list of prev_events. Normally this is prohibited just because most
-                events should have a prev_event and we should only use this in special
-                cases (previously useful for MSC2716).
             prev_event_ids: The event IDs to use as the prev events
             state_event_ids:
                 The full state at a given event. This was previously used particularly
@@ -680,7 +669,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                             new_room=new_room,
                             require_consent=require_consent,
                             outlier=outlier,
-                            allow_no_prev_events=allow_no_prev_events,
                             prev_event_ids=prev_event_ids,
                             state_event_ids=state_event_ids,
                             depth=depth,
@@ -703,7 +691,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         new_room: bool = False,
         require_consent: bool = True,
         outlier: bool = False,
-        allow_no_prev_events: bool = False,
         prev_event_ids: Optional[List[str]] = None,
         state_event_ids: Optional[List[str]] = None,
         depth: Optional[int] = None,
@@ -729,10 +716,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             outlier: Indicates whether the event is an `outlier`, i.e. if
                 it's from an arbitrary point and floating in the DAG as
                 opposed to being inline with the current DAG.
-            allow_no_prev_events: Whether to allow this event to be created an empty
-                list of prev_events. Normally this is prohibited just because most
-                events should have a prev_event and we should only use this in special
-                cases (previously useful for MSC2716).
             prev_event_ids: The event IDs to use as the prev events
             state_event_ids:
                 The full state at a given event. This was previously used particularly
@@ -942,7 +925,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                 membership=effective_membership_state,
                 txn_id=txn_id,
                 ratelimit=ratelimit,
-                allow_no_prev_events=allow_no_prev_events,
                 prev_event_ids=prev_event_ids,
                 state_event_ids=state_event_ids,
                 depth=depth,

--- a/tests/handlers/test_message.py
+++ b/tests/handlers/test_message.py
@@ -204,46 +204,19 @@ class EventCreationTestCase(unittest.HomeserverTestCase):
         self.assertEqual(len(events), 2)
         self.assertEqual(events[0].event_id, events[1].event_id)
 
-    def test_when_empty_prev_events_allowed_create_event_with_empty_prev_events(
+    def test_reject_event_with_empty_prev_events(
         self,
     ) -> None:
-        """When we set allow_no_prev_events=True, should be able to create a
-        event without any prev_events (only auth_events).
         """
-        # Create a member event we can use as an auth_event
-        memberEvent, _ = self._create_and_persist_member_event()
-
-        # Try to create the event with empty prev_events bit with some auth_events
-        event, _ = self.get_success(
-            self.handler.create_event(
-                self.requester,
-                {
-                    "type": EventTypes.Message,
-                    "room_id": self.room_id,
-                    "sender": self.requester.user.to_string(),
-                    "content": {"msgtype": "m.text", "body": random_string(5)},
-                },
-                # Empty prev_events is the key thing we're testing here
-                prev_event_ids=[],
-                # But with some auth_events
-                auth_event_ids=[memberEvent.event_id],
-                # Allow no prev_events!
-                allow_no_prev_events=True,
-            )
-        )
-        self.assertIsNotNone(event)
-
-    def test_when_empty_prev_events_not_allowed_reject_event_with_empty_prev_events(
-        self,
-    ) -> None:
-        """When we set allow_no_prev_events=False, shouldn't be able to create a
-        event without any prev_events even if it has auth_events. Expect an
-        exception to be raised.
+        Shouldn't be able to create an event without any `prev_events` even if it has
+        `auth_events`. Expect an exception to be raised.
         """
         # Create a member event we can use as an auth_event
         memberEvent, _ = self._create_and_persist_member_event()
 
         # Try to create the event with empty prev_events but with some auth_events
+        #
+        # We expect the test to fail because empty prev_events are not allowed
         self.get_failure(
             self.handler.create_event(
                 self.requester,
@@ -257,35 +230,6 @@ class EventCreationTestCase(unittest.HomeserverTestCase):
                 prev_event_ids=[],
                 # But with some auth_events
                 auth_event_ids=[memberEvent.event_id],
-                # We expect the test to fail because empty prev_events are not
-                # allowed here!
-                allow_no_prev_events=False,
-            ),
-            AssertionError,
-        )
-
-    def test_when_empty_prev_events_allowed_reject_event_with_empty_prev_events_and_auth_events(
-        self,
-    ) -> None:
-        """When we set allow_no_prev_events=True, should be able to create a
-        event without any prev_events or auth_events. Expect an exception to be
-        raised.
-        """
-        # Try to create the event with empty prev_events and empty auth_events
-        self.get_failure(
-            self.handler.create_event(
-                self.requester,
-                {
-                    "type": EventTypes.Message,
-                    "room_id": self.room_id,
-                    "sender": self.requester.user.to_string(),
-                    "content": {"msgtype": "m.text", "body": random_string(5)},
-                },
-                prev_event_ids=[],
-                # The event should be rejected when there are no auth_events
-                auth_event_ids=[],
-                # Allow no prev_events!
-                allow_no_prev_events=True,
             ),
             AssertionError,
         )


### PR DESCRIPTION
Remove `allow_no_prev_events` option. This option is no longer used since we backed out the MSC2716 changes in https://github.com/matrix-org/synapse/pull/15748 and is even mentioned as a follow-up task in the PR description there.

The `allow_no_prev_events` option was first introduced in https://github.com/matrix-org/synapse/pull/11243 to support MSC2716 back in the day.


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
