### PR TITLE
Updated providers.json with complete YouTube schema

### DIFF
--- a/synapse/res/providers.json
+++ b/synapse/res/providers.json
@@ -13,13 +13,21 @@
         ]
     },
     {
-        "provider_name": "YouTube Shorts",
-        "provider_url": "http://www.youtube.com/",
+        "provider_name": "YouTube",
+        "provider_url": "https://www.youtube.com/",
         "endpoints": [
             {
                 "schemes": [
-                    "https://youtube.com/shorts/*",
-                    "https://*.youtube.com/shorts/*"
+                    "https://*.youtube.com/watch*",
+                    "https://*.youtube.com/v/*",
+                    "https://youtu.be/*",
+                    "https://*.youtube.com/playlist?list=*",
+                    "https://youtube.com/playlist?list=*",
+                    "https://*.youtube.com/shorts*",
+                    "https://youtube.com/shorts*",
+                    "https://*.youtube.com/embed/*",
+                    "https://*.youtube.com/live*",
+                    "https://youtube.com/live*"
                 ],
                 "url": "https://www.youtube.com/oembed"
             }


### PR DESCRIPTION
Previously only included YouTube Shorts.

The only thing I'm uncertain about is that when I tried to add `                "discovery": true` to the `"endpoints"`, Synapse didn't want to start with that included. Perhaps someone can shine some light on that?

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [X] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
