### PR TITLE
Document that there can be multiple workers handling the receipts stream

### DIFF
--- a/changelog.d/18760.doc.md
+++ b/changelog.d/18760.doc.md
@@ -1,0 +1,1 @@
+Document that there can be multiple workers handling the `receipts` stream.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -533,7 +533,7 @@ the stream writer for the `account_data` stream:
 ##### The `receipts` stream
 
 The `receipts` stream supports multiple writers. The following endpoints
-can be handled by any worker, but should be routed directly one of the workers
+can be handled by any worker, but should be routed directly to one of the workers
 configured as stream writer for the `receipts` stream:
 
     ^/_matrix/client/(r0|v3|unstable)/rooms/.*/receipt
@@ -556,7 +556,7 @@ the stream writer for the `push_rules` stream:
 ##### The `device_lists` stream
 
 The `device_lists` stream supports multiple writers. The following endpoints
-can be handled by any worker, but should be routed directly one of the workers
+can be handled by any worker, but should be routed directly to one of the workers
 configured as stream writer for the `device_lists` stream:
 
     ^/_matrix/client/(r0|v3)/delete_devices$

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -532,8 +532,9 @@ the stream writer for the `account_data` stream:
 
 ##### The `receipts` stream
 
-The following endpoints should be routed directly to the worker configured as
-the stream writer for the `receipts` stream:
+The `receipts` stream supports multiple writers. The following endpoints
+can be handled by any worker, but should be routed directly one of the workers
+configured as stream writer for the `receipts` stream:
 
     ^/_matrix/client/(r0|v3|unstable)/rooms/.*/receipt
     ^/_matrix/client/(r0|v3|unstable)/rooms/.*/read_markers


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))


Noticed when inspecting https://github.com/element-hq/synapse/pull/18581 that some of the documentation was changed to highlight that there can be multiple workers handling the `receipts` stream & I'm aware of instances running multipe `receipts` workers. Document this on `workers.md` too as this is the primary resource for worker configuration
