### PR TITLE
Use `twisted.internet.testing` module in tests instead of deprecated `twisted.test.proto_helpers`.

### DIFF
--- a/changelog.d/18728.misc
+++ b/changelog.d/18728.misc
@@ -1,0 +1,1 @@
+Use `twisted.internet.testing` module in tests instead of deprecated `twisted.test.proto_helpers`.

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -23,7 +23,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pymacaroons
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.auth.internal import InternalAuth
 from synapse.api.auth_blocking import AuthBlocking

--- a/tests/api/test_filtering.py
+++ b/tests/api/test_filtering.py
@@ -25,7 +25,7 @@ from unittest.mock import patch
 
 import jsonschema
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EduTypes, EventContentFields
 from synapse.api.errors import SynapseError

--- a/tests/api/test_urls.py
+++ b/tests/api/test_urls.py
@@ -13,7 +13,7 @@
 #
 
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.urls import LoginSSORedirectURIBuilder
 from synapse.server import HomeServer

--- a/tests/app/test_openid_listener.py
+++ b/tests/app/test_openid_listener.py
@@ -22,7 +22,7 @@ from unittest.mock import Mock, patch
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.app.generic_worker import GenericWorkerServer
 from synapse.app.homeserver import SynapseHomeServer

--- a/tests/appservice/test_api.py
+++ b/tests/appservice/test_api.py
@@ -21,7 +21,7 @@
 from typing import Any, List, Mapping, Optional, Sequence, Union
 from unittest.mock import Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.appservice import ApplicationService
 from synapse.server import HomeServer

