### PR TITLE
Fix `triage_labelled` GHA workflow

### DIFF
--- a/.ci/scripts/triage_labelled_issue.sh
+++ b/.ci/scripts/triage_labelled_issue.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+# 1) Resolve project ID.
+PROJECT_ID=$(gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json | jq -r '.id')
+
+# 2) Find existing item (project card) for this issue.
+ITEM_ID=$(
+  gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json \
+  | jq -r --arg url "$ISSUE_URL" '.items[] | select(.content.url==$url) | .id' | head -n1
+)
+
+# 3) If one doesn't exist, add this issue to the project.
+if [ -z "${ITEM_ID:-}" ]; then
+  ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$ISSUE_URL" --format json | jq -r '.id')
+fi
+
+# 4) Get Status field id + the option id for TARGET_STATUS.
+FIELDS_JSON=$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json)
+STATUS_FIELD=$(echo "$FIELDS_JSON" | jq -r '.fields[] | select(.name=="Status")')
+STATUS_FIELD_ID=$(echo "$STATUS_FIELD" | jq -r '.id')
+OPTION_ID=$(echo "$STATUS_FIELD" | jq -r --arg name "$TARGET_STATUS" '.options[] | select(.name==$name) | .id')
+
+if [ -z "${OPTION_ID:-}" ]; then
+  echo "No Status option named \"$TARGET_STATUS\" found"; exit 1
+fi
+
+# 5) Set Status (moves item to the matching column in the board view).
+gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$OPTION_ID"

--- a/.ci/scripts/triage_labelled_issue.sh
+++ b/.ci/scripts/triage_labelled_issue.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -euo pipefail
 
 # 1) Resolve project ID.

--- a/.github/workflows/triage_labelled.yml
+++ b/.github/workflows/triage_labelled.yml
@@ -22,32 +22,4 @@ jobs:
       TARGET_STATUS: Needs info
     steps:
       - name: Ensure item exists, then set Status
-        run: |
-          set -euo pipefail
-
-          # 1) Resolve project ID.
-          PROJECT_ID=$(gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json | jq -r '.id')
-
-          # 2) Find existing item (project card) for this issue.
-          ITEM_ID=$(
-            gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json \
-            | jq -r --arg url "$ISSUE_URL" '.items[] | select(.content.url==$url) | .id' | head -n1
-          )
-
-          # 3) If one doesn't exist, add this issue to the project.
-          if [ -z "${ITEM_ID:-}" ]; then
-            ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$ISSUE_URL" --format json | jq -r '.id')
-          fi
-
-          # 4) Get Status field id + the option id for TARGET_STATUS.
-          FIELDS_JSON=$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json)
-          STATUS_FIELD=$(echo "$FIELDS_JSON" | jq -r '.fields[] | select(.name=="Status")')
-          STATUS_FIELD_ID=$(echo "$STATUS_FIELD" | jq -r '.id')
-          OPTION_ID=$(echo "$STATUS_FIELD" | jq -r --arg name "$TARGET_STATUS" '.options[] | select(.name==$name) | .id')
-
-          if [ -z "${OPTION_ID:-}" ]; then
-            echo "No Status option named \"$TARGET_STATUS\" found"; exit 1
-          fi
-
-          # 5) Set Status (moves item to the matching column in the board view).
-          gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$OPTION_ID"
+        run: .ci/scripts/triage_labelled_issue.sh

--- a/.github/workflows/triage_labelled.yml
+++ b/.github/workflows/triage_labelled.yml
@@ -22,5 +22,10 @@ jobs:
       # This field is case-sensitive.
       TARGET_STATUS: Needs info
     steps:
-      - name: Ensure item exists, then set Status
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # Only clone the script file we care about, instead of the whole repo.
+          sparse-checkout: .ci/scripts/triage_labelled_issue.sh
+
+      - name: Ensure issue exists on the board, then set Status
         run: .ci/scripts/triage_labelled_issue.sh

--- a/.github/workflows/triage_labelled.yml
+++ b/.github/workflows/triage_labelled.yml
@@ -15,7 +15,8 @@ jobs:
       # This token must have the following scopes: ["repo:public_repo", "admin:org->read:org", "user->read:user", "project"]
       GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
       PROJECT_OWNER: matrix-org
-      # Backend issue triage board
+      # Backend issue triage board.
+      # https://github.com/orgs/matrix-org/projects/67/views/1
       PROJECT_NUMBER: 67
       ISSUE_URL: ${{ github.event.issue.html_url }}
       # This field is case-sensitive.

--- a/.github/workflows/triage_labelled.yml
+++ b/.github/workflows/triage_labelled.yml
@@ -6,43 +6,48 @@ on:
 
 jobs:
   move_needs_info:
