### PR TITLE
Bump batch size from 50 to 1000 for `_get_e2e_cross_signing_signatures_for_devices` query

### DIFF
--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -354,7 +354,7 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
             if d is not None and d.keys is not None
         )
 
-        for batch in batch_iter(signature_query, 50):
+        for batch in batch_iter(signature_query, 1000):
             cross_sigs_result = (
                 await self._get_e2e_cross_signing_signatures_for_devices(batch)
             )


### PR DESCRIPTION
Increase the batch size from 50 to 1000 when fetching the signatures of E2E keys. This results in fewer queries to the DB, which in one instance, significantly reduced DB pressure on matrix.org.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
