### PR TITLE
register_new_matrix_user: Fix error message for registration shared secret

### DIFF
--- a/changelog.d/18780.bugfix
+++ b/changelog.d/18780.bugfix
@@ -1,1 +1,1 @@
-Fix error message in `register_new_matrix_user` for empty registration shared secret.
+Fix error message in `register_new_matrix_user` utility script for empty `registration_shared_secret`.

--- a/changelog.d/18780.bugfix
+++ b/changelog.d/18780.bugfix
@@ -1,0 +1,1 @@
+Fix error message in `register_new_matrix_user` for empty registration shared secret.

--- a/synapse/_scripts/register_new_matrix_user.py
+++ b/synapse/_scripts/register_new_matrix_user.py
@@ -281,12 +281,12 @@ def main() -> None:
 
         if not secret and not secret_file:
             bail(_NO_SHARED_SECRET_OPTS_ERROR)
-        if secret_file:
-            if secret:
-                bail(_CONFLICTING_SHARED_SECRET_OPTS_ERROR)
+        elif secret and secret_file:
+            bail(_CONFLICTING_SHARED_SECRET_OPTS_ERROR)
+        elif not secret and secret_file:
             secret = _read_file(secret_file, "registration_shared_secret_path").strip()
-        if not secret:
-            bail(_EMPTY_SHARED_SECRET_OPTS_ERROR)
+            if not secret:
+                bail(_EMPTY_SHARED_SECRET_OPTS_ERROR)
 
     if args.password_file:
         password = _read_file(args.password_file, "password-file").strip()

--- a/synapse/_scripts/register_new_matrix_user.py
+++ b/synapse/_scripts/register_new_matrix_user.py
@@ -273,7 +273,12 @@ def main() -> None:
         assert config is not None
 
         secret = config.get("registration_shared_secret")
+        if not isinstance(secret, (str, type(None))):
+            bail("registration_shared_secret is not a string.")
         secret_file = config.get("registration_shared_secret_path")
+        if not isinstance(secret_file, (str, type(None))):
+            bail("registration_shared_secret_path is not a string.")
+
         if not secret and not secret_file:
             bail(_NO_SHARED_SECRET_OPTS_ERROR)
         if secret_file:

--- a/synapse/_scripts/register_new_matrix_user.py
+++ b/synapse/_scripts/register_new_matrix_user.py
@@ -41,7 +41,7 @@ _NO_SHARED_SECRET_OPTS_ERROR = """\
 No 'registration_shared_secret' or 'registration_shared_secret_path' defined in config.
 """
 
-_EMPTY_SHARED_SECRET_OPTS_ERROR = """\
+_EMPTY_SHARED_SECRET_PATH_OPTS_ERROR = """\
 The secret given via `registration_shared_secret_path` must not be empty.
 """
 
@@ -286,7 +286,7 @@ def main() -> None:
         elif not secret and secret_file:
             secret = _read_file(secret_file, "registration_shared_secret_path").strip()
             if not secret:
-                bail(_EMPTY_SHARED_SECRET_OPTS_ERROR)
+                bail(_EMPTY_SHARED_SECRET_PATH_OPTS_ERROR)
 
     if args.password_file:
         password = _read_file(args.password_file, "password-file").strip()

--- a/synapse/_scripts/register_new_matrix_user.py
+++ b/synapse/_scripts/register_new_matrix_user.py
@@ -30,6 +30,7 @@ from typing import Any, Callable, Dict, Optional
 
 import requests
 import yaml
+from typing_extensions import Never
 
 _CONFLICTING_SHARED_SECRET_OPTS_ERROR = """\
 Conflicting options 'registration_shared_secret' and 'registration_shared_secret_path'
@@ -174,6 +175,12 @@ def register_new_user(
     )
 
 
+def bail(err_msg: str) -> Never:
+    """Prints the given message to stderr and exits."""
+    print(err_msg, file=sys.stderr)
+    sys.exit(1)
+
+
 def main() -> None:
     logging.captureWarnings(True)
 
@@ -268,16 +275,13 @@ def main() -> None:
         secret = config.get("registration_shared_secret")
         secret_file = config.get("registration_shared_secret_path")
         if not secret and not secret_file:
-            print(_NO_SHARED_SECRET_OPTS_ERROR, file=sys.stderr)
-            sys.exit(1)
+            bail(_NO_SHARED_SECRET_OPTS_ERROR)
         if secret_file:
             if secret:
-                print(_CONFLICTING_SHARED_SECRET_OPTS_ERROR, file=sys.stderr)
-                sys.exit(1)
+                bail(_CONFLICTING_SHARED_SECRET_OPTS_ERROR)
             secret = _read_file(secret_file, "registration_shared_secret_path").strip()
         if not secret:
-            print(_EMPTY_SHARED_SECRET_OPTS_ERROR, file=sys.stderr)
-            sys.exit(1)
+            bail(_EMPTY_SHARED_SECRET_OPTS_ERROR)
 
     if args.password_file:
         password = _read_file(args.password_file, "password-file").strip()

--- a/synapse/_scripts/register_new_matrix_user.py
+++ b/synapse/_scripts/register_new_matrix_user.py
@@ -40,6 +40,10 @@ _NO_SHARED_SECRET_OPTS_ERROR = """\
 No 'registration_shared_secret' or 'registration_shared_secret_path' defined in config.
 """
 
+_EMPTY_SHARED_SECRET_OPTS_ERROR = """\
+The secret given via `registration_shared_secret_path` must not be empty.
+"""
+
 _DEFAULT_SERVER_URL = "http://localhost:8008"
 
 
@@ -263,13 +267,16 @@ def main() -> None:
 
         secret = config.get("registration_shared_secret")
         secret_file = config.get("registration_shared_secret_path")
+        if not secret and not secret_file:
+            print(_NO_SHARED_SECRET_OPTS_ERROR, file=sys.stderr)
+            sys.exit(1)
         if secret_file:
             if secret:
                 print(_CONFLICTING_SHARED_SECRET_OPTS_ERROR, file=sys.stderr)
                 sys.exit(1)
             secret = _read_file(secret_file, "registration_shared_secret_path").strip()
         if not secret:
-            print(_NO_SHARED_SECRET_OPTS_ERROR, file=sys.stderr)
+            print(_EMPTY_SHARED_SECRET_OPTS_ERROR, file=sys.stderr)
             sys.exit(1)
 
     if args.password_file:


### PR DESCRIPTION
Fixes the error message in `register_new_matrix_user` for an empty registration shared secret read from file.

### New behavior

| secret     | secret path | file      | result   |
|------------|-------------|-----------|----------|
| empty      | empty       | *         | ✗ NO     |
| empty      | non-empty   | empty     | ✗ EMPTY  |
| empty      | non-empty   | non-empty | ✓        |
| non-empty  | empty       | *         | ✓        |
| non-empty  | non-empty   | *         | ✗ CON    |


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
