### PR TITLE
OIDC doc: adds missing `jwt_config` values to authentik example

### DIFF
--- a/changelog.d/18931.doc
+++ b/changelog.d/18931.doc
@@ -1,0 +1,2 @@
+Clarify necessary `jwt_config` parameter in OIDC documentation for authentik.
+Contributed by @maxkratz.

--- a/docs/openid.md
+++ b/docs/openid.md
@@ -186,6 +186,7 @@ oidc_providers:
 4. Note the slug of your application, Client ID and Client Secret.
 
 Note: RSA keys must be used for signing for Authentik, ECC keys do not work.
+Note: The provider must have a signing key set and must not use an encryption key.
 
 Synapse config:
 ```yaml
@@ -204,6 +205,11 @@ oidc_providers:
       config:
         localpart_template: "{{ user.preferred_username }}"
         display_name_template: "{{ user.preferred_username|capitalize }}" # TO BE FILLED: If your users have names in Authentik and you want those in Synapse, this should be replaced with user.name|capitalize.
+[...]
+jwt_config:
+    enabled: true
+    secret: "your client secret" # TO BE FILLED (same as `client_secret` above)
+    algorithm: "RS256"
 ```
 
 ### Dex

--- a/docs/openid.md
+++ b/docs/openid.md
@@ -210,6 +210,7 @@ jwt_config:
     enabled: true
     secret: "your client secret" # TO BE FILLED (same as `client_secret` above)
     algorithm: "RS256"
+    # (...other fields)
 ```
 
 ### Dex


### PR DESCRIPTION
This PR addresses https://github.com/element-hq/synapse/issues/17896 by extending the Synapse documentation regarding the necessary `jwt_config` entry in the example on how to connect authentik via OIDC to Synapse.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
