### PR TITLE
Cache `_get_e2e_cross_signing_signatures_for_devices`

### DIFF
--- a/changelog.d/18899.feature
+++ b/changelog.d/18899.feature
@@ -1,0 +1,1 @@
+Add an in-memory cache to `_get_e2e_cross_signing_signatures_for_devices` to reduce DB load.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -2653,12 +2653,19 @@ def make_in_list_sql_clause(
 
 
 # These overloads ensure that `columns` and `iterable` values have the same length.
-# Suppress "Single overload definition, multiple required" complaint.
-@overload  # type: ignore[misc]
+@overload
 def make_tuple_in_list_sql_clause(
     database_engine: BaseDatabaseEngine,
     columns: Tuple[str, str],
     iterable: Collection[Tuple[Any, Any]],
+) -> Tuple[str, list]: ...
+
+
+@overload
+def make_tuple_in_list_sql_clause(
+    database_engine: BaseDatabaseEngine,
+    columns: Tuple[str, str, str],
+    iterable: Collection[Tuple[Any, Any, Any]],
 ) -> Tuple[str, list]: ...
 
 

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -62,6 +62,12 @@ PURGE_HISTORY_CACHE_NAME = "ph_cache_fake"
 # As above, but for invalidating room caches on room deletion
 DELETE_ROOM_CACHE_NAME = "dr_cache_fake"
 
+# This cache takes a list of tuples as its first argument, which requires
+# special handling.
+GET_E2E_CROSS_SIGNING_SIGNATURES_FOR_DEVICE_CACHE_NAME = (
+    "_get_e2e_cross_signing_signatures_for_device"
+)
+
 # How long between cache invalidation table cleanups, once we have caught up
 # with the backlog.
 REGULAR_CLEANUP_INTERVAL_MS = Config.parse_duration("1h")
@@ -270,6 +276,30 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
                     # room membership.
                     #
                     # self._membership_stream_cache.all_entities_changed(token)  # type: ignore[attr-defined]
+                elif (
+                    row.cache_func
+                    == GET_E2E_CROSS_SIGNING_SIGNATURES_FOR_DEVICE_CACHE_NAME
+                ):
+                    # "keys" is a list of strings, where each string is a
+                    # stringified representation of the tuple keys, i.e.
+                    # keys: ['(@userid:domain,DEVICEID)','(@userid2:domain,DEVICEID2)']
+                    #
+                    # This is a side-effect of not being able to send nested information over replication.
+                    for tuple_key in row.keys:
+                        user_id, device_id = (
+                            # Remove the leading and following parantheses.
+                            tuple_key[1:-1]
+                            # Split by comma
+                            .split(",")
+                        )
+
+                        # Invalidate each key.
+                        #
+                        # Note: .invalidate takes a tuple of arguments, hence the need
+                        # to nest our tuple in another tuple.
+                        self._get_e2e_cross_signing_signatures_for_device.invalidate(  # type: ignore[attr-defined]
+                            ((user_id, device_id),)
+                        )
                 else:
                     self._attempt_to_invalidate_cache(row.cache_func, row.keys)
 

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -488,7 +488,7 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
                 result.setdefault(user_id, {})[device_id] = None
 
         return result
-    
+
     @cached()
     def _get_e2e_cross_signing_signatures_for_device(
         self,
@@ -499,7 +499,7 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
         See @cachedList for why a separate method is needed.
         """
         raise NotImplementedError()
-    
+
     @cachedList(
         cached_method_name="_get_e2e_cross_signing_signatures_for_device",
         list_name="device_query",
@@ -525,6 +525,7 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
 
             As results are cached, the return type is immutable.
         """
+
         def _get_e2e_cross_signing_signatures_for_devices_txn(
             txn: LoggingTransaction, device_query: Iterable[Tuple[str, str]]
         ) -> Mapping[Tuple[str, str], Sequence[Tuple[str, str]]]:
@@ -1825,6 +1826,7 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
             user_id: the user who made the signatures
             signatures: signatures to add
         """
+
         def _store_e2e_cross_signing_signatures(
             txn: LoggingTransaction,
             signatures: "Iterable[SignatureListItem]",

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -1851,12 +1851,27 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
                 ],
             )
 
+            to_invalidate = [
+                # Each entry is a tuple of arguments to
+                # `_get_e2e_cross_signing_signatures_for_device`, which
+                # itself takes a tuple. Hence the double-tuple.
+                ((user_id, item.target_device_id),)
+                for item in signatures
+            ]
+
+            if to_invalidate:
+                self._invalidate_cache_and_stream_bulk(
+                    txn,
+                    self._get_e2e_cross_signing_signatures_for_device,
+                    to_invalidate,
+                )
+
         await self.db_pool.runInteraction(
             "add_e2e_signing_key",
             _store_e2e_cross_signing_signatures,
             signatures,
         )
-    
+
 
 class EndToEndKeyStore(EndToEndKeyWorkerStore, SQLBaseStore):
     def __init__(

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -377,12 +377,6 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
                     user_id, {}
                 )
 
-                if signature_list is None:
-                    # There are no signatures for this user_id/device_id combination.
-                    # We do this here to ensure that the "signatures" key gets created above,
-                    # even if it is empty.
-                    continue
-
                 for key_id, signature in signature_list:
                     signing_user_signatures[key_id] = signature
 
@@ -507,7 +501,7 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
     )
     async def _get_e2e_cross_signing_signatures_for_devices(
         self, device_query: Iterable[Tuple[str, str]]
-    ) -> Mapping[Tuple[str, str], Optional[Sequence[Tuple[str, str]]]]:
+    ) -> Mapping[Tuple[str, str], Sequence[Tuple[str, str]]]:
         """Get cross-signing signatures for a given list of user IDs and devices.
 
         Args:
@@ -516,9 +510,8 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
         Returns:
             A mapping of results. The keys are the original (user_id, device_id)
             tuple, while the value is the matching list of tuples of
-            (key_id, signature). The value will be `None` instead if no
-            signatures exist for the device (this is a behaviour of
-            `@cachedList`).
+            (key_id, signature). The value will be an empty list if no
+            signatures exist for the device.
 
             Given this method is annotated with `@cachedList`, the return dict's
             keys match the tuples within `device_query`, so that cache entries can

--- a/synapse/util/caches/descriptors.py
+++ b/synapse/util/caches/descriptors.py
@@ -579,9 +579,12 @@ def cachedList(
     Used to do batch lookups for an already created cache. One of the arguments
     is specified as a list that is iterated through to lookup keys in the
     original cache. A new tuple consisting of the (deduplicated) keys that weren't in
-    the cache gets passed to the original function, which is expected to results
+    the cache gets passed to the original function, which is expected to result
     in a map of key to value for each passed value. The new results are stored in the
-    original cache. Note that any missing values are cached as None.
+    original cache.
+
+    Note that any values in the input that end up being missing from both the
+    cache and the returned dictionary will be cached as `None`.
 
     Args:
         cached_method_name: The name of the single-item lookup method.


### PR DESCRIPTION
This PR adds a cache to `_get_e2e_cross_signing_signatures_for_devices` to put less pressure on the database.

**Recommended to review commit-by-commit.**

Requires https://github.com/matrix-org/sytest/pull/1409 for Sytest CI to pass.


Spawning from [discussion in `#matrix-ops:matrix.org`](https://matrix.to/#/!yHWhpxlXVaLcsgDUKb:matrix.org/$-pyPPlE6qxYjMTbi1O1NjL5e2eA5lqBcl9DNyT808t0?via=matrix.org&via=element.io&via=vector.modular.im) and then [later decided to PR](https://matrix.to/#/!yHWhpxlXVaLcsgDUKb:matrix.org/$RxcZJ5lmxD6R3N9WkqoeKfqqvJZBpT3TImbp5wdSnCc?via=matrix.org&via=element.io&via=vector.modular.im)


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
