### PR TITLE
Updated providers.json to use X instead of Twitter following rebrand and schema change

### DIFF
--- a/changelog.d/18767.misc
+++ b/changelog.d/18767.misc
@@ -1,0 +1,1 @@
+Update OEmbed providers to use 'X' instead of 'Twitter' in URL previews, following a rebrand. Contributed by @HammyHavoc.

--- a/synapse/res/providers.json
+++ b/synapse/res/providers.json
@@ -1,14 +1,15 @@
 [
     {
-        "provider_name": "Twitter",
-        "provider_url": "http://www.twitter.com/",
+        "provider_name": "X",
+        "provider_url": "https://x.com/",
         "endpoints": [
             {
                 "schemes": [
-                    "https://twitter.com/*/moments/*",
-                    "https://*.twitter.com/*/moments/*"
+                    "https://x.com/*",
+                    "https://x.com/*/status/*",
+                    "https://*.x.com/*/status/*"
                 ],
-                "url": "https://publish.twitter.com/oembed"
+                "url": "https://publish.x.com/oembed"
             }
         ]
     },


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [X] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
