### PR TITLE
`/client/versions`: Advertise MSC4076: Add disable_badge_count to pusher configuration

### DIFF
--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -180,6 +180,8 @@ class VersionsRestServlet(RestServlet):
                     "org.matrix.msc4155": self.config.experimental.msc4155_enabled,
                     # MSC4306: Support for thread subscriptions
                     "org.matrix.msc4306": self.config.experimental.msc4306_enabled,
+                    # MSC4076: Let E2EE clients calculate app badge counts themselves (disable_badge_count)
+                    "org.matrix.msc4076": self.config.experimental.msc4076_enabled,
                 },
             },
         )


### PR DESCRIPTION
so that we can use [MSC4076: Let E2EE clients calculate app badge counts themselves (disable_badge_count)](https://github.com/matrix-org/matrix-spec-proposals/pull/4076).

I was not aware of this need when I submitted https://github.com/element-hq/synapse/pull/17975.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
