### PR TITLE
Fix performance regression related to delayed events processing

### DIFF
--- a/changelog.d/18926.bugfix
+++ b/changelog.d/18926.bugfix
@@ -1,1 +1,1 @@
-Fix performance regression related to the delayed events feature.
+Fix a performance regression related to the experimental Delayed Events ([MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140)) feature.

--- a/changelog.d/18926.bugfix
+++ b/changelog.d/18926.bugfix
@@ -1,0 +1,1 @@
+Fix performance regression related to the delayed events feature.

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -229,6 +229,8 @@ class DelayedEventsHandler:
         Process current state deltas to cancel other users' pending delayed events
         that target the same state.
         """
+        # TODO: How to handle state deltas that are the result of a state reset?
+
         # Get the senders of each delta's state event (as sender information is
         # not currently stored in the `current_state_deltas` table).
         event_id_and_sender_dict = await self._store.get_senders_for_event_ids(

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -146,6 +146,11 @@ class DelayedEventsHandler:
         )
 
     async def _unsafe_process_new_event(self) -> None:
+        # We purposefully fetch the current max room stream ordering before
+        # doing anything else, as it could increment duing processing of state
+        # deltas. We want to avoid updating `delayed_events_stream_pos` past
+        # the stream ordering of the state deltas we've processed. Otherwise
+        # we'll leave gaps in our processing.
         room_max_stream_ordering = self._store.get_room_max_stream_ordering()
 
         # Check that there are actually any delayed events to process. If not, bail early.

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -252,8 +252,8 @@ class DelayedEventsHandler:
 
             sender_str = event_id_and_sender_dict.get(delta.event_id, None)
             if sender_str is None:
-                logger.debug(
-                    "Not handling delta for event where sender is unknown: %s",
+                logger.error(
+                    "Skipping state delta with event ID '%s' as 'sender' was unknown. This is unexpected - please report it as a bug!",
                     delta.event_id,
                 )
                 continue

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -194,7 +194,7 @@ class DelayedEventsHandler:
                 self._clock, name="delayed_events_delta", server_name=self.server_name
             ):
                 room_max_stream_ordering = self._store.get_room_max_stream_ordering()
-                if self._event_pos == room_max_stream_ordering:
+                if self._event_pos >= room_max_stream_ordering:
                     return
 
                 logger.debug(

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -237,8 +237,17 @@ class DelayedEventsHandler:
                 ),
             )
 
-            if self._next_send_ts_changed(next_send_ts):
-                self._schedule_next_at_or_none(next_send_ts)
+            # Schedule the next delayed event call for the earliest
+            # event.
+            if next_send_ts is not None:
+                if (
+                    earliest_next_send_ts is None
+                    or next_send_ts < earliest_next_send_ts
+                ):
+                    earliest_next_send_ts = next_send_ts
+
+        if self._next_send_ts_changed(earliest_next_send_ts):
+            self._schedule_next_at_or_none(earliest_next_send_ts)
 
     async def add(
         self,

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -237,7 +237,6 @@ class DelayedEventsHandler:
 
         # Note: No need to batch as `get_current_state_deltas` will only ever
         # return 100 rows at a time.
-        earliest_next_send_ts = None
         for delta in deltas:
             if delta.event_id is None:
                 logger.debug(
@@ -280,17 +279,8 @@ class DelayedEventsHandler:
                 ),
             )
 
-            # Schedule the next delayed event call for the earliest
-            # event.
-            if next_send_ts is not None:
-                if (
-                    earliest_next_send_ts is None
-                    or next_send_ts < earliest_next_send_ts
-                ):
-                    earliest_next_send_ts = next_send_ts
-
-        if self._next_send_ts_changed(earliest_next_send_ts):
-            self._schedule_next_at_or_none(earliest_next_send_ts)
+            if self._next_send_ts_changed(next_send_ts):
+                self._schedule_next_at_or_none(next_send_ts)
 
     async def add(
         self,

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -1548,7 +1548,7 @@ class PresenceHandler(BasePresenceHandler):
                 self.clock, name="presence_delta", server_name=self.server_name
             ):
                 room_max_stream_ordering = self.store.get_room_max_stream_ordering()
-                if self._event_pos == room_max_stream_ordering:
+                if self._event_pos >= room_max_stream_ordering:
                     return
 
                 logger.debug(

--- a/synapse/handlers/sliding_sync/room_lists.py
+++ b/synapse/handlers/sliding_sync/room_lists.py
@@ -13,7 +13,6 @@
 #
 
 
-import enum
 import logging
 from itertools import chain
 from typing import (
@@ -75,18 +74,13 @@ from synapse.types.handlers.sliding_sync import (
 )
 from synapse.types.state import StateFilter
 from synapse.util import MutableOverlayMapping
+from synapse.util.sentinel import Sentinel
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
 
 
 logger = logging.getLogger(__name__)
-
-
-class Sentinel(enum.Enum):
-    # defining a sentinel in this way allows mypy to correctly handle the
-    # type of a dictionary lookup and subsequent type narrowing.
-    UNSET_SENTINEL = object()
 
 
 # Helper definition for the types that we might return. We do this to avoid

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -682,6 +682,8 @@ class StateStorageController:
                - the stream id which these results go up to
                - list of current_state_delta_stream rows. If it is empty, we are
                  up to date.
+
+            A maximum of 100 rows will be returned.
         """
         # FIXME(faster_joins): what do we do here?
         #   https://github.com/matrix-org/synapse/issues/13008

--- a/synapse/storage/databases/main/delayed_events.py
+++ b/synapse/storage/databases/main/delayed_events.py
@@ -182,6 +182,21 @@ class DelayedEventsStore(SQLBaseStore):
             "restart_delayed_event", restart_delayed_event_txn
         )
 
