### PR TITLE
Fix `Failed to stop metrics` in request metrics

### DIFF
--- a/synapse/http/request_metrics.py
+++ b/synapse/http/request_metrics.py
@@ -243,7 +243,6 @@ class RequestMetrics:
         response_timer.labels(
             code=response_code_str,
             **response_base_labels,
-            **{SERVER_NAME_LABEL: self.our_server_name},
         ).observe(time_sec - self.start_ts)
 
         resource_usage = context.get_resource_usage()


### PR DESCRIPTION
Fix `Failed to stop metrics` in request metrics

```
Failed to stop metrics: TypeError("prometheus_client.metrics.MetricWrapperBase.labels() got multiple values for keyword argument 'server_name'")
```

### Testing strategy

 1. `SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.handlers.test_message`
 1. Inspect `_trial_temp/test.log` to see any warnings/errors in the logs (search for "Failed to stop metrics")


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
