### PR TITLE
  Fix GET /_matrix/federation/v1/user/devices/{userId} response

### DIFF
--- a/changelog.d/18739.bugfix
+++ b/changelog.d/18739.bugfix
@@ -1,0 +1,1 @@
+Fix `master_key` and `self_signing_key` being sent on federation user device queries when they are not set.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -870,7 +870,7 @@ class DeviceHandler:
         # do not set the master_key field if it is None,
         # since then we send a null in the JSON response
         if master_key is not None:
-           json_body["master_key"] = master_key
+            json_body["master_key"] = master_key
 
         # do not set the self_signing_key field if it is None,
         # since then we send a null in the JSON response


### PR DESCRIPTION
Don't send the fields `master_key` and `self_signing_key` when they are not defined for the queried user device.'

Before this change they would be sent and set to null in the JSON response object, which would violate the OpenAPI definitions (https://spec.matrix.org/v1.3/server-server-api/#get_matrixfederationv1userdevicesuserid).

[12](https://discourse.haskell.org/t/welcome-to-the-haskell-discourse/7/1)
### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
