### PR TITLE
Reduce database usage in Sliding Sync by not querying for background update completion after the update is known to be complete.

### DIFF
--- a/changelog.d/18718.misc
+++ b/changelog.d/18718.misc
@@ -1,0 +1,1 @@
+Reduce database usage in Sliding Sync by not querying for background update completion after the update is known to be complete.

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -364,9 +364,11 @@ class EventsWorkerStore(SQLBaseStore):
             replaces_index="event_txn_id_device_id_txn_id",
         )
 
-        # Flag to track when the sliding sync background jobs have
-        # finished (so we don't have to keep querying it every time)
         self._has_finished_sliding_sync_background_jobs = False
+        """
+        Flag to track when the sliding sync background jobs have
+        finished (so we don't have to keep querying it every time)
+        """
 
     def get_un_partial_stated_events_token(self, instance_name: str) -> int:
         return (


### PR DESCRIPTION
I noticed this transaction was the top txn by rate on our sliding sync workers,
plus responsible for about 5~10% of database time.

But mostly it'd just makes the database dashboard cleaner not to have this.

<ol>
<li>

Stop querying for background job completeness once they are complete 

</li>
</ol>
