### PR TITLE
Clarify Python dependency constraints

### DIFF
--- a/changelog.d/18856.doc
+++ b/changelog.d/18856.doc
@@ -1,0 +1,1 @@
+Clarify Python dependency constraints in our deprecation policy.

--- a/docs/deprecation_policy.md
+++ b/docs/deprecation_policy.md
@@ -67,7 +67,7 @@ available in both the latest [Debian Stable](https://packages.debian.org/stable/
 extra scrutiny or consideration at this point.
 
 We aggressively update Rust dependencies. Since these are statically linked and managed
-entirely by `cargo` during build, they pose no ongoing maintenance burden on others.
+entirely by `cargo` during build, they *can* pose no ongoing maintenance burden on others.
 This allows us to freely upgrade to leverage the latest ecosystem advancements assuming
 they don't have their own system-level dependencies.
 
@@ -85,5 +85,5 @@ downloading and building all libraries to satisfy dependencies, and these librar
 statically linked into the final binary. This means that from a packager's perspective,
 the Rust dependency versions are an internal build detail, not a runtime dependency to
 be managed on the target system. Consequently, we have even greater flexibility to
-upgrade Rust dependencies as needed for the project.
-
+upgrade Rust dependencies as needed for the project. Some distros (e.g. Fedora) do
+package Rust libraries, but this appears to be the outlier rather than the norm.

--- a/docs/deprecation_policy.md
+++ b/docs/deprecation_policy.md
@@ -26,6 +26,17 @@ The oldest supported version of SQLite is the version
 [provided](https://packages.debian.org/bullseye/libsqlite3-0) by
 [Debian oldstable](https://wiki.debian.org/DebianOldStable).
 
+For Python dependencies, we often specify loose version constraints (ex. `>=X.Y.Z`) to
+be forwards compatible with any new versions. Upper bounds (`<A.B.C`) are only added
+when necessary to prevent known incompatibilities.
+
+When selecting a minimum version, we prioritize alignment with major Linux
+distributions. A version is typically considered acceptable once it is available in both
+the latest [Debian Stable](https://packages.debian.org/stable/) and [Ubuntu
+LTS](https://launchpad.net/ubuntu) repositories.
+
+
+
 Context
 -------
 

--- a/docs/deprecation_policy.md
+++ b/docs/deprecation_policy.md
@@ -1,13 +1,11 @@
-Deprecation Policy for Platform Dependencies
-============================================
+# Deprecation Policy
 
-Synapse has a number of platform dependencies, including Python, Rust, 
-PostgreSQL and SQLite. This document outlines the policy towards which versions 
-we support, and when we drop support for versions in the future.
+Synapse has a number of **platform dependencies** (Python, Rust, PostgreSQL, and SQLite)
+and **application dependencies** (Python and Rust packages). This document outlines the
+policy towards which versions we support, and when we drop support for versions in the
+future.
 
-
-Policy
-------
+## Platform Dependencies
 
 Synapse follows the upstream support life cycles for Python and PostgreSQL,
 i.e. when a version reaches End of Life Synapse will withdraw support for that
@@ -26,19 +24,8 @@ The oldest supported version of SQLite is the version
 [provided](https://packages.debian.org/bullseye/libsqlite3-0) by
 [Debian oldstable](https://wiki.debian.org/DebianOldStable).
 
-For Python dependencies, we often specify loose version constraints (ex. `>=X.Y.Z`) to
-be forwards compatible with any new versions. Upper bounds (`<A.B.C`) are only added
-when necessary to prevent known incompatibilities.
 
-When selecting a minimum version, we prioritize alignment with major Linux
-distributions. A version is typically considered acceptable once it is available in both
-the latest [Debian Stable](https://packages.debian.org/stable/) and [Ubuntu
-LTS](https://launchpad.net/ubuntu) repositories.
-
-
-
-Context
--------
+### Context
 
 It is important for system admins to have a clear understanding of the platform
 requirements of Synapse and its deprecation policies so that they can
@@ -62,3 +49,41 @@ On a similar note, SQLite does not generally have a concept of "supported
 release"; bugfixes are published for the latest minor release only. We chose to
 track Debian's oldstable as this is relatively conservative, predictably updated
 and is consistent with the `.deb` packages released by Matrix.org.
+
+
+## Application dependencies
+
+For application-level Python dependencies, we often specify loose version constraints
+(ex. `>=X.Y.Z`) to be forwards compatible with any new versions. Upper bounds (`<A.B.C`)
+are only added when necessary to prevent known incompatibilities.
+
+When selecting a minimum version, while we are mindful of the impact on downstream
+package maintainers, our primary focus is on the maintainability and progress of Synapse
+itself.
+
+For developers, a Python dependency version can be considered a "no-brainer" upgrade once it is
+available in both the latest [Debian Stable](https://packages.debian.org/stable/) and
+[Ubuntu LTS](https://launchpad.net/ubuntu) repositories. No need to burden yourself with
+extra scrutiny or consideration at this point.
+
+We aggressively update Rust dependencies. Since these are statically linked and managed
+entirely by `cargo` during build, they pose no ongoing maintenance burden on others.
+This allows us to freely upgrade to leverage the latest ecosystem advancements assuming
+they don't have their own system-level dependencies.
+
+
+### Context
+
+Because Python dependencies can easily be managed in a virtual environment, we are less
+concerned about the criteria for selecting minimum versions. The only thing of concern
+is making sure we're not making it unnecessarily difficult for downstream package
+maintainers. Generally, this just means avoiding the bleeding edge for a few months.
+
+The situation for Rust dependencies is fundamentally different. For packagers, the
+concerns around Python dependency versions do not apply. The `cargo` tool handles
+downloading and building all libraries to satisfy dependencies, and these libraries are
+statically linked into the final binary. This means that from a packager's perspective,
+the Rust dependency versions are an internal build detail, not a runtime dependency to
+be managed on the target system. Consequently, we have even greater flexibility to
+upgrade Rust dependencies as needed for the project.
+


### PR DESCRIPTION
Clarify Python dependency constraints

Spawning from https://github.com/element-hq/synapse/pull/18852#issuecomment-3212003675 as I don't actually know the the exact rule of thumb. It's unclear to me what we care about exactly. Our [deprecation policy](https://element-hq.github.io/synapse/latest/deprecation_policy.html) mentions Debian oldstable support at-least for the version of SQLite. But then we only refer to Debian stable for the Twisted dependency:

https://github.com/element-hq/synapse/blob/40edb10a98ae24c637b7a9cf6a3003bf6fa48b5f/pyproject.toml#L179-L186


### Dev notes

Arch:

 - https://wiki.archlinux.org/title/Python_package_guidelines
 - https://wiki.archlinux.org/title/Rust_package_guidelines

Fedora:

 - https://docs.fedoraproject.org/en-US/packaging-guidelines/Rust/

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
