### PR TITLE
Store the `LoggingContext` in a `ContextVar`

### DIFF
--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -849,6 +849,7 @@ def run_coroutine_in_background(
 T = TypeVar("T")
 
 
+# TODO: This function is a no-op now and should be removed in a follow-up PR.
 def make_deferred_yieldable(deferred: "defer.Deferred[T]") -> "defer.Deferred[T]":
     return deferred
 


### PR DESCRIPTION
This is a first step towards `ContextVar` based `LoggingContext`. This PR only goes as far as to store the `LoggingContext` in a `ContextVar` instead of thread local. But this still gives us the benefit of being able to remove the painful complexity around needing to make sure the thread local is set correctly as awaitables are suspended and resumed in the Twisted reactor.

Part of https://github.com/element-hq/synapse/issues/10342 (previously https://github.com/matrix-org/synapse/issues/10342)


### Todo

 - [ ] Update `docs/log_contexts.md`

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
