### PR TITLE
MSC4306: register the thread subscriptions servlet in the client servlet section

### DIFF
--- a/changelog.d/18726.bugfix
+++ b/changelog.d/18726.bugfix
@@ -1,0 +1,1 @@
+Register the MSC4306 endpoints in the CS API when the experimental feature is enabled.

--- a/synapse/rest/__init__.py
+++ b/synapse/rest/__init__.py
@@ -63,6 +63,7 @@ from synapse.rest.client import (
     sync,
     tags,
     thirdparty,
+    thread_subscriptions,
     tokenrefresh,
     user_directory,
     versions,
@@ -122,6 +123,7 @@ CLIENT_SERVLET_FUNCTIONS: Tuple[RegisterServletsFunc, ...] = (
     login_token_request.register_servlets,
     rendezvous.register_servlets,
     auth_metadata.register_servlets,
+    thread_subscriptions.register_servlets,
 )
 
 SERVLET_GROUPS: Dict[str, Iterable[RegisterServletsFunc]] = {

--- a/synapse/rest/client/thread_subscriptions.py
+++ b/synapse/rest/client/thread_subscriptions.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Tuple
+from typing import TYPE_CHECKING, Tuple
 
 from synapse._pydantic_compat import StrictBool
 from synapse.api.errors import Codes, NotFoundError, SynapseError
@@ -10,9 +10,11 @@ from synapse.http.servlet import (
 )
 from synapse.http.site import SynapseRequest
 from synapse.rest.client._base import client_patterns
-from synapse.server import HomeServer
 from synapse.types import JsonDict, RoomID
 from synapse.types.rest import RequestBodyModel
+
+if TYPE_CHECKING:
+    from synapse.server import HomeServer
 
 
 class ThreadSubscriptionsRestServlet(RestServlet):


### PR DESCRIPTION
The MSC4306 endpoints were never registered, and thus never made available, even if the experimental feature flag was enabled.