### PR TITLE
Try dumping the whole response in `Request.write` directly

### DIFF
--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -909,6 +909,9 @@ def _write_bytes_to_request(request: Request, bytes_to_write: bytes) -> None:
     large response bodies.
     """
 
+    request.write(bytes_to_write)
+    request.finish()
+
     # The problem with dumping all of the response into the `Request` object at
     # once (via `Request.write`) is that doing so starts the timeout for the
     # next request to be received: so if it takes longer than 60s to stream back
@@ -919,12 +922,12 @@ def _write_bytes_to_request(request: Request, bytes_to_write: bytes) -> None:
 
     # To make sure we don't write all of the bytes at once we split it up into
     # chunks.
-    chunk_size = 4096
-    bytes_generator = chunk_seq(bytes_to_write, chunk_size)
+    # chunk_size = 4096
+    # bytes_generator = chunk_seq(bytes_to_write, chunk_size)
 
-    # We use a `_ByteProducer` here rather than `NoRangeStaticProducer` as the
-    # unit tests can't cope with being given a pull producer.
-    _ByteProducer(request, bytes_generator)
+    # # We use a `_ByteProducer` here rather than `NoRangeStaticProducer` as the
+    # # unit tests can't cope with being given a pull producer.
+    # _ByteProducer(request, bytes_generator)
 
 
 def set_cors_headers(request: "SynapseRequest") -> None:


### PR DESCRIPTION
Try dumping the whole response in `Request.write` directly

Spawning from https://github.com/element-hq/synapse/issues/17722#issuecomment-3201849077 in order to try to reproduce the problem described by the following comment.

The current reasoning why we use a Twisted `Producer` is in this comment. This comment was introduced in https://github.com/matrix-org/synapse/pull/10905 but this knowledge is actually from the PR description of https://github.com/matrix-org/synapse/pull/3701.

https://github.com/element-hq/synapse/blob/40edb10a98ae24c637b7a9cf6a3003bf6fa48b5f/synapse/http/server.py#L912-L915

Originally, we introduced the `_ByteProducer` so that we could iteratively encode JSON and send it over the wire to [avoid blocking the Twisted reactor while serializing large JSON objects](https://github.com/matrix-org/synapse/issues/6998). It was initially a [pull producer](https://github.com/matrix-org/synapse/pull/8013) and was changed to a [push producer](https://github.com/matrix-org/synapse/pull/8116). In https://github.com/matrix-org/synapse/pull/10905, we stopped using the iterative JSON encoder because it's slow Python implementation and now use the standard `JsonEncoder.encode` functions (which are backed by a C library) in a background thread to not block the Twisted reactor.

So it seems like the only reasoning left for using a Twisted `Producer` is the remaining comment above. This behavior was described as a "bug" by @glyph (founder of the Twisted project) so if we can get this problem solved in Twisted, we can eventually remove our `Producer` usage.

> There's definitely a bug where `request.write(big)` should not time you out and close the connection if it takes a long time to write `big`.  Have you reported that one?
>
> *-- @glyph, https://github.com/element-hq/synapse/issues/17722#issuecomment-3201849077*

This is useful because it eliminates complexity and one variable that may be contributing to https://github.com/element-hq/synapse/issues/17722


But overall, using a `Producer` doesn't seem like a completely wrong thing given this description in the docs:

> The purpose of this guide is to describe the Twisted producer and consumer system. The producer system allows applications to stream large amounts of data in a manner which is both memory and CPU efficient, and which does not introduce a source of unacceptable latency into the reactor.
>
> *-- https://docs.twisted.org/en/twisted-25.5.0/core/howto/producers.html*


**Update:** This "bug" behavior is now tracked as a bug in the Twisted repo -> https://github.com/twisted/twisted/issues/12498 (Idle connection timeout incorrectly enforced while sending large response with `Request.write(...)`)



### Dev notes

Commit history:

 - https://github.com/matrix-org/synapse/pull/3693
 - (where we started using a `Producer`) https://github.com/matrix-org/synapse/pull/3701
 - https://github.com/matrix-org/synapse/issues/6998
 - (where we started using our own `_ByteProducer`) https://github.com/matrix-org/synapse/pull/8013
 - https://github.com/matrix-org/synapse/pull/8116
 - https://github.com/matrix-org/synapse/pull/10844
 - https://github.com/matrix-org/synapse/pull/10905

Other smoke:

 - https://github.com/matrix-org/synapse/issues/3741
 - https://github.com/matrix-org/synapse-s3-storage-provider/pull/9

---

Twisted Producers: https://docs.twisted.org/en/stable/core/howto/producers.html

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
