### PR TITLE
Reduce strictness of delayed event delta fetching

### DIFF
--- a/changelog.d/18858.bugfix
+++ b/changelog.d/18858.bugfix
@@ -1,0 +1,1 @@
+Do not throw an error when fetching a rejected delayed state event on startup.

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -215,9 +215,9 @@ class DelayedEventsHandler:
                 "Handling: %r %r, %s", delta.event_type, delta.state_key, delta.event_id
             )
 
-            event = await self._store.get_event(
-                delta.event_id, check_room_id=delta.room_id
-            )
+            event = await self._store.get_event(delta.event_id, allow_none=True)
+            if not event:
+                continue
             sender = UserID.from_string(event.sender)
 
             next_send_ts = await self._store.cancel_delayed_state_events(


### PR DESCRIPTION
- Use `allow_none=True` on the event lookup
- Don't check the room ID of events

Do this to not fail on deltas for rejected events, and to be more in line with how other delta event lookups are done.

MSC4140

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
