### PR TITLE
Correct version that `recaptcha_{private,public}_key_path` config options were introduced

### DIFF
--- a/changelog.d/18684.feature
+++ b/changelog.d/18684.feature
@@ -1,0 +1,1 @@
+Add `recaptcha_private_key_path` and `recaptcha_public_key_path` config option.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -2363,7 +2363,7 @@ recaptcha_public_key: YOUR_PUBLIC_KEY
 
 The file should be a plain text file, containing only the public key. Synapse reads the public key from the given file once at startup.
 
-_Added in Synapse 1.134.0._
+_Added in Synapse 1.135.0._
 
 Defaults to `null`.
 
@@ -2387,7 +2387,7 @@ recaptcha_private_key: YOUR_PRIVATE_KEY
 
 The file should be a plain text file, containing only the private key. Synapse reads the private key from the given file once at startup.
 
-_Added in Synapse 1.134.0._
+_Added in Synapse 1.135.0._
 
 Defaults to `null`.
 

--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -2703,7 +2703,7 @@ properties:
       Synapse reads the public key from the given file once at startup.
 
 
-      _Added in Synapse 1.134.0._
+      _Added in Synapse 1.135.0._
     default: null
     examples:
       - /path/to/key/file
@@ -2726,7 +2726,7 @@ properties:
       Synapse reads the private key from the given file once at startup.
 
 
-      _Added in Synapse 1.134.0._
+      _Added in Synapse 1.135.0._
     default: null
     examples:
       - /path/to/key/file


### PR DESCRIPTION
Correct version that `recaptcha_{private,public}_key_path` config options were introduced

Introduced in https://github.com/element-hq/synapse/pull/17984

I already see a [`v1.134.0rc1`](https://github.com/element-hq/synapse/releases/tag/v1.134.0rc1) tag from 5 days ago so I assume https://github.com/element-hq/synapse/pull/17984 will actually ship in the next release (which will be `v1.135.0`)

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