--- a/tests/appservice/test_scheduler.py
+++ b/tests/appservice/test_scheduler.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, Mock
 from typing_extensions import TypeAlias
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.appservice import (
     ApplicationService,

--- a/tests/config/test_room_directory.py
+++ b/tests/config/test_room_directory.py
@@ -19,7 +19,7 @@
 #
 import yaml
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 import synapse.rest.client.login

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -31,7 +31,7 @@ from signedjson.types import SigningKey, VerifyKey
 
 from twisted.internet import defer
 from twisted.internet.defer import Deferred, ensureDeferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import SynapseError
 from synapse.crypto import keyring

--- a/tests/events/test_auto_accept_invites.py
+++ b/tests/events/test_auto_accept_invites.py
@@ -27,7 +27,7 @@ from unittest.mock import Mock
 import attr
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes
 from synapse.api.errors import SynapseError

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -23,7 +23,7 @@ from unittest.mock import AsyncMock, Mock
 
 import attr
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EduTypes
 from synapse.events.presence_router import PresenceRouter, load_legacy_presence_router

--- a/tests/events/test_snapshot.py
+++ b/tests/events/test_snapshot.py
@@ -19,7 +19,7 @@
 #
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.events import EventBase
 from synapse.events.snapshot import EventContext

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -2,7 +2,7 @@ from typing import Callable, Collection, List, Optional, Tuple
 from unittest import mock
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes
 from synapse.events import EventBase

--- a/tests/federation/test_federation_client.py
+++ b/tests/federation/test_federation_client.py
@@ -23,7 +23,7 @@ from unittest import mock
 
 import twisted.web.client
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.room_versions import RoomVersions
 from synapse.events import EventBase

--- a/tests/federation/test_federation_devices.py
+++ b/tests/federation/test_federation_devices.py
@@ -21,7 +21,7 @@
 import logging
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.handlers.device import DeviceListUpdater
 from synapse.server import HomeServer

--- a/tests/federation/test_federation_media.py
+++ b/tests/federation/test_federation_media.py
@@ -22,7 +22,7 @@ import os
 import shutil
 import tempfile
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.media.filepath import MediaFilePaths
 from synapse.media.media_storage import MediaStorage

--- a/tests/federation/test_federation_out_of_band_membership.py
+++ b/tests/federation/test_federation_out_of_band_membership.py
@@ -29,7 +29,7 @@ from unittest.mock import Mock
 import attr
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventContentFields, EventTypes, Membership
 from synapse.api.room_versions import RoomVersion, RoomVersions

--- a/tests/federation/test_federation_sender.py
+++ b/tests/federation/test_federation_sender.py
@@ -24,7 +24,7 @@ from signedjson import key, sign
 from signedjson.types import BaseKey, SigningKey
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EduTypes, RoomEncryptionAlgorithms
 from synapse.api.presence import UserPresenceState

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -25,7 +25,7 @@ from unittest.mock import Mock
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes, Membership
 from synapse.api.errors import FederationError

--- a/tests/federation/transport/test_knocking.py
+++ b/tests/federation/transport/test_knocking.py
@@ -21,7 +21,7 @@
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes, JoinRules, Membership
 from synapse.api.room_versions import RoomVersion, RoomVersions

--- a/tests/handlers/test_admin.py
+++ b/tests/handlers/test_admin.py
@@ -22,7 +22,7 @@
 from collections import Counter
 from unittest.mock import Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 import synapse.storage

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -25,7 +25,7 @@ from unittest.mock import AsyncMock, Mock
 from parameterized import parameterized
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 import synapse.storage

--- a/tests/handlers/test_auth.py
+++ b/tests/handlers/test_auth.py
@@ -23,7 +23,7 @@ from unittest.mock import AsyncMock
 
 import pymacaroons
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import AuthError, ResourceLimitError
 from synapse.rest import admin

--- a/tests/handlers/test_cas.py
+++ b/tests/handlers/test_cas.py
@@ -21,7 +21,7 @@
 from typing import Any, Dict
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.handlers.cas import CasResponse
 from synapse.server import HomeServer

--- a/tests/handlers/test_deactivate_account.py
+++ b/tests/handlers/test_deactivate_account.py
@@ -19,7 +19,7 @@
 #
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import AccountDataTypes, EventTypes, JoinRules, Membership
 from synapse.push.rulekinds import PRIORITY_CLASS_MAP

--- a/tests/handlers/test_device.py
+++ b/tests/handlers/test_device.py
@@ -24,7 +24,7 @@ from typing import Optional
 from unittest import mock
 
 from twisted.internet.defer import ensureDeferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import RoomEncryptionAlgorithms
 from synapse.api.errors import NotFoundError, SynapseError

--- a/tests/handlers/test_directory.py
+++ b/tests/handlers/test_directory.py
@@ -22,7 +22,7 @@
 from typing import Any, Awaitable, Callable, Dict
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.api.errors
 import synapse.rest.admin

--- a/tests/handlers/test_e2e_keys.py
+++ b/tests/handlers/test_e2e_keys.py
@@ -26,7 +26,7 @@ from unittest import mock
 from parameterized import parameterized
 from signedjson import key as key, sign as sign
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import RoomEncryptionAlgorithms
 from synapse.api.errors import Codes, SynapseError

--- a/tests/handlers/test_e2e_room_keys.py
+++ b/tests/handlers/test_e2e_room_keys.py
@@ -23,7 +23,7 @@
 import copy
 from unittest import mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import SynapseError
 from synapse.server import HomeServer

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -24,7 +24,7 @@ from unittest import TestCase
 from unittest.mock import AsyncMock, Mock, patch
 
 from twisted.internet.defer import Deferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes
 from synapse.api.errors import (

--- a/tests/handlers/test_federation_event.py
+++ b/tests/handlers/test_federation_event.py
@@ -21,7 +21,7 @@
 from typing import Optional
 from unittest import mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import AuthError, StoreError
 from synapse.api.room_versions import RoomVersion

--- a/tests/handlers/test_message.py
+++ b/tests/handlers/test_message.py
@@ -21,7 +21,7 @@
 import logging
 from typing import Tuple
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes
 from synapse.api.errors import SynapseError

--- a/tests/handlers/test_oauth_delegation.py
+++ b/tests/handlers/test_oauth_delegation.py
@@ -33,7 +33,7 @@ from signedjson.key import (
 )
 from signedjson.sign import sign_json
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import (
     AuthError,

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -25,7 +25,7 @@ from urllib.parse import parse_qs, urlparse
 
 import pymacaroons
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.handlers.sso import MappingException
 from synapse.http.site import SynapseRequest

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -25,7 +25,7 @@ from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Type, Union
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse
 from synapse.api.constants import LoginType

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -29,7 +29,7 @@ from signedjson.key import (
     get_verify_key,
 )
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes, Membership, PresenceState
 from synapse.api.presence import UserDevicePresenceState, UserPresenceState

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -23,7 +23,7 @@ from unittest.mock import AsyncMock, Mock
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.types
 from synapse.api.errors import AuthError, SynapseError

--- a/tests/handlers/test_receipts.py
+++ b/tests/handlers/test_receipts.py
@@ -22,7 +22,7 @@
 from copy import deepcopy
 from typing import List
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EduTypes, ReceiptTypes
 from synapse.server import HomeServer

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -22,7 +22,7 @@
 from typing import Any, Collection, List, Optional, Tuple
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.auth.internal import InternalAuth
 from synapse.api.constants import UserTypes

--- a/tests/handlers/test_room_member.py
+++ b/tests/handlers/test_room_member.py
@@ -1,6 +1,6 @@
 from unittest.mock import AsyncMock, patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 import synapse.rest.client.login

--- a/tests/handlers/test_room_policy.py
+++ b/tests/handlers/test_room_policy.py
@@ -15,7 +15,7 @@
 from typing import Optional
 from unittest import mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.events import EventBase, make_event_from_dict
 from synapse.rest import admin

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 from unittest import mock
 
 from twisted.internet.defer import ensureDeferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import (
     EventContentFields,

--- a/tests/handlers/test_saml.py
+++ b/tests/handlers/test_saml.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, Mock
 
 import attr
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import RedirectException
 from synapse.module_api import ModuleApi

--- a/tests/handlers/test_sliding_sync.py
+++ b/tests/handlers/test_sliding_sync.py
@@ -24,7 +24,7 @@ from unittest.mock import patch
 import attr
 from parameterized import parameterized, parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import (
     EventTypes,

--- a/tests/handlers/test_sso.py
+++ b/tests/handlers/test_sso.py
@@ -21,7 +21,7 @@ from http import HTTPStatus
 from typing import BinaryIO, Callable, Dict, List, Optional, Tuple
 from unittest.mock import Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.http_headers import Headers
 
 from synapse.api.errors import Codes, SynapseError

--- a/tests/handlers/test_stats.py
+++ b/tests/handlers/test_stats.py
@@ -20,7 +20,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, cast
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.rest import admin
 from synapse.rest.client import login, room

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from parameterized import parameterized, parameterized_class
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import AccountDataTypes, EventTypes, JoinRules
 from synapse.api.errors import Codes, ResourceLimitError

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -26,7 +26,7 @@ from unittest.mock import ANY, AsyncMock, Mock, call
 
 from netaddr import IPSet
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 from synapse.api.constants import EduTypes

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -21,7 +21,7 @@ from typing import Any, Tuple
 from unittest.mock import AsyncMock, Mock, patch
 from urllib.parse import quote
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import UserTypes

--- a/tests/handlers/test_worker_lock.py
+++ b/tests/handlers/test_worker_lock.py
@@ -23,7 +23,7 @@ import logging
 import platform
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.util import Clock

--- a/tests/http/server/_base.py
+++ b/tests/http/server/_base.py
@@ -40,8 +40,8 @@ from unittest.mock import Mock
 
 from twisted.internet.defer import Deferred
 from twisted.internet.error import ConnectionDone
-from twisted.python.failure import Failure
 from twisted.internet.testing import MemoryReactorClock
+from twisted.python.failure import Failure
 from twisted.web.server import Site
 
 from synapse.http.server import (

--- a/tests/http/server/_base.py
+++ b/tests/http/server/_base.py
@@ -41,7 +41,7 @@ from unittest.mock import Mock
 from twisted.internet.defer import Deferred
 from twisted.internet.error import ConnectionDone
 from twisted.python.failure import Failure
-from twisted.test.proto_helpers import MemoryReactorClock
+from twisted.internet.testing import MemoryReactorClock
 from twisted.web.server import Site
 
 from synapse.http.server import (

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -28,7 +28,7 @@ from netaddr import IPSet
 from twisted.internet.defer import Deferred
 from twisted.internet.error import DNSLookupError
 from twisted.python.failure import Failure
-from twisted.test.proto_helpers import AccumulatingProtocol
+from twisted.internet.testing import AccumulatingProtocol
 from twisted.web.client import Agent, ResponseDone
 from twisted.web.iweb import UNKNOWN_LENGTH
 

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -27,8 +27,8 @@ from netaddr import IPSet
 
 from twisted.internet.defer import Deferred
 from twisted.internet.error import DNSLookupError
-from twisted.python.failure import Failure
 from twisted.internet.testing import AccumulatingProtocol
+from twisted.python.failure import Failure
 from twisted.web.client import Agent, ResponseDone
 from twisted.web.iweb import UNKNOWN_LENGTH
 

--- a/tests/http/test_matrixfederationclient.py
+++ b/tests/http/test_matrixfederationclient.py
@@ -27,7 +27,7 @@ from parameterized import parameterized
 from twisted.internet import defer
 from twisted.internet.defer import Deferred, TimeoutError
 from twisted.internet.error import ConnectingCancelledError, DNSLookupError
-from twisted.test.proto_helpers import MemoryReactor, StringTransport
+from twisted.internet.testing import MemoryReactor, StringTransport
 from twisted.web.client import Agent, ResponseNeverReceived
 from twisted.web.http import HTTPChannel
 from twisted.web.http_headers import Headers

--- a/tests/http/test_simple_client.py
+++ b/tests/http/test_simple_client.py
@@ -24,7 +24,7 @@ from netaddr import IPSet
 
 from twisted.internet import defer
 from twisted.internet.error import DNSLookupError
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.http import RequestTimedOutError
 from synapse.http.client import SimpleHttpClient

--- a/tests/http/test_site.py
+++ b/tests/http/test_site.py
@@ -20,7 +20,7 @@
 #
 
 from twisted.internet.address import IPv6Address
-from twisted.test.proto_helpers import MemoryReactor, StringTransport
+from twisted.internet.testing import MemoryReactor, StringTransport
 
 from synapse.app.homeserver import SynapseHomeServer
 from synapse.server import HomeServer

--- a/tests/logging/test_opentracing.py
+++ b/tests/logging/test_opentracing.py
@@ -22,7 +22,7 @@
 from typing import Awaitable, cast
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactorClock
+from twisted.internet.testing import MemoryReactorClock
 
 from synapse.logging.context import (
     LoggingContext,

--- a/tests/logging/test_remote_handler.py
+++ b/tests/logging/test_remote_handler.py
@@ -21,7 +21,7 @@
 from typing import Tuple
 
 from twisted.internet.protocol import Protocol
-from twisted.test.proto_helpers import AccumulatingProtocol, MemoryReactorClock
+from twisted.internet.testing import AccumulatingProtocol, MemoryReactorClock
 
 from synapse.logging import RemoteHandler
 

--- a/tests/media/test_media_retention.py
+++ b/tests/media/test_media_retention.py
@@ -24,7 +24,7 @@ from typing import Iterable, Optional
 
 from matrix_common.types.mxc_uri import MXCUri
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.rest import admin
 from synapse.rest.client import login, register, room

--- a/tests/media/test_media_storage.py
+++ b/tests/media/test_media_storage.py
@@ -34,7 +34,7 @@ from PIL import Image as Image
 from twisted.internet import defer
 from twisted.internet.defer import Deferred
 from twisted.python.failure import Failure
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import UNKNOWN_LENGTH, IResponse
 from twisted.web.resource import Resource

--- a/tests/media/test_media_storage.py
+++ b/tests/media/test_media_storage.py
@@ -33,8 +33,8 @@ from PIL import Image as Image
 
 from twisted.internet import defer
 from twisted.internet.defer import Deferred
-from twisted.python.failure import Failure
 from twisted.internet.testing import MemoryReactor
+from twisted.python.failure import Failure
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import UNKNOWN_LENGTH, IResponse
 from twisted.web.resource import Resource

--- a/tests/media/test_oembed.py
+++ b/tests/media/test_oembed.py
@@ -24,7 +24,7 @@ from typing import Any
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.media.oembed import OEmbedProvider, OEmbedResult
 from synapse.server import HomeServer

--- a/tests/media/test_url_previewer.py
+++ b/tests/media/test_url_previewer.py
@@ -20,7 +20,7 @@
 #
 import os
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.util import Clock

--- a/tests/metrics/test_phone_home_stats.py
+++ b/tests/metrics/test_phone_home_stats.py
@@ -14,7 +14,7 @@
 import logging
 from unittest.mock import AsyncMock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.app.phone_stats_home import (
     PHONE_HOME_INTERVAL_SECONDS,

--- a/tests/module_api/test_account_data_manager.py
+++ b/tests/module_api/test_account_data_manager.py
@@ -18,7 +18,7 @@
 # [This file includes modifications made by New Vector Limited]
 #
 #
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import SynapseError
 from synapse.rest import admin

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Optional
 from unittest.mock import AsyncMock, Mock
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EduTypes, EventTypes
 from synapse.api.errors import NotFoundError

--- a/tests/module_api/test_event_unsigned_addition.py
+++ b/tests/module_api/test_event_unsigned_addition.py
@@ -18,7 +18,7 @@
 # [This file includes modifications made by New Vector Limited]
 #
 #
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.events import EventBase
 from synapse.rest import admin, login, room

--- a/tests/module_api/test_spamchecker.py
+++ b/tests/module_api/test_spamchecker.py
@@ -14,7 +14,7 @@
 #
 from typing import Literal, Union
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.config.server import DEFAULT_ROOM_VERSION
 from synapse.rest import admin, login, room, room_upgrade_rest_servlet

--- a/tests/push/test_bulk_push_rule_evaluator.py
+++ b/tests/push/test_bulk_push_rule_evaluator.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, patch
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventContentFields, RelationTypes
 from synapse.api.room_versions import RoomVersions

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -27,7 +27,7 @@ import pkg_resources
 from parameterized import parameterized
 
 from twisted.internet.defer import Deferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.errors import Codes, SynapseError

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -23,7 +23,7 @@ from unittest.mock import Mock
 from parameterized import parameterized
 
 from twisted.internet.defer import Deferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.logging.context import make_deferred_yieldable

--- a/tests/push/test_push_rule_evaluator.py
+++ b/tests/push/test_push_rule_evaluator.py
@@ -21,7 +21,7 @@
 
 from typing import Any, Dict, List, Optional, Union, cast
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes, HistoryVisibility, Membership

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -23,8 +23,8 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from twisted.internet.address import IPv4Address
 from twisted.internet.protocol import Protocol, connectionDone
-from twisted.python.failure import Failure
 from twisted.internet.testing import MemoryReactor
+from twisted.python.failure import Failure
 from twisted.web.resource import Resource
 
 from synapse.app.generic_worker import GenericWorkerServer

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from twisted.internet.address import IPv4Address
 from twisted.internet.protocol import Protocol, connectionDone
 from twisted.python.failure import Failure
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 from synapse.app.generic_worker import GenericWorkerServer

--- a/tests/replication/storage/_base.py
+++ b/tests/replication/storage/_base.py
@@ -22,7 +22,7 @@
 from typing import Any, Callable, Iterable, Optional
 from unittest.mock import Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.util import Clock

--- a/tests/replication/storage/test_events.py
+++ b/tests/replication/storage/test_events.py
@@ -24,7 +24,7 @@ from typing import Any, Iterable, List, Optional, Tuple
 from canonicaljson import encode_canonical_json
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import ReceiptTypes
 from synapse.api.room_versions import RoomVersions

--- a/tests/replication/tcp/streams/test_events.py
+++ b/tests/replication/tcp/streams/test_events.py
@@ -22,7 +22,7 @@ from typing import Any, List, Optional
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes, Membership
 from synapse.events import EventBase

--- a/tests/replication/tcp/streams/test_thread_subscriptions.py
+++ b/tests/replication/tcp/streams/test_thread_subscriptions.py
@@ -12,7 +12,7 @@
 # <https://www.gnu.org/licenses/agpl-3.0.html>.
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.replication.tcp.streams._base import (
     _STREAM_UPDATE_TARGET_ROW_COUNT,

--- a/tests/replication/test_auth.py
+++ b/tests/replication/test_auth.py
@@ -20,7 +20,7 @@
 #
 import logging
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.rest.client import register
 from synapse.server import HomeServer

--- a/tests/replication/test_federation_ack.py
+++ b/tests/replication/test_federation_ack.py
@@ -21,7 +21,7 @@
 
 from unittest import mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.app.generic_worker import GenericWorkerServer
 from synapse.replication.tcp.commands import FederationAckCommand

--- a/tests/replication/test_federation_sender_shard.py
+++ b/tests/replication/test_federation_sender_shard.py
@@ -28,7 +28,7 @@ from signedjson.key import (
     get_verify_key,
 )
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes, Membership
 from synapse.api.room_versions import RoomVersion

--- a/tests/replication/test_multi_media_repo.py
+++ b/tests/replication/test_multi_media_repo.py
@@ -23,7 +23,7 @@ import os
 from typing import Any, Optional, Tuple
 
 from twisted.internet.protocol import Factory
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.http import HTTPChannel
 from twisted.web.server import Request
 

--- a/tests/replication/test_pusher_shard.py
+++ b/tests/replication/test_pusher_shard.py
@@ -22,7 +22,7 @@ import logging
 from unittest.mock import Mock
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.rest import admin
 from synapse.rest.client import login, room

--- a/tests/replication/test_sharded_event_persister.py
+++ b/tests/replication/test_sharded_event_persister.py
@@ -21,7 +21,7 @@
 import logging
 from unittest.mock import patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.rest import admin
 from synapse.rest.client import login, room, sync

--- a/tests/replication/test_sharded_receipts.py
+++ b/tests/replication/test_sharded_receipts.py
@@ -20,7 +20,7 @@
 #
 import logging
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import ReceiptTypes
 from synapse.rest import admin

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -24,7 +24,7 @@ from typing import Dict, cast
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 import synapse.rest.admin

--- a/tests/rest/admin/test_background_updates.py
+++ b/tests/rest/admin/test_background_updates.py
@@ -22,7 +22,7 @@ from typing import Collection
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.errors import Codes

--- a/tests/rest/admin/test_device.py
+++ b/tests/rest/admin/test_device.py
@@ -22,7 +22,7 @@ import urllib.parse
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.errors import Codes

--- a/tests/rest/admin/test_event_reports.py
+++ b/tests/rest/admin/test_event_reports.py
@@ -20,7 +20,7 @@
 #
 from typing import List
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.errors import Codes

--- a/tests/rest/admin/test_federation.py
+++ b/tests/rest/admin/test_federation.py
@@ -22,7 +22,7 @@ from typing import List, Optional
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.errors import Codes

--- a/tests/rest/admin/test_media.py
+++ b/tests/rest/admin/test_media.py
@@ -24,7 +24,7 @@ from typing import Dict
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 import synapse.rest.admin

--- a/tests/rest/admin/test_registration_tokens.py
+++ b/tests/rest/admin/test_registration_tokens.py
@@ -22,7 +22,7 @@ import random
 import string
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.errors import Codes

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -28,7 +28,7 @@ from unittest.mock import AsyncMock, Mock
 from parameterized import parameterized
 
 from twisted.internet.task import deferLater
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes, Membership, RoomTypes

--- a/tests/rest/admin/test_scheduled_tasks.py
+++ b/tests/rest/admin/test_scheduled_tasks.py
@@ -15,7 +15,7 @@
 #
 from typing import Mapping, Optional, Tuple
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.errors import Codes

--- a/tests/rest/admin/test_server_notice.py
+++ b/tests/rest/admin/test_server_notice.py
@@ -20,7 +20,7 @@
 #
 from typing import List, Sequence
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.errors import Codes

--- a/tests/rest/admin/test_statistics.py
+++ b/tests/rest/admin/test_statistics.py
@@ -21,7 +21,7 @@
 #
 from typing import Dict, List, Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 import synapse.rest.admin

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -32,7 +32,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 from parameterized import parameterized, parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 import synapse.rest.admin

--- a/tests/rest/admin/test_username_available.py
+++ b/tests/rest/admin/test_username_available.py
@@ -20,7 +20,7 @@
 #
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.errors import Codes, SynapseError

--- a/tests/rest/client/sliding_sync/test_connection_tracking.py
+++ b/tests/rest/client/sliding_sync/test_connection_tracking.py
@@ -15,7 +15,7 @@ import logging
 
 from parameterized import parameterized, parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes

--- a/tests/rest/client/sliding_sync/test_extension_account_data.py
+++ b/tests/rest/client/sliding_sync/test_extension_account_data.py
@@ -17,7 +17,7 @@ import logging
 from parameterized import parameterized, parameterized_class
 from typing_extensions import assert_never
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import AccountDataTypes

--- a/tests/rest/client/sliding_sync/test_extension_e2ee.py
+++ b/tests/rest/client/sliding_sync/test_extension_e2ee.py
@@ -15,7 +15,7 @@ import logging
 
 from parameterized import parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.rest.client import devices, login, room, sync

--- a/tests/rest/client/sliding_sync/test_extension_receipts.py
+++ b/tests/rest/client/sliding_sync/test_extension_receipts.py
@@ -15,7 +15,7 @@ import logging
 
 from parameterized import parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EduTypes, ReceiptTypes

--- a/tests/rest/client/sliding_sync/test_extension_to_device.py
+++ b/tests/rest/client/sliding_sync/test_extension_to_device.py
@@ -16,7 +16,7 @@ from typing import List
 
 from parameterized import parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.rest.client import login, sendtodevice, sync

--- a/tests/rest/client/sliding_sync/test_extension_typing.py
+++ b/tests/rest/client/sliding_sync/test_extension_typing.py
@@ -15,7 +15,7 @@ import logging
 
 from parameterized import parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EduTypes

--- a/tests/rest/client/sliding_sync/test_extensions.py
+++ b/tests/rest/client/sliding_sync/test_extensions.py
@@ -17,7 +17,7 @@ from typing import Literal
 from parameterized import parameterized, parameterized_class
 from typing_extensions import assert_never
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import ReceiptTypes

--- a/tests/rest/client/sliding_sync/test_lists_filters.py
+++ b/tests/rest/client/sliding_sync/test_lists_filters.py
@@ -15,7 +15,7 @@ import logging
 
 from parameterized import parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import (

--- a/tests/rest/client/sliding_sync/test_room_subscriptions.py
+++ b/tests/rest/client/sliding_sync/test_room_subscriptions.py
@@ -16,7 +16,7 @@ from http import HTTPStatus
 
 from parameterized import parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes, HistoryVisibility

--- a/tests/rest/client/sliding_sync/test_rooms_invites.py
+++ b/tests/rest/client/sliding_sync/test_rooms_invites.py
@@ -15,7 +15,7 @@ import logging
 
 from parameterized import parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes, HistoryVisibility

--- a/tests/rest/client/sliding_sync/test_rooms_meta.py
+++ b/tests/rest/client/sliding_sync/test_rooms_meta.py
@@ -15,7 +15,7 @@ import logging
 
 from parameterized import parameterized, parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EventContentFields, EventTypes, Membership

--- a/tests/rest/client/sliding_sync/test_rooms_required_state.py
+++ b/tests/rest/client/sliding_sync/test_rooms_required_state.py
@@ -16,7 +16,7 @@ import logging
 
 from parameterized import parameterized, parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EventContentFields, EventTypes, JoinRules, Membership

--- a/tests/rest/client/sliding_sync/test_rooms_timeline.py
+++ b/tests/rest/client/sliding_sync/test_rooms_timeline.py
@@ -16,7 +16,7 @@ from typing import List, Optional
 
 from parameterized import parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes

--- a/tests/rest/client/sliding_sync/test_sliding_sync.py
+++ b/tests/rest/client/sliding_sync/test_sliding_sync.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock
 from parameterized import parameterized, parameterized_class
 from typing_extensions import assert_never
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import (

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -28,7 +28,7 @@ from unittest.mock import Mock
 import pkg_resources
 
 from twisted.internet.interfaces import IReactorTCP
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import LoginType, Membership

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -23,7 +23,7 @@ from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from twisted.internet.defer import succeed
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 import synapse.rest.admin

--- a/tests/rest/client/test_capabilities.py
+++ b/tests/rest/client/test_capabilities.py
@@ -19,7 +19,7 @@
 #
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS

--- a/tests/rest/client/test_consent.py
+++ b/tests/rest/client/test_consent.py
@@ -21,7 +21,7 @@
 import os
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.urls import ConsentURIBuilder

--- a/tests/rest/client/test_delayed_events.py
+++ b/tests/rest/client/test_delayed_events.py
@@ -19,7 +19,7 @@ from typing import List
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import Codes
 from synapse.rest import admin

--- a/tests/rest/client/test_devices.py
+++ b/tests/rest/client/test_devices.py
@@ -21,7 +21,7 @@
 from http import HTTPStatus
 
 from twisted.internet.defer import ensureDeferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import NotFoundError
 from synapse.appservice import ApplicationService

--- a/tests/rest/client/test_directory.py
+++ b/tests/rest/client/test_directory.py
@@ -19,7 +19,7 @@
 #
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.appservice import ApplicationService
 from synapse.rest import admin

--- a/tests/rest/client/test_ephemeral_message.py
+++ b/tests/rest/client/test_ephemeral_message.py
@@ -19,7 +19,7 @@
 #
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventContentFields, EventTypes
 from synapse.rest import admin

--- a/tests/rest/client/test_events.py
+++ b/tests/rest/client/test_events.py
@@ -23,7 +23,7 @@
 
 from unittest.mock import Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EduTypes

--- a/tests/rest/client/test_filter.py
+++ b/tests/rest/client/test_filter.py
@@ -19,7 +19,7 @@
 #
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import Codes
 from synapse.rest.client import filter

--- a/tests/rest/client/test_identity.py
+++ b/tests/rest/client/test_identity.py
@@ -20,7 +20,7 @@
 
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.rest.client import login, room

--- a/tests/rest/client/test_login.py
+++ b/tests/rest/client/test_login.py
@@ -37,7 +37,7 @@ from urllib.parse import urlencode
 
 import pymacaroons
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 import synapse.rest.admin

--- a/tests/rest/client/test_login_token_request.py
+++ b/tests/rest/client/test_login_token_request.py
@@ -19,7 +19,7 @@
 #
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.rest import admin
 from synapse.rest.client import login, login_token_request, versions

--- a/tests/rest/client/test_media.py
+++ b/tests/rest/client/test_media.py
@@ -39,7 +39,7 @@ from twisted.internet.defer import Deferred
 from twisted.internet.error import DNSLookupError
 from twisted.internet.interfaces import IAddress, IResolutionReceiver
 from twisted.python.failure import Failure
-from twisted.test.proto_helpers import AccumulatingProtocol, MemoryReactor
+from twisted.internet.testing import AccumulatingProtocol, MemoryReactor
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import UNKNOWN_LENGTH, IResponse
 from twisted.web.resource import Resource

--- a/tests/rest/client/test_media.py
+++ b/tests/rest/client/test_media.py
@@ -38,8 +38,8 @@ from twisted.internet.address import IPv4Address, IPv6Address
 from twisted.internet.defer import Deferred
 from twisted.internet.error import DNSLookupError
 from twisted.internet.interfaces import IAddress, IResolutionReceiver
-from twisted.python.failure import Failure
 from twisted.internet.testing import AccumulatingProtocol, MemoryReactor
+from twisted.python.failure import Failure
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import UNKNOWN_LENGTH, IResponse
 from twisted.web.resource import Resource

--- a/tests/rest/client/test_mutual_rooms.py
+++ b/tests/rest/client/test_mutual_rooms.py
@@ -20,7 +20,7 @@
 #
 from urllib.parse import quote
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.rest.client import login, mutual_rooms, room

--- a/tests/rest/client/test_notifications.py
+++ b/tests/rest/client/test_notifications.py
@@ -21,7 +21,7 @@
 from typing import List, Optional, Tuple
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.rest.client import login, notifications, receipts, room

--- a/tests/rest/client/test_owned_state.py
+++ b/tests/rest/client/test_owned_state.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 
 from parameterized import parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import Codes
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS, RoomVersions

--- a/tests/rest/client/test_password_policy.py
+++ b/tests/rest/client/test_password_policy.py
@@ -21,7 +21,7 @@
 
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import LoginType
 from synapse.api.errors import Codes

--- a/tests/rest/client/test_power_levels.py
+++ b/tests/rest/client/test_power_levels.py
@@ -20,7 +20,7 @@
 #
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import Codes
 from synapse.events.utils import CANONICALJSON_MAX_INT, CANONICALJSON_MIN_INT

--- a/tests/rest/client/test_presence.py
+++ b/tests/rest/client/test_presence.py
@@ -20,7 +20,7 @@
 from http import HTTPStatus
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.handlers.presence import PresenceHandler
 from synapse.rest.client import presence

--- a/tests/rest/client/test_profile.py
+++ b/tests/rest/client/test_profile.py
@@ -27,7 +27,7 @@ from typing import Any, Dict, Optional
 
 from canonicaljson import encode_canonical_json
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import Codes
 from synapse.rest import admin

--- a/tests/rest/client/test_read_marker.py
+++ b/tests/rest/client/test_read_marker.py
@@ -18,7 +18,7 @@
 # [This file includes modifications made by New Vector Limited]
 #
 #
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes

--- a/tests/rest/client/test_receipts.py
+++ b/tests/rest/client/test_receipts.py
@@ -21,7 +21,7 @@
 from http import HTTPStatus
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EduTypes, EventTypes, HistoryVisibility, ReceiptTypes

--- a/tests/rest/client/test_redactions.py
+++ b/tests/rest/client/test_redactions.py
@@ -22,7 +22,7 @@ from typing import List, Optional
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes, RelationTypes
 from synapse.api.room_versions import RoomVersion, RoomVersions

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -26,7 +26,7 @@ from unittest.mock import AsyncMock
 
 import pkg_resources
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import (

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -23,7 +23,7 @@ import urllib.parse
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from unittest.mock import AsyncMock, patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import AccountDataTypes, EventTypes, RelationTypes
 from synapse.rest import admin

--- a/tests/rest/client/test_rendezvous.py
+++ b/tests/rest/client/test_rendezvous.py
@@ -22,7 +22,7 @@
 from typing import Dict
 from urllib.parse import urlparse
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 from synapse.rest.client import rendezvous

--- a/tests/rest/client/test_reporting.py
+++ b/tests/rest/client/test_reporting.py
@@ -20,7 +20,7 @@
 #
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.rest.client import login, reporting, room

--- a/tests/rest/client/test_retention.py
+++ b/tests/rest/client/test_retention.py
@@ -20,7 +20,7 @@
 from typing import Any, Dict
 from unittest.mock import Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes
 from synapse.rest import admin

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -31,7 +31,7 @@ from urllib import parse as urlparse
 
 from parameterized import param, parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import (

--- a/tests/rest/client/test_shadow_banned.py
+++ b/tests/rest/client/test_shadow_banned.py
@@ -21,7 +21,7 @@
 
 from unittest.mock import Mock, patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EduTypes, EventTypes

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -24,7 +24,7 @@ from typing import List
 
 from parameterized import parameterized, parameterized_class
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import (

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -22,7 +22,7 @@ import threading
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes, LoginType, Membership
 from synapse.api.errors import SynapseError

--- a/tests/rest/client/test_thread_subscriptions.py
+++ b/tests/rest/client/test_thread_subscriptions.py
@@ -13,7 +13,7 @@
 
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.rest import admin
 from synapse.rest.client import login, profile, room, thread_subscriptions

--- a/tests/rest/client/test_typing.py
+++ b/tests/rest/client/test_typing.py
@@ -21,7 +21,7 @@
 
 """Tests REST events for /rooms paths."""
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EduTypes
 from synapse.rest.client import room

--- a/tests/rest/client/test_upgrade_room.py
+++ b/tests/rest/client/test_upgrade_room.py
@@ -21,7 +21,7 @@
 from typing import Optional
 from unittest.mock import patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventContentFields, EventTypes, RoomTypes
 from synapse.config.server import DEFAULT_ROOM_VERSION

--- a/tests/rest/client/utils.py
+++ b/tests/rest/client/utils.py
@@ -42,7 +42,7 @@ from urllib.parse import urlencode
 
 import attr
 
-from twisted.test.proto_helpers import MemoryReactorClock
+from twisted.internet.testing import MemoryReactorClock
 from twisted.web.server import Site
 
 from synapse.api.constants import Membership, ReceiptTypes

--- a/tests/rest/key/v2/test_remote_key_resource.py
+++ b/tests/rest/key/v2/test_remote_key_resource.py
@@ -27,7 +27,7 @@ from canonicaljson import encode_canonical_json
 from signedjson.sign import sign_json
 from signedjson.types import SigningKey
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import NoResource, Resource
 
 from synapse.crypto.keyring import PerspectivesKeyFetcher

--- a/tests/rest/media/test_domain_blocking.py
+++ b/tests/rest/media/test_domain_blocking.py
@@ -20,7 +20,7 @@
 #
 from typing import Dict
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 from synapse.media._base import FileInfo

--- a/tests/rest/media/test_url_preview.py
+++ b/tests/rest/media/test_url_preview.py
@@ -29,7 +29,7 @@ from twisted.internet._resolver import HostResolution
 from twisted.internet.address import IPv4Address, IPv6Address
 from twisted.internet.error import DNSLookupError
 from twisted.internet.interfaces import IAddress, IResolutionReceiver
-from twisted.test.proto_helpers import AccumulatingProtocol, MemoryReactor
+from twisted.internet.testing import AccumulatingProtocol, MemoryReactor
 from twisted.web.resource import Resource
 
 from synapse.config.oembed import OEmbedEndpointConfig

--- a/tests/rest/synapse/mas/test_devices.py
+++ b/tests/rest/synapse/mas/test_devices.py
@@ -11,7 +11,7 @@
 # See the GNU Affero General Public License for more details:
 # <https://www.gnu.org/licenses/agpl-3.0.html>.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.types import UserID

--- a/tests/rest/synapse/mas/test_users.py
+++ b/tests/rest/synapse/mas/test_users.py
@@ -13,7 +13,7 @@
 
 from urllib.parse import urlencode
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.appservice import ApplicationService
 from synapse.server import HomeServer

--- a/tests/server.py
+++ b/tests/server.py
@@ -80,7 +80,7 @@ from twisted.internet.interfaces import (
 from twisted.internet.protocol import ClientFactory, DatagramProtocol, Factory
 from twisted.python import threadpool
 from twisted.python.failure import Failure
-from twisted.test.proto_helpers import AccumulatingProtocol, MemoryReactorClock
+from twisted.internet.testing import AccumulatingProtocol, MemoryReactorClock
 from twisted.web.http_headers import Headers
 from twisted.web.resource import IResource
 from twisted.web.server import Request, Site

--- a/tests/server.py
+++ b/tests/server.py
@@ -78,9 +78,9 @@ from twisted.internet.interfaces import (
     ITransport,
 )
 from twisted.internet.protocol import ClientFactory, DatagramProtocol, Factory
+from twisted.internet.testing import AccumulatingProtocol, MemoryReactorClock
 from twisted.python import threadpool
 from twisted.python.failure import Failure
-from twisted.internet.testing import AccumulatingProtocol, MemoryReactorClock
 from twisted.web.http_headers import Headers
 from twisted.web.resource import IResource
 from twisted.web.server import Request, Site

--- a/tests/server_notices/test_consent.py
+++ b/tests/server_notices/test_consent.py
@@ -20,7 +20,7 @@
 
 import os
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.rest.client import login, room, sync

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -20,7 +20,7 @@
 from typing import Tuple
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes, LimitBlockingTypes, ServerNoticeMsgType
 from synapse.api.errors import ResourceLimitError

--- a/tests/storage/databases/main/test_deviceinbox.py
+++ b/tests/storage/databases/main/test_deviceinbox.py
@@ -22,7 +22,7 @@
 from unittest.mock import patch
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.rest import admin
 from synapse.rest.client import devices

--- a/tests/storage/databases/main/test_end_to_end_keys.py
+++ b/tests/storage/databases/main/test_end_to_end_keys.py
@@ -20,7 +20,7 @@
 #
 from typing import List, Optional, Tuple
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage._base import db_to_json

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -25,7 +25,7 @@ from unittest import mock
 
 from twisted.enterprise.adbapi import ConnectionPool
 from twisted.internet.defer import CancelledError, Deferred, ensureDeferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.room_versions import EventFormatVersions, RoomVersions
 from synapse.events import make_event_from_dict

--- a/tests/storage/databases/main/test_lock.py
+++ b/tests/storage/databases/main/test_lock.py
@@ -23,7 +23,7 @@
 from twisted.internet import defer, reactor
 from twisted.internet.base import ReactorBase
 from twisted.internet.defer import Deferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.databases.main.lock import _LOCK_TIMEOUT_MS, _RENEWAL_INTERVAL_MS

--- a/tests/storage/databases/main/test_receipts.py
+++ b/tests/storage/databases/main/test_receipts.py
@@ -21,7 +21,7 @@
 
 from typing import Any, Dict, Optional, Sequence, Tuple
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.rest import admin
 from synapse.rest.client import login, room

--- a/tests/storage/databases/main/test_room.py
+++ b/tests/storage/databases/main/test_room.py
@@ -21,7 +21,7 @@
 
 import json
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import RoomTypes
 from synapse.rest import admin

--- a/tests/storage/test__base.py
+++ b/tests/storage/test__base.py
@@ -22,7 +22,7 @@
 import secrets
 from typing import Generator, List, Tuple, cast
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.util import Clock

--- a/tests/storage/test_account_data.py
+++ b/tests/storage/test_account_data.py
@@ -21,7 +21,7 @@
 
 from typing import Iterable, Optional, Set
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import AccountDataTypes
 from synapse.api.errors import Codes, SynapseError

--- a/tests/storage/test_appservice.py
+++ b/tests/storage/test_appservice.py
@@ -27,7 +27,7 @@ from unittest.mock import AsyncMock, Mock
 import yaml
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.appservice import ApplicationService, ApplicationServiceState
 from synapse.config._base import ConfigError

--- a/tests/storage/test_background_update.py
+++ b/tests/storage/test_background_update.py
@@ -25,7 +25,7 @@ from unittest.mock import AsyncMock, Mock
 import yaml
 
 from twisted.internet.defer import Deferred, ensureDeferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.background_updates import (

--- a/tests/storage/test_cleanup_extrems.py
+++ b/tests/storage/test_cleanup_extrems.py
@@ -22,7 +22,7 @@
 import os.path
 from unittest.mock import Mock, patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes

--- a/tests/storage/test_client_ips.py
+++ b/tests/storage/test_client_ips.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.http.site import XForwardedForRequest

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -24,7 +24,7 @@ from unittest.mock import Mock, call
 
 from twisted.internet import defer
 from twisted.internet.defer import CancelledError, Deferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.database import (

--- a/tests/storage/test_devices.py
+++ b/tests/storage/test_devices.py
@@ -21,7 +21,7 @@
 
 from typing import Collection, List, Tuple
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.api.errors
 from synapse.api.constants import EduTypes

--- a/tests/storage/test_directory.py
+++ b/tests/storage/test_directory.py
@@ -19,7 +19,7 @@
 #
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.types import RoomAlias, RoomID

--- a/tests/storage/test_e2e_room_keys.py
+++ b/tests/storage/test_e2e_room_keys.py
@@ -19,7 +19,7 @@
 #
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.databases.main.e2e_room_keys import RoomKey

--- a/tests/storage/test_end_to_end_keys.py
+++ b/tests/storage/test_end_to_end_keys.py
@@ -19,7 +19,7 @@
 #
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.util import Clock

--- a/tests/storage/test_event_chain.py
+++ b/tests/storage/test_event_chain.py
@@ -23,7 +23,7 @@ from typing import Dict, List, Set, Tuple, cast
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.trial import unittest
 
 from synapse.api.constants import EventTypes

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -36,7 +36,7 @@ from typing import (
 import attr
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes
 from synapse.api.room_versions import (

--- a/tests/storage/test_event_push_actions.py
+++ b/tests/storage/test_event_push_actions.py
@@ -21,7 +21,7 @@
 
 from typing import Optional, Tuple
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import MAIN_TIMELINE, RelationTypes
 from synapse.rest import admin

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -22,7 +22,7 @@
 import logging
 from typing import List, Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes, Membership
 from synapse.api.room_versions import RoomVersions

--- a/tests/storage/test_events_bg_updates.py
+++ b/tests/storage/test_events_bg_updates.py
@@ -15,7 +15,7 @@
 
 from typing import Dict
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import MAX_DEPTH
 from synapse.api.room_versions import RoomVersion, RoomVersions

--- a/tests/storage/test_id_generators.py
+++ b/tests/storage/test_id_generators.py
@@ -20,7 +20,7 @@
 #
 from typing import Dict, List, Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.database import (

--- a/tests/storage/test_monthly_active_users.py
+++ b/tests/storage/test_monthly_active_users.py
@@ -20,7 +20,7 @@
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import UserTypes
 from synapse.server import HomeServer

--- a/tests/storage/test_profile.py
+++ b/tests/storage/test_profile.py
@@ -19,7 +19,7 @@
 #
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.database import LoggingTransaction

--- a/tests/storage/test_purge.py
+++ b/tests/storage/test_purge.py
@@ -18,7 +18,7 @@
 #
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import NotFoundError, SynapseError
 from synapse.rest.client import room

--- a/tests/storage/test_receipts.py
+++ b/tests/storage/test_receipts.py
@@ -21,7 +21,7 @@
 
 from typing import Collection, Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import ReceiptTypes
 from synapse.server import HomeServer

--- a/tests/storage/test_redaction.py
+++ b/tests/storage/test_redaction.py
@@ -22,7 +22,7 @@ from typing import List, Optional, cast
 
 from canonicaljson import json
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes, Membership
 from synapse.api.room_versions import RoomVersions

--- a/tests/storage/test_registration.py
+++ b/tests/storage/test_registration.py
@@ -18,7 +18,7 @@
 # [This file includes modifications made by New Vector Limited]
 #
 #
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import UserTypes
 from synapse.api.errors import ThreepidValidationError

--- a/tests/storage/test_relations.py
+++ b/tests/storage/test_relations.py
@@ -19,7 +19,7 @@
 #
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import MAIN_TIMELINE
 from synapse.server import HomeServer

--- a/tests/storage/test_rollback_worker.py
+++ b/tests/storage/test_rollback_worker.py
@@ -21,7 +21,7 @@
 from typing import List
 from unittest import mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.app.generic_worker import GenericWorkerServer
 from synapse.server import HomeServer

--- a/tests/storage/test_room.py
+++ b/tests/storage/test_room.py
@@ -19,7 +19,7 @@
 #
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.room_versions import RoomVersions
 from synapse.server import HomeServer

--- a/tests/storage/test_room_search.py
+++ b/tests/storage/test_room_search.py
@@ -22,7 +22,7 @@
 from typing import List, Tuple
 from unittest.case import SkipTest
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -22,7 +22,7 @@
 import logging
 from typing import List, Optional, Tuple, cast
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventContentFields, EventTypes, JoinRules, Membership
 from synapse.api.room_versions import RoomVersions

--- a/tests/storage/test_sliding_sync_tables.py
+++ b/tests/storage/test_sliding_sync_tables.py
@@ -23,7 +23,7 @@ from typing import Dict, List, Optional, Tuple, cast
 import attr
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventContentFields, EventTypes, Membership, RoomTypes
 from synapse.api.room_versions import RoomVersions

--- a/tests/storage/test_state.py
+++ b/tests/storage/test_state.py
@@ -24,7 +24,7 @@ from typing import List, Tuple, cast
 
 from immutabledict import immutabledict
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes, Membership
 from synapse.api.room_versions import RoomVersions

--- a/tests/storage/test_state_deletion.py
+++ b/tests/storage/test_state_deletion.py
@@ -15,7 +15,7 @@
 
 import logging
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.rest import admin
 from synapse.rest.client import login, room

--- a/tests/storage/test_stream.py
+++ b/tests/storage/test_stream.py
@@ -25,7 +25,7 @@ from unittest.mock import AsyncMock, patch
 
 from immutabledict import immutabledict
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import (
     Direction,

--- a/tests/storage/test_thread_subscriptions.py
+++ b/tests/storage/test_thread_subscriptions.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.database import LoggingTransaction

--- a/tests/storage/test_transactions.py
+++ b/tests/storage/test_transactions.py
@@ -18,7 +18,7 @@
 #
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.databases.main.transactions import DestinationRetryTimings

--- a/tests/storage/test_txn_limit.py
+++ b/tests/storage/test_txn_limit.py
@@ -19,7 +19,7 @@
 #
 #
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.types import Cursor

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, cast
 from unittest import mock
 from unittest.mock import Mock, patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EventTypes, Membership, UserTypes
 from synapse.appservice import ApplicationService

--- a/tests/storage/test_user_filters.py
+++ b/tests/storage/test_user_filters.py
@@ -20,7 +20,7 @@
 #
 
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.database import LoggingTransaction

--- a/tests/test_mau.py
+++ b/tests/test_mau.py
@@ -22,7 +22,7 @@
 
 from typing import List, Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import APP_SERVICE_REGISTRATION_TYPE, LoginType
 from synapse.api.errors import Codes, HttpResponseException, SynapseError

--- a/tests/test_phone_home.py
+++ b/tests/test_phone_home.py
@@ -22,7 +22,7 @@
 import resource
 from unittest import mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.app.phone_stats_home import phone_stats_home
 from synapse.rest import admin

--- a/tests/test_terms_auth.py
+++ b/tests/test_terms_auth.py
@@ -21,7 +21,7 @@
 from unittest.mock import Mock
 
 from twisted.internet.interfaces import IReactorTime
-from twisted.test.proto_helpers import MemoryReactor, MemoryReactorClock
+from twisted.internet.testing import MemoryReactor, MemoryReactorClock
 
 from synapse.rest.client.register import register_servlets
 from synapse.server import HomeServer

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -54,9 +54,9 @@ import unpaddedbase64
 from typing_extensions import Concatenate, ParamSpec
 
 from twisted.internet.defer import Deferred, ensureDeferred
+from twisted.internet.testing import MemoryReactor, MemoryReactorClock
 from twisted.python.failure import Failure
 from twisted.python.threadpool import ThreadPool
-from twisted.internet.testing import MemoryReactor, MemoryReactorClock
 from twisted.trial import unittest
 from twisted.web.resource import Resource
 from twisted.web.server import Request

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -56,7 +56,7 @@ from typing_extensions import Concatenate, ParamSpec
 from twisted.internet.defer import Deferred, ensureDeferred
 from twisted.python.failure import Failure
 from twisted.python.threadpool import ThreadPool
-from twisted.test.proto_helpers import MemoryReactor, MemoryReactorClock
+from twisted.internet.testing import MemoryReactor, MemoryReactorClock
 from twisted.trial import unittest
 from twisted.web.resource import Resource
 from twisted.web.server import Request

--- a/tests/util/test_task_scheduler.py
+++ b/tests/util/test_task_scheduler.py
@@ -21,7 +21,7 @@
 from typing import List, Optional, Tuple
 
 from twisted.internet.task import deferLater
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.types import JsonMapping, ScheduledTask, TaskStatus


### PR DESCRIPTION
Follows: #18727

<ol>
<li>

`rg -l proto_helpers | xargs sd 'from twisted.test.proto_helpers' 'from twisted.internet.testing'`

</li>
<li>

linting (import sorting) 

</li>
</ol>
