### PR TITLE
Wait for response to be sent

### DIFF
--- a/synapse/http/proxy.py
+++ b/synapse/http/proxy.py
@@ -173,7 +173,7 @@ class ProxyResource(_AsyncResource):
 
         return response.code, response
 
-    def _send_response(
+    async def _send_response(
         self,
         request: "SynapseRequest",
         code: int,
@@ -205,7 +205,7 @@ class ProxyResource(_AsyncResource):
 
         response.deliverBody(_ProxyResponseBody(request))
 
-    def _send_error_response(
+    async def _send_error_response(
         self,
         f: failure.Failure,
         request: "SynapseRequest",

--- a/synapse/media/_base.py
+++ b/synapse/media/_base.py
@@ -122,9 +122,9 @@ MAXIMUM_ALLOWED_MAX_TIMEOUT_MS = 60_000
 _IMMUTABLE_ETAG = "1"
 
 
-def respond_404(request: SynapseRequest) -> None:
+async def respond_404(request: SynapseRequest) -> None:
     assert request.path is not None
-    respond_with_json(
+    await respond_with_json(
         request,
         404,
         cs_error("Not found '%s'" % (request.path.decode(),), code=Codes.NOT_FOUND),
@@ -154,7 +154,7 @@ async def respond_with_file(
 
         finish_request(request)
     else:
-        respond_404(request)
+        await respond_404(request)
 
 
 def add_file_headers(

--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -396,8 +396,8 @@ class MediaRepository:
 
         return MXCUri(self.server_name, media_id)
 
-    def respond_not_yet_uploaded(self, request: SynapseRequest) -> None:
-        respond_with_json(
+    async def respond_not_yet_uploaded(self, request: SynapseRequest) -> None:
+        await respond_with_json(
             request,
             504,
             cs_error("Media has not been uploaded yet", code=Codes.NOT_YET_UPLOADED),
@@ -455,7 +455,7 @@ class MediaRepository:
             await self.clock.sleep(0.5)
 
         logger.info("Media %s has not yet been uploaded", media_id)
-        self.respond_not_yet_uploaded(request)
+        await self.respond_not_yet_uploaded(request)
         return None
 
     async def get_local_media(

--- a/synapse/media/thumbnailer.py
+++ b/synapse/media/thumbnailer.py
@@ -699,7 +699,7 @@ class ThumbnailProvider:
             logger.info("Failed to find any generated thumbnails")
 
             assert request.path is not None
-            respond_with_json(
+            await respond_with_json(
                 request,
                 400,
                 cs_error(

--- a/synapse/rest/client/media.py
+++ b/synapse/rest/client/media.py
@@ -112,7 +112,7 @@ class MediaConfigResource(RestServlet):
             )
         )
         response = user_specific_config if user_specific_config else self.limits_dict
-        respond_with_json(request, 200, response, send_cors=True)
+        await respond_with_json(request, 200, response, send_cors=True)
 
 
 class ThumbnailResource(RestServlet):

--- a/synapse/rest/media/config_resource.py
+++ b/synapse/rest/media/config_resource.py
@@ -50,4 +50,4 @@ class MediaConfigResource(RestServlet):
             )
         )
         response = user_specific_config if user_specific_config else self.limits_dict
-        respond_with_json(request, 200, response, send_cors=True)
+        await respond_with_json(request, 200, response, send_cors=True)

--- a/synapse/rest/media/create_resource.py
+++ b/synapse/rest/media/create_resource.py
@@ -79,7 +79,7 @@ class CreateResource(RestServlet):
             content_uri,
             unused_expires_at,
         )
-        respond_with_json(
+        await respond_with_json(
             request,
             200,
             {

--- a/synapse/rest/media/upload_resource.py
+++ b/synapse/rest/media/upload_resource.py
@@ -130,7 +130,7 @@ class UploadServlet(BaseUploadServlet):
 
         logger.info("Uploaded content with URI '%s'", content_uri)
 
-        respond_with_json(
+        await respond_with_json(
             request, 200, {"content_uri": str(content_uri)}, send_cors=True
         )
 
@@ -184,4 +184,4 @@ class AsyncUploadServlet(BaseUploadServlet):
                 raise SynapseError(400, "Bad content")
 
             logger.info("Uploaded content for media ID %r", media_id)
-            respond_with_json(request, 200, {}, send_cors=True)
+            await respond_with_json(request, 200, {}, send_cors=True)

--- a/tests/http/test_additional_resource.py
+++ b/tests/http/test_additional_resource.py
@@ -36,7 +36,7 @@ class _AsyncTestCustomEndpoint:
 
     async def handle_request(self, request: Request) -> None:
         assert isinstance(request, SynapseRequest)
-        respond_with_json(request, 200, {"some_key": "some_value_async"})
+        await respond_with_json(request, 200, {"some_key": "some_value_async"})
 
 
 class _SyncTestCustomEndpoint:
@@ -45,7 +45,7 @@ class _SyncTestCustomEndpoint:
 
     async def handle_request(self, request: Request) -> None:
         assert isinstance(request, SynapseRequest)
-        respond_with_json(request, 200, {"some_key": "some_value_sync"})
+        await respond_with_json(request, 200, {"some_key": "some_value_sync"})
 
 
 class AdditionalResourceTests(HomeserverTestCase):


### PR DESCRIPTION
Spawning from https://github.com/element-hq/synapse/pull/18804#discussion_r2272826978 as mentioned by @richvdh,

> [...] the goal is just to use `async`/`await` all the way up the chain so the `trace_servlet` doesn't close until we're finished and `LoggingContext.scope` sticks around until the end as expected.

~~But we're no longer using `LoggingContext.scope` since moving to OpenTracing's `ContextVarsScopeManager` in https://github.com/element-hq/synapse/pull/18849~~ (reverted in https://github.com/element-hq/synapse/pull/18849)

The benefit now is TODO

---

In terms of tracing, TODO


Before | After
--- | ---
<img width="807" height="125" alt="2025-08-20_15-50" src="https://github.com/user-attachments/assets/0a682ac7-7bf0-4807-b65f-180985178e28" /> | .


### Dev notes

You can see how I did the simpler implementation of `async` HTTP resources in https://github.com/element-hq/synapse-small-hosts/pull/313

Related links:

https://github.com/element-hq/synapse/pull/18804
https://github.com/twisted/twisted/issues/12498

https://github.com/element-hq/synapse/pull/19007
https://github.com/element-hq/synapse/issues/19004#issuecomment-3358052171


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
