### PR TITLE
Make the Make Room Admin API choose to puppet the room creator in v12 rooms

### DIFF
--- a/changelog.d/18805.bugfix
+++ b/changelog.d/18805.bugfix
@@ -1,0 +1,1 @@
+Fix bug where the [Make Room Admin API](https://element-hq.github.io/synapse/latest/admin_api/rooms.html#make-room-admin-api) would not treat a room v12's creator power level as the highest in room.

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -634,7 +634,7 @@ class MakeRoomAdminRestServlet(ResolveRoomIdMixin, RestServlet):
                 for creator in creators:
                     if self.is_mine_id(creator):
                         # include the creator as they won't be in the PL users map.
-                        admin_users.insert(0, creator)
+                        admin_users.append(creator)
 
             if not admin_users:
                 raise SynapseError(

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -2917,6 +2917,39 @@ class MakeRoomAdminTestCase(unittest.HomeserverTestCase):
         )
         self.assertEquals(pl["users"][self.admin_user], 100)
 
+    def test_v12_room_with_many_user_pls(self) -> None:
+        """Test that you can be promoted to the admin user's PL in v12 rooms that contain a range of user PLs."""
+        room_id = self.helper.create_room_as(
+            self.creator,
+            tok=self.creator_tok,
+            room_version=RoomVersions.V12.identifier,
+            is_public=True,
+            extra_content={
+                "power_level_content_override": {
+                    "users": {
+                        self.second_user_id: 50,
+                    },
+                },
+            },
+        )
+
+        self.helper.join(room_id, self.admin_user, tok=self.admin_user_tok)
+        self.helper.join(room_id, self.second_user_id, tok=self.second_tok)
+
+        channel = self.make_request(
+            "POST",
+            f"/_synapse/admin/v1/rooms/{room_id}/make_room_admin",
+            content={},
+            access_token=self.admin_user_tok,
+        )
+
+        self.assertEqual(200, channel.code, msg=channel.json_body)
+
+        pl = self.helper.get_state(
+            room_id, EventTypes.PowerLevels, tok=self.creator_tok
+        )
+        self.assertEquals(pl["users"][self.admin_user], 100)
+
 
 class BlockRoomTestCase(unittest.HomeserverTestCase):
     servlets = [


### PR DESCRIPTION
Original fix by @AndrewFerr.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
