### PR TITLE
Fix `run_as_background_process` messing with the caller logging context

### DIFF
--- a/changelog.d/18887.misc
+++ b/changelog.d/18887.misc
@@ -1,0 +1,1 @@
+Fix `run_as_background_process` messing with the caller logging context.


### PR DESCRIPTION
Fix `run_as_background_process` messing with the caller logging context

Spawning from https://github.com/element-hq/synapse/pull/18870

### Testing strategy

There seems to be some test pollution with logging context as running all `tests.util.test_logcontext.LoggingContextTestCase` tests will only result in one of these failing. But if you run them individually, they both fail (without a fix):

 1. `SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.util.test_logcontext.LoggingContextTestCase.test_run_as_background_process`
 1. `SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.util.test_logcontext.LoggingContextTestCase.test_run_as_background_process_make_deferred_yieldable`


### Todo

 - [ ] Come up with a fix
 - [x] Add tests


### Dev notes

Synapse log context docs: [`docs/log_contexts.md`](https://github.com/element-hq/synapse/blob/b2997a8f20d1999ec9f73c3d4a5fb210d4294176/docs/log_contexts.md)

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
