### PR TITLE
Fix prefixed support for MSC4133

### DIFF
--- a/synapse/rest/client/profile.py
+++ b/synapse/rest/client/profile.py
@@ -100,6 +100,10 @@ class ProfileFieldRestServlet(RestServlet):
         re.compile(
             r"^/_matrix/client/v3/profile/(?P<user_id>[^/]*)/(?P<field_name>[^/]*)"
         ),
+        if hs.config.experimental.msc4133_enabled:
+            re.compile(
+                r"^/_matrix/client/unstable/uk\.tcpip\.msc4133/profile/(?P<user_id>[^/]*)/(?P<field_name>[^/]*)"
+            )
     ]
 
     CATEGORY = "Event sending requests"

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -175,6 +175,7 @@ class VersionsRestServlet(RestServlet):
                     "org.matrix.simplified_msc3575": msc3575_enabled,
                     # Arbitrary key-value profile fields.
                     "uk.tcpip.msc4133": self.config.experimental.msc4133_enabled,
+                    "uk.tcpip.msc4133.stable": True,
                     # MSC4155: Invite filtering
                     "org.matrix.msc4155": self.config.experimental.msc4155_enabled,
                     # MSC4306: Support for thread subscriptions


### PR DESCRIPTION
This fixes two bugs that affect the availability of MSC4133 until the next spec release.

 1. The servlet didn't recognise the unstable endpoint even when the homeserver advertised it
 2. The HS didn't advertise support for the stable prefixed version

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