-    name: Move X-Needs-Info on the triage board
     runs-on: ubuntu-latest
     if: >
       contains(github.event.issue.labels.*.name, 'X-Needs-Info')
+    permissions:
+      contents: read
+    env:
+      # This token must have the following scopes: ["repo:public_repo", "admin:org->read:org", "user->read:user", "project"]
+      GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+      PROJECT_OWNER: matrix-org
+      # Backend issue triage board
+      PROJECT_NUMBER: 67
+      ISSUE_URL: ${{ github.event.issue.html_url }}
+      # This field is case-sensitive.
+      TARGET_STATUS: Needs info
     steps:
-      - uses: actions/add-to-project@4515659e2b458b27365e167605ac44f219494b66 # v1.0.2
-        id: add_project
-        with:
-          project-url: "https://github.com/orgs/matrix-org/projects/67"
-          github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
-        # This action will error if the issue already exists on the project. Which is
-        # common as `X-Needs-Info` will often be added to issues that are already in
-        # the triage queue. Prevent the whole job from failing in this case.
-        continue-on-error: true
-      - name: Set status
-        env:
-          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+      - name: Ensure item exists, then set Status
         run: |
-          gh api graphql -f query='
-          mutation(
-              $project: ID!
-              $item: ID!
-              $fieldid: ID!
-              $columnid: String!
-            )  {
-            updateProjectV2ItemFieldValue(
-              input: {
-               projectId: $project
-                itemId: $item
-                fieldId: $fieldid
-                value: { 
-                  singleSelectOptionId: $columnid
-                  }
-              }
-            ) {
-              projectV2Item {
-                id
-              }
-            }
-          }' -f project="PVT_kwDOAIB0Bs4AFDdZ" -f item=${{ steps.add_project.outputs.itemId }} -f fieldid="PVTSSF_lADOAIB0Bs4AFDdZzgC6ZA4" -f columnid=ba22e43c --silent
+          set -euo pipefail
+
+          # 1) Resolve project ID.
+          PROJECT_ID=$(gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json | jq -r '.id')
+
+          # 2) Find existing item (project card) for this issue.
+          ITEM_ID=$(
+            gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json \
+            | jq -r --arg url "$ISSUE_URL" '.items[] | select(.content.url==$url) | .id' | head -n1
+          )
+
+          # 3) If one doesn't exist, add this issue to the project.
+          if [ -z "${ITEM_ID:-}" ]; then
+            ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$ISSUE_URL" --format json | jq -r '.id')
+          fi
+
+          # 4) Get Status field id + the option id for TARGET_STATUS.
+          FIELDS_JSON=$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json)
+          STATUS_FIELD=$(echo "$FIELDS_JSON" | jq -r '.fields[] | select(.name=="Status")')
+          STATUS_FIELD_ID=$(echo "$STATUS_FIELD" | jq -r '.id')
+          OPTION_ID=$(echo "$STATUS_FIELD" | jq -r --arg name "$TARGET_STATUS" '.options[] | select(.name==$name) | .id')
+
+          if [ -z "${OPTION_ID:-}" ]; then
+            echo "No Status option named \"$TARGET_STATUS\" found"; exit 1
+          fi
+
+          # 5) Set Status (moves item to the matching column in the board view).
+          gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$OPTION_ID"

--- a/changelog.d/18913.misc
+++ b/changelog.d/18913.misc
@@ -1,0 +1,1 @@
+Fix the GitHub Actions workflow that moves issues labeled "X-Needs-Info" to the "Needs info" column on the team's internal triage board.


### PR DESCRIPTION
I got tired of this workflow failing when triaging issues.

The old workflow failed if the item was already on the board. This was partially fixed in https://github.com/element-hq/synapse/pull/18755, which would skip the `actions/add-to-project` step if the issue was already on the board.

However, that meant that the second step now failed, as it now had an empty value for `${{ steps.add_project.outputs.itemId }}`.

---

This PR rips out the `add-to-project` action (which doesn't handle an issue already being on a project) and our old hand-written code and replaces it with new manual code. I tried to look for another action to replace what we had and came across https://github.com/EndBug/project-fields. But that action doesn't support adding the issue to the project.

This new code was mostly written by AI (GPT-5). It was [tested successfully](https://github.com/anoadragon453/synapse/actions/runs/17672398292/job/50226912575) in a separate repo to ensure it works (though I've since deleted the associated test project).

---

Just as before, issues are not moved out of the "Needs Info" column automatically, unless they are closed. I think it may make sense to move them to "Traiged", but that can be done in a separate PR.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
