### PR TITLE
Fix worker documentation around room Admin APIs

### DIFF
--- a/changelog.d/18853.doc.md
+++ b/changelog.d/18853.doc.md
@@ -1,0 +1,1 @@
+Fix worker documentation incorrectly indicating all room Admin API requests were capable of being handled by workers.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -252,7 +252,7 @@ information.
     ^/_matrix/client/(api/v1|r0|v3|unstable)/directory/room/.*$
     ^/_matrix/client/(r0|v3|unstable)/capabilities$
     ^/_matrix/client/(r0|v3|unstable)/notifications$
-    ^/_synapse/admin/v1/rooms/
+    ^/_synapse/admin/v1/rooms/[^/]+$
 
     # Encryption requests
     ^/_matrix/client/(r0|v3|unstable)/keys/query$


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Discovered via https://github.com/element-hq/ess-helm/issues/677. Looking at https://github.com/element-hq/synapse/blob/v1.136.0/synapse/rest/admin/__init__.py#L266 only `RoomRestServlet` is generally worker capable. This is just the Room Details API and the v1 Room Delete API and not all the APIs documented on https://element-hq.github.io/synapse/latest/admin_api/rooms.html