+    async def get_count_of_delayed_events(self) -> int:
+        """Returns the number of pending delayed events in the DB."""
+
+        def _get_count_of_delayed_events(txn: LoggingTransaction) -> int:
+            sql = "SELECT count(*) FROM delayed_events"
+
+            txn.execute(sql)
+            resp = txn.fetchone()
+            return resp[0] if resp is not None else 0
+
+        return await self.db_pool.runInteraction(
+            "get_count_of_delayed_events",
+            _get_count_of_delayed_events,
+        )
+
     async def get_all_delayed_events_for_user(
         self,
         user_localpart: str,

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -2137,7 +2137,7 @@ class EventsWorkerStore(SQLBaseStore):
 
     async def get_senders_for_event_ids(
         self, event_ids: Collection[str]
-    ) -> Dict[str, str]:
+    ) -> Dict[str, Optional[str]]:
         """
         Given a sequence of event IDs, return the sender associated with each.
 
@@ -2151,7 +2151,9 @@ class EventsWorkerStore(SQLBaseStore):
         for that event ID will be returned.
         """
 
-        def _get_senders_for_event_ids(txn: LoggingTransaction) -> Dict[str, str]:
+        def _get_senders_for_event_ids(
+            txn: LoggingTransaction,
+        ) -> Dict[str, Optional[str]]:
             rows = self.db_pool.simple_select_many_txn(
                 txn=txn,
                 table="events",

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -2146,6 +2146,9 @@ class EventsWorkerStore(SQLBaseStore):
 
         Returns:
             A dict of event ID -> sender of the event.
+
+        If a given event ID does not exist in the `events` table, then no entry
+        for that event ID will be returned.
         """
 
         def _get_senders_for_event_ids(txn: LoggingTransaction) -> Dict[str, str]:

--- a/synapse/storage/databases/main/state_deltas.py
+++ b/synapse/storage/databases/main/state_deltas.py
@@ -94,6 +94,8 @@ class StateDeltasStore(SQLBaseStore):
                 - the stream id which these results go up to
                 - list of current_state_delta_stream rows. If it is empty, we are
                   up to date.
+
+            A maximum of 100 rows will be returned.
         """
         prev_stream_id = int(prev_stream_id)
 

--- a/synapse/util/sentinel.py
+++ b/synapse/util/sentinel.py
@@ -1,0 +1,21 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2025 New Vector, Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+
+import enum
+
+
+class Sentinel(enum.Enum):
+    # defining a sentinel in this way allows mypy to correctly handle the
+    # type of a dictionary lookup and subsequent type narrowing.
+    UNSET_SENTINEL = object()

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -20,7 +20,7 @@
 #
 
 import logging
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from twisted.internet.testing import MemoryReactor
 
@@ -37,6 +37,77 @@ from synapse.util import Clock
 from tests.unittest import HomeserverTestCase
 
 logger = logging.getLogger(__name__)
+
+
+class EventsTestCase(HomeserverTestCase):
+    servlets = [
+        admin.register_servlets,
+        room.register_servlets,
+        login.register_servlets,
+    ]
+
+    def prepare(
+        self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
+    ) -> None:
+        self._store = self.hs.get_datastores().main
+
+    def test_get_senders_for_event_ids(self) -> None:
+        """Tests the `get_senders_for_event_ids` storage function."""
+
+        users_and_tokens: Dict[str, str] = {}
+        for localpart_suffix in range(10):
+            localpart = f"user_{localpart_suffix}"
+            user_id = self.register_user(localpart, "rabbit")
+            token = self.login(localpart, "rabbit")
+
+            users_and_tokens[user_id] = token
+
+        room_creator_user_id = self.register_user("room_creator", "rabbit")
+        room_creator_token = self.login("room_creator", "rabbit")
+        users_and_tokens[room_creator_user_id] = room_creator_token
+
+        # Create a room and invite some users.
+        room_id = self.helper.create_room_as(
+            room_creator_user_id, tok=room_creator_token
+        )
+        event_ids_to_senders: Dict[str, str] = {}
+        for user_id, token in users_and_tokens.items():
+            if user_id == room_creator_user_id:
+                continue
+
+            self.helper.invite(
+                room=room_id,
+                targ=user_id,
+                tok=room_creator_token,
+            )
+
+            # Have the user accept the invite and join the room.
+            self.helper.join(
+                room=room_id,
+                user=user_id,
+                tok=token,
+            )
+
+            # Have the user send an event.
+            response = self.helper.send_event(
+                room_id=room_id,
+                type="m.room.message",
+                content={
+                    "msgtype": "m.text",
+                    "body": f"hello, I'm {user_id}!",
+                },
+                tok=token,
+            )
+
+            # Record the event ID and sender.
+            event_id = response["event_id"]
+            event_ids_to_senders[event_id] = user_id
+
+        # Check that `get_senders_for_event_ids` returns the correct data.
+        response = self.get_success(
+            self._store.get_senders_for_event_ids(list(event_ids_to_senders.keys()))
+        )
+        self.assert_dict(event_ids_to_senders, response)
 
 
 class ExtremPruneTestCase(HomeserverTestCase):


### PR DESCRIPTION
Hopefully fixes https://github.com/element-hq/synapse/issues/18925.

Carries out a number of optimisations to this bit of the codebase (note that on element.io we have about 7mil state deltas to process):

* Replace a `get_event` DB query per state delta with a single, smaller query for all state deltas.
* Bail out early if there are no delayed events in the DB to update.
* ~~Set the next "scheduled at" time to the minimum of all delayed events once, instead of doing so for every delta.~~ this ended up causing tests to fail, and has been reverted.

Highly recommended to review commit-by-commit.

MSC4140

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
