### PR TITLE
Allow return code 403 when fetching profile via federation

### DIFF
--- a/changelog.d/18696.bugfix
+++ b/changelog.d/18696.bugfix
@@ -1,0 +1,1 @@
+Allow return code 403 (allowed by C2S Spec since v1.2) when fetching profiles via federation.

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -124,7 +124,7 @@ class ProfileHandler:
             except RequestSendFailed as e:
                 raise SynapseError(502, "Failed to fetch profile") from e
             except HttpResponseException as e:
-                if e.code < 500 and e.code not in (403,404):
+                if e.code < 500 and e.code not in (403, 404):
                     # Other codes are not allowed in c2s API
                     logger.info(
                         "Server replied with wrong response: %s %s", e.code, e.msg

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -124,7 +124,7 @@ class ProfileHandler:
             except RequestSendFailed as e:
                 raise SynapseError(502, "Failed to fetch profile") from e
             except HttpResponseException as e:
-                if e.code < 500 and e.code != 404:
+                if e.code < 500 and e.code not in (403,404):
                     # Other codes are not allowed in c2s API
                     logger.info(
                         "Server replied with wrong response: %s %s", e.code, e.msg


### PR DESCRIPTION
According to the [Matrix c2s spec](https://spec.matrix.org/v1.2/client-server-api/#profiles), returning code 403 is allowed when querying a user profile.

When remote Synapse server admins choose to set ` allow_profile_lookup_over_federation: false`, your local synapse would send error 502 when a profile is queried over federation during Invitation (and no shared room exists yet). This would cause the Element client to error out without any possibility to recover.

Although there exists a workaround for element (not necessary with some other clients), this is unfortunately not the default.

Fixes #18425 
Fixes #18280 
Fixes #18504

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
