### PR TITLE
Make `.sleep(..)` return a coroutine

### DIFF
--- a/synapse/util/__init__.py
+++ b/synapse/util/__init__.py
@@ -27,7 +27,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Generator,
     Iterator,
     Mapping,
     Optional,
@@ -42,7 +41,6 @@ from matrix_common.versionstring import get_distribution_version_string
 from typing_extensions import ParamSpec
 
 from twisted.internet import defer, task
-from twisted.internet.defer import Deferred
 from twisted.internet.interfaces import IDelayedCall, IReactorTime
 from twisted.internet.task import LoopingCall
 from twisted.python.failure import Failure
@@ -121,13 +119,11 @@ class Clock:
 
     _reactor: IReactorTime = attr.ib()
 
-    @defer.inlineCallbacks
-    def sleep(self, seconds: float) -> "Generator[Deferred[float], Any, Any]":
+    async def sleep(self, seconds: float) -> None:
         d: defer.Deferred[float] = defer.Deferred()
         with context.PreserveLoggingContext():
             self._reactor.callLater(seconds, d.callback, seconds)
-            res = yield d
-        return res
+            await d
 
     def time(self) -> float:
         """Returns the current system time in seconds since epoch."""

--- a/tests/rest/client/test_transactions.py
+++ b/tests/rest/client/test_transactions.py
@@ -90,7 +90,7 @@ class HttpTransactionCacheTestCase(unittest.TestCase):
     ) -> Generator["defer.Deferred[Any]", object, None]:
         @defer.inlineCallbacks
         def cb() -> Generator["defer.Deferred[object]", object, Tuple[int, JsonDict]]:
-            yield Clock(reactor).sleep(0)
+            yield defer.ensureDeferred(Clock(reactor).sleep(0))
             return 1, {}
 
         @defer.inlineCallbacks

--- a/tests/server_notices/__init__.py
+++ b/tests/server_notices/__init__.py
@@ -131,7 +131,7 @@ class ServerNoticesTests(unittest.HomeserverTestCase):
                 break
 
             # Sleep and try again.
-            self.clock.sleep(0.1)
+            self.get_success(self.clock.sleep(0.1))
         else:
             self.fail(
                 f"Failed to join the server notices room. No 'join' field in sync_body['rooms']: {sync_body['rooms']}"


### PR DESCRIPTION
This helps ensure that mypy can catch places where we don't await on it, like in #18763.