### PR TITLE
Better explain logcontext in `run_in_background(...)` and `run_as_background_process(...)`

### DIFF
--- a/changelog.d/18900.misc
+++ b/changelog.d/18900.misc
@@ -1,0 +1,1 @@
+Better explain how we manage the logcontext in `run_in_background(...)` and `run_as_background_process(...)`.

--- a/docs/log_contexts.md
+++ b/docs/log_contexts.md
@@ -73,7 +73,7 @@ context as we want to know which server the logs came from. In practice, this is
 always the case yet especially outside of request handling.
 
 Whenever yielding control back to the reactor (event loop), the `sentinel` logcontext is
-used to avoid leaking the current logcontext into the other reactor which would
+set to avoid leaking the current logcontext into the other reactor which would
 erroneously get attached to the next operation picked up by the event loop.
 
 ## Using logcontexts with awaitables

--- a/docs/log_contexts.md
+++ b/docs/log_contexts.md
@@ -59,6 +59,23 @@ def do_request_handling():
     logger.debug("phew")
 ```
 
+### The `sentinel` context
+
+The default context is `synapse.logging.context.SENTINEL_CONTEXT`, which is an empty
+sentinel value to represent the root context. This is what is used when there is no
+other context set. The phrase "clear the logcontext" means to set the current context to
+the `sentinel` context.
+
+No CPU/database usage metrics are recorded against the `sentinel` context.
+
+Ideally, nothing from the Synapse homeserver would be logged against the `sentinel`
+context as we want to know which server the logs came from. In practice, this is not
+always the case yet especially outside of request handling.
+
+Whenever yielding control back to the reactor (event loop), the `sentinel` logcontext is
+used to avoid leaking the current logcontext into the other reactor which would
+erroneously get attached to the next operation picked up by the event loop.
+
 ## Using logcontexts with awaitables
 
 Awaitables break the linear flow of code so that there is no longer a single entry point

--- a/docs/log_contexts.md
+++ b/docs/log_contexts.md
@@ -63,8 +63,8 @@ def do_request_handling():
 
 The default context is `synapse.logging.context.SENTINEL_CONTEXT`, which is an empty
 sentinel value to represent the root context. This is what is used when there is no
-other context set. The phrase "clear the logcontext" means to set the current context to
-the `sentinel` context.
+other context set. The phrase "clear/reset the logcontext" means to set the current
+context to the `sentinel` context.
 
 No CPU/database usage metrics are recorded against the `sentinel` context.
 

--- a/docs/log_contexts.md
+++ b/docs/log_contexts.md
@@ -61,20 +61,25 @@ def do_request_handling():
 
 ### The `sentinel` context
 
-The default context is `synapse.logging.context.SENTINEL_CONTEXT`, which is an empty
-sentinel value to represent the root context. This is what is used when there is no
-other context set. The phrase "clear/reset the logcontext" means to set the current
-context to the `sentinel` context.
+The default logcontext is `synapse.logging.context.SENTINEL_CONTEXT`, which is an empty
+sentinel value to represent the root logcontext. This is what is used when there is no
+other logcontext set. The phrase "clear/reset the logcontext" means to set the current
+logcontext to the `sentinel` logcontext.
 
-No CPU/database usage metrics are recorded against the `sentinel` context.
+No CPU/database usage metrics are recorded against the `sentinel` logcontext.
 
 Ideally, nothing from the Synapse homeserver would be logged against the `sentinel`
-context as we want to know which server the logs came from. In practice, this is not
+logcontext as we want to know which server the logs came from. In practice, this is not
 always the case yet especially outside of request handling.
 
-Whenever yielding control back to the reactor (event loop), the `sentinel` logcontext is
-set to avoid leaking the current logcontext into the other reactor which would
-erroneously get attached to the next operation picked up by the event loop.
+Global things outside of Synapse (e.g. Twisted reactor code) should run in the
+`sentinel` logcontext. It's only when it calls into application code that a logcontext
+gets activated. This means the reactor should be started in the `sentinel` logcontext,
+and any time an awaitable yields control back to the reactor, it should reset the
+logcontext to be the `sentinel` logcontext. This is important to avoid leaking the
+current logcontext to the reactor (which would then get picked up and associated with
+the next thing the reactor does).
+
 
 ## Using logcontexts with awaitables
 

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -625,9 +625,17 @@ class LoggingContextFilter(logging.Filter):
 
 
 class PreserveLoggingContext:
-    """Context manager which replaces the logging context
+    """
+    Context manager which replaces the logging context
 
-    The previous logging context is restored on exit."""
+    The previous logging context is restored on exit.
+
+    `make_deferred_yieldable` is pretty equivalent to using `with
+    PreserveLoggingContext():` (using the default sentinel context), i.e. it clears the
+    logcontext before awaiting (and so before execution passes back to the reactor) and
+    restores the old context once the awaitable completes (execution passes from the
+    reactor back to the code).
+    """
 
     __slots__ = ["_old_context", "_new_context"]
 
@@ -938,6 +946,11 @@ def make_deferred_yieldable(deferred: "defer.Deferred[T]") -> "defer.Deferred[T]
 
     (This is more-or-less the opposite operation to run_in_background in terms of how it
     handles log contexts.)
+
+    Pretty much equivalent to using `with PreserveLoggingContext():`, i.e. it clears the
+    logcontext before awaiting (and so before execution passes back to the reactor) and
+    restores the old context once the awaitable completes (execution passes from the
+    reactor back to the code).
     """
     # The deferred has already completed
     if deferred.called and not deferred.paused:

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -227,7 +227,16 @@ LoggingContextOrSentinel = Union["LoggingContext", "_Sentinel"]
 
 
 class _Sentinel:
-    """Sentinel to represent the root context"""
+    """
+    Sentinel to represent the root context
+
+    This should only be used for tasks outside of Synapse like when we yield control
+    back to the Twisted reactor (event loop) so we don't leak the current logging
+    context to other tasks that are scheduled next in the event loop.
+
+    Nothing from the Synapse homeserver should be logged with the sentinel context. i.e.
+    we should always know which server the logs are coming from.
+    """
 
     __slots__ = ["previous_context", "finished", "request", "tag"]
 

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -896,6 +896,15 @@ def run_coroutine_in_background(
     coroutine directly rather than a function. We can do this because coroutines
     do not run until called, and so calling an async function without awaiting
     cannot change the log contexts.
+
+    This is an ergonomic helper so we can do this:
+    ```python
+    run_coroutine_in_background(func1(arg1))
+    ```
+    Rather than having to do this:
+    ```python
+    run_in_background(lambda: func1(arg1))
+    ```
     """
     calling_context = current_context()
 

--- a/synapse/metrics/background_process_metrics.py
+++ b/synapse/metrics/background_process_metrics.py
@@ -295,6 +295,9 @@ def run_as_background_process(
     #    `sentinel` context and means the new `BackgroundProcessLoggingContext` will
     #    remember the `sentinel` context as its previous context to return to when it
     #    exits and yields control back to the reactor.
+    #
+    # TODO: I think we could simplify this whole block by using `return run_in_background(run)`
+    # which appears to give equivalent behaviour.
     with PreserveLoggingContext():
         # The async `run` task is wrapped in a deferred, which will have the side effect
         # of executing the coroutine.

--- a/synapse/metrics/background_process_metrics.py
+++ b/synapse/metrics/background_process_metrics.py
@@ -228,6 +228,11 @@ def run_as_background_process(
     clock.looping_call and friends (or for firing-and-forgetting in the middle of a
     normal synapse async function).
 
+    Because the returned Deferred does not follow the synapse logcontext rules, awaiting
+    the result of this function will result in the log context being cleared. In order
+    to properly await the result of this function and maintain the current log context,
+    use `make_deferred_yieldable`.
+
     Args:
         desc: a description for this background process type
         server_name: The homeserver name that this background process is being run for
@@ -280,7 +285,20 @@ def run_as_background_process(
                     name=desc, **{SERVER_NAME_LABEL: server_name}
                 ).dec()
 
+    # To explain how the log contexts work here:
+    #  - When this function is called, the current context is stored (using
+    #    `PreserveLoggingContext`), we kick off the background task, and we restore the
+    #    original context before returning (also part of `PreserveLoggingContext`).
+    #  - When the background task finishes, we don't want to leak our background context
+    #    into the reactor which would erroneously get attached to the next operation
+    #    picked up by the event loop. We use `PreserveLoggingContext` to set the
+    #    `sentinel` context and means the new `BackgroundProcessLoggingContext` will
+    #    remember the `sentinel` context as its previous context to return to when it
+    #    exits and yields control back to the reactor.
     with PreserveLoggingContext():
+        # The async `run` task is wrapped in a deferred, which will have the side effect
+        # of executing the coroutine.
+        #
         # Note that we return a Deferred here so that it can be used in a
         # looping_call and other places that expect a Deferred.
         return defer.ensureDeferred(run())

--- a/synapse/metrics/background_process_metrics.py
+++ b/synapse/metrics/background_process_metrics.py
@@ -47,7 +47,7 @@ from twisted.internet import defer
 from synapse.logging.context import (
     ContextResourceUsage,
     LoggingContext,
-    run_in_background,
+    PreserveLoggingContext,
 )
 from synapse.logging.opentracing import SynapseTags, start_active_span
 from synapse.metrics import SERVER_NAME_LABEL
@@ -229,9 +229,9 @@ def run_as_background_process(
     normal synapse async function).
 
     Because the returned Deferred does not follow the synapse logcontext rules, awaiting
-    the result of this function will result in the log context being cleared. In order
-    to properly await the result of this function and maintain the current log context,
-    use `make_deferred_yieldable`.
+    the result of this function will result in the log context being cleared (bad). In
+    order to properly await the result of this function and maintain the current log
+    context, use `make_deferred_yieldable`.
 
     Args:
         desc: a description for this background process type
@@ -285,7 +285,22 @@ def run_as_background_process(
                     name=desc, **{SERVER_NAME_LABEL: server_name}
                 ).dec()
 
-    return run_in_background(run)
+    # To explain how the log contexts work here:
+    #  - When this function is called, the current context is stored (using
+    #    `PreserveLoggingContext`), we kick off the background task, and we restore the
+    #    original context before returning (also part of `PreserveLoggingContext`).
+    #  - When the background task finishes, we don't want to leak our background context
+    #    into the reactor which would erroneously get attached to the next operation
+    #    picked up by the event loop. We use `PreserveLoggingContext` to set the
+    #    `sentinel` context and means the new `BackgroundProcessLoggingContext` will
+    #    remember the `sentinel` context as its previous context to return to when it
+    #    exits and yields control back to the reactor.
+    #
+    # TODO: Why can't we simplify to using `return run_in_background(run)`?
+    with PreserveLoggingContext():
+        # Note that we return a Deferred here so that it can be used in a
+        # looping_call and other places that expect a Deferred.
+        return defer.ensureDeferred(run())
 
 
 P = ParamSpec("P")


### PR DESCRIPTION
Better explain `LoggingContext` in `run_in_background(...)` and `run_as_background_process(...)`. Also adds a section in the docs explaining the `sentinel` logcontext.


Spawning from https://github.com/element-hq/synapse/pull/18870


### Testing strategy

 1. Run Synapse normally and with `daemonize: true`: `poetry run synapse_homeserver --config-path homeserver.yaml`
 1. Execute some requests
 1. Shutdown the server
 1. Look for any bad log entries in your homeserver logs:
    - `Expected logging context sentinel but found main`
    - `Expected logging context main was lost`
    - `Expected previous context`
    - `utime went backwards!`/`stime went backwards!`
    - `Called stop on logcontext POST-0 without recording a start rusage`
    - `Background process re-entered without a proc`

Twisted trial tests:

 1. Run full Twisted trial test suite.
 1. Check the logs for `Test starting with non-sentinel logging context ...`


### Dev notes

 - https://github.com/element-hq/synapse/commit/f22e7cda2c72d461acba664cb083e8c4e3c7572a (https://github.com/matrix-org/synapse/pull/3170)


```
SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.util.test_logcontext

SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.crypto.test_keyring
```

```
SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.metrics.test_background_process_metrics
```

---

> The `make_deferred_yieldable(...)` function is a way of doing so, but it is equivalent to using `with PreserveLoggingContext():`, i.e. it clears the logcontext before awaiting (and so before execution passes back to the reactor) and restores the old context once the awaitable completes (execution passes from the reactor back to the code).
>
> *-- https://github.com/element-hq/synapse/pull/18357#discussion_r2300364504*


### Todo

 - [x] Fix `Expected logging context main was lost`/`Expected logging context GET-0 was lost` issues (start Synapse, `curl http://localhost:8008/_matrix/client/versions`, exit Synapse)

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
