### PR TITLE
Introduce `Clock.call_when_running(...)` to include logcontext by default

### DIFF
--- a/changelog.d/18944.misc
+++ b/changelog.d/18944.misc
@@ -1,1 +1,1 @@
-Introduce `Clock.call_when_running(...)` so that any Synapse code running when the reactor starts includes logcontext as we want to know which server the logs came from.
+Introduce `Clock.call_when_running(...)` to wrap startup code in a logcontext, ensuring we can identify which server generated the logs.

--- a/changelog.d/18944.misc
+++ b/changelog.d/18944.misc
@@ -1,0 +1,1 @@
+Introduce `Clock.call_when_running(...)` so that any Synapse code running when the reactor starts includes logcontext as we want to know which server the logs came from.

--- a/scripts-dev/sign_json.py
+++ b/scripts-dev/sign_json.py
@@ -30,7 +30,7 @@ from signedjson.sign import sign_json
 
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS
 from synapse.crypto.event_signing import add_hashes_and_signatures
-from synapse.util import json_encoder
+from synapse.util.json import json_encoder
 
 
 def main() -> None:

--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -1586,8 +1586,7 @@ def main() -> None:
 
         @defer.inlineCallbacks
         def run() -> Generator["defer.Deferred[Any]", Any, None]:
-            with LoggingContext("synapse_port_db_run"):
-                yield defer.ensureDeferred(porter.run())
+            yield defer.ensureDeferred(porter.run())
 
         hs.get_clock().call_when_running(run)
 

--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -98,7 +98,8 @@ from synapse.storage.databases.state.bg_updates import StateBackgroundUpdateStor
 from synapse.storage.engines import create_engine
 from synapse.storage.prepare_database import prepare_database
 from synapse.types import ISynapseReactor
-from synapse.util import SYNAPSE_VERSION, Clock
+from synapse.util import SYNAPSE_VERSION
+from synapse.util.clock import Clock
 from synapse.util.stringutils import random_string
 
 # Cast safety: Twisted does some naughty magic which replaces the

--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -1567,7 +1567,7 @@ def main() -> None:
     config = HomeServerConfig()
     config.parse_config_dict(hs_config, "", "")
 
-    hs = MockHomeserver(hs_config)
+    hs = MockHomeserver(config)
 
     def start(stdscr: Optional["curses.window"] = None) -> None:
         progress: Progress

--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -54,7 +54,6 @@ from twisted.internet import defer, reactor as reactor_
 from synapse.config.database import DatabaseConnectionConfig
 from synapse.config.homeserver import HomeServerConfig
 from synapse.logging.context import (
-    LoggingContext,
     make_deferred_yieldable,
     run_in_background,
 )

--- a/synapse/_scripts/update_synapse_database.py
+++ b/synapse/_scripts/update_synapse_database.py
@@ -74,7 +74,7 @@ def run_background_updates(hs: HomeServer) -> None:
             )
         )
 
-    reactor.callWhenRunning(run)
+    hs.get_clock().call_when_running(run)
 
     reactor.run()
 

--- a/synapse/api/auth/mas.py
+++ b/synapse/api/auth/mas.py
@@ -43,9 +43,9 @@ from synapse.logging.opentracing import (
 from synapse.metrics import SERVER_NAME_LABEL
 from synapse.synapse_rust.http_client import HttpClient
 from synapse.types import JsonDict, Requester, UserID, create_requester
-from synapse.util import json_decoder
 from synapse.util.caches.cached_call import RetryOnExceptionCachedCall
 from synapse.util.caches.response_cache import ResponseCache, ResponseCacheContext
+from synapse.util.json import json_decoder
 
 from . import introspection_response_timer
 

--- a/synapse/api/auth/msc3861_delegated.py
+++ b/synapse/api/auth/msc3861_delegated.py
@@ -48,9 +48,9 @@ from synapse.logging.opentracing import (
 from synapse.metrics import SERVER_NAME_LABEL
 from synapse.synapse_rust.http_client import HttpClient
 from synapse.types import Requester, UserID, create_requester
-from synapse.util import json_decoder
 from synapse.util.caches.cached_call import RetryOnExceptionCachedCall
 from synapse.util.caches.response_cache import ResponseCache, ResponseCacheContext
+from synapse.util.json import json_decoder
 
 from . import introspection_response_timer
 

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -30,7 +30,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from twisted.web import http
 
-from synapse.util import json_decoder
+from synapse.util.json import json_decoder
 
 if typing.TYPE_CHECKING:
     from synapse.config.homeserver import HomeServerConfig

--- a/synapse/api/ratelimiting.py
+++ b/synapse/api/ratelimiting.py
@@ -26,7 +26,7 @@ from synapse.api.errors import LimitExceededError
 from synapse.config.ratelimiting import RatelimitSettings
 from synapse.storage.databases.main import DataStore
 from synapse.types import Requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 if TYPE_CHECKING:
     # To avoid circular imports:

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -241,7 +241,7 @@ def redirect_stdio_to_logs() -> None:
 
 
 def register_start(
-    cb: Callable[P, Awaitable], *args: P.args, **kwargs: P.kwargs
+    hs: "HomeServer", cb: Callable[P, Awaitable], *args: P.args, **kwargs: P.kwargs
 ) -> None:
     """Register a callback with the reactor, to be called once it is running
 
@@ -278,7 +278,8 @@ def register_start(
             # on as normal.
             os._exit(1)
 
-    reactor.callWhenRunning(lambda: defer.ensureDeferred(wrapper()))
+    clock = hs.get_clock()
+    clock.call_when_running(lambda: defer.ensureDeferred(wrapper()))
 
 
 def listen_metrics(bind_addresses: StrCollection, port: int) -> None:

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -360,7 +360,7 @@ def start(config_options: List[str]) -> None:
         with LoggingContext("start"):
             await _base.start(hs)
 
-    register_start(start)
+    register_start(hs, start)
 
     # redirect stdio to the logs, if configured.
     if not hs.config.logging.no_redirect_stdio:

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -356,9 +356,7 @@ def start(config_options: List[str]) -> None:
         handle_startup_exception(e)
 
     async def start() -> None:
-        # Re-establish log context now that we're back from the reactor
-        with LoggingContext("start"):
-            await _base.start(hs)
+        await _base.start(hs)
 
     register_start(hs, start)
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -377,17 +377,15 @@ def setup(config_options: List[str]) -> SynapseHomeServer:
         handle_startup_exception(e)
 
     async def start() -> None:
-        # Re-establish log context now that we're back from the reactor
-        with LoggingContext("start"):
-            # Load the OIDC provider metadatas, if OIDC is enabled.
-            if hs.config.oidc.oidc_enabled:
-                oidc = hs.get_oidc_handler()
-                # Loading the provider metadata also ensures the provider config is valid.
-                await oidc.load_metadata()
+        # Load the OIDC provider metadatas, if OIDC is enabled.
+        if hs.config.oidc.oidc_enabled:
+            oidc = hs.get_oidc_handler()
+            # Loading the provider metadata also ensures the provider config is valid.
+            await oidc.load_metadata()
 
-            await _base.start(hs)
+        await _base.start(hs)
 
-            hs.get_datastores().main.db_pool.updates.start_doing_background_updates()
+        hs.get_datastores().main.db_pool.updates.start_doing_background_updates()
 
     register_start(hs, start)
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -389,7 +389,7 @@ def setup(config_options: List[str]) -> SynapseHomeServer:
 
             hs.get_datastores().main.db_pool.updates.start_doing_background_updates()
 
-    register_start(start)
+    register_start(hs, start)
 
     return hs
 

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -84,7 +84,7 @@ from synapse.logging.context import run_in_background
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.storage.databases.main import DataStore
 from synapse.types import DeviceListUpdates, JsonMapping
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/events/builder.py
+++ b/synapse/events/builder.py
@@ -38,7 +38,7 @@ from synapse.storage.databases.main import DataStore
 from synapse.synapse_rust.events import EventInternalMetadata
 from synapse.types import EventID, JsonDict, StrCollection
 from synapse.types.state import StateFilter
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.stringutils import random_string
 
 if TYPE_CHECKING:

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -178,7 +178,7 @@ from synapse.types import (
     StrCollection,
     get_domain_from_id,
 )
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.metrics import Measure
 from synapse.util.retryutils import filter_destinations_by_retry_limiter
 

--- a/synapse/federation/sender/transaction_manager.py
+++ b/synapse/federation/sender/transaction_manager.py
@@ -36,7 +36,7 @@ from synapse.logging.opentracing import (
 )
 from synapse.metrics import SERVER_NAME_LABEL
 from synapse.types import JsonDict
-from synapse.util import json_decoder
+from synapse.util.json import json_decoder
 from synapse.util.metrics import measure_func
 
 if TYPE_CHECKING:

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -62,7 +62,7 @@ class DeactivateAccountHandler:
         # Start the user parter loop so it can resume parting users from rooms where
         # it left off (if it has work left to do).
         if hs.config.worker.worker_app is None:
-            hs.get_reactor().callWhenRunning(self._start_user_parting)
+            hs.get_clock().call_when_running(self._start_user_parting)
         else:
             self._notify_account_deactivated_client = (
                 ReplicationNotifyAccountDeactivatedServlet.make_client(hs)

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -1002,7 +1002,7 @@ class DeviceWriterHandler(DeviceHandler):
         # rolling-restarting Synapse.
         if self._is_main_device_list_writer:
             # On start up check if there are any updates pending.
-            hs.get_reactor().callWhenRunning(self._handle_new_device_update_async)
+            hs.get_clock().call_when_running(self._handle_new_device_update_async)
             self.device_list_updater = DeviceListUpdater(hs, self)
             hs.get_federation_registry().register_edu_handler(
                 EduTypes.DEVICE_LIST_UPDATE,

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -34,7 +34,7 @@ from synapse.logging.opentracing import (
     set_tag,
 )
 from synapse.types import JsonDict, Requester, StreamKeyType, UserID, get_domain_from_id
-from synapse.util import json_encoder
+from synapse.util.json import json_encoder
 from synapse.util.stringutils import random_string
 
 if TYPE_CHECKING:

--- a/synapse/handlers/e2e_keys.py
+++ b/synapse/handlers/e2e_keys.py
@@ -44,9 +44,9 @@ from synapse.types import (
     get_domain_from_id,
     get_verify_key_from_cross_signing_key,
 )
-from synapse.util import json_decoder
 from synapse.util.async_helpers import Linearizer, concurrently_execute
 from synapse.util.cancellation import cancellable
+from synapse.util.json import json_decoder
 from synapse.util.retryutils import (
     NotRetryingDestination,
     filter_destinations_by_retry_limiter,

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -39,8 +39,8 @@ from synapse.http import RequestTimedOutError
 from synapse.http.client import SimpleHttpClient
 from synapse.http.site import SynapseRequest
 from synapse.types import JsonDict, Requester
-from synapse.util import json_decoder
 from synapse.util.hash import sha256_and_url_safe_base64
+from synapse.util.json import json_decoder
 from synapse.util.stringutils import (
     assert_valid_client_secret,
     random_string,

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -81,9 +81,10 @@ from synapse.types import (
     create_requester,
 )
 from synapse.types.state import StateFilter
-from synapse.util import json_decoder, json_encoder, log_failure, unwrapFirstError
+from synapse.util import log_failure, unwrapFirstError
 from synapse.util.async_helpers import Linearizer, gather_results
 from synapse.util.caches.expiringcache import ExpiringCache
+from synapse.util.json import json_decoder, json_encoder
 from synapse.util.metrics import measure_func
 from synapse.visibility import get_effective_room_visibility_from_state
 

--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -67,8 +67,9 @@ from synapse.http.site import SynapseRequest
 from synapse.logging.context import make_deferred_yieldable
 from synapse.module_api import ModuleApi
 from synapse.types import JsonDict, UserID, map_username_to_mxid_localpart
-from synapse.util import Clock, json_decoder
 from synapse.util.caches.cached_call import RetryOnExceptionCachedCall
+from synapse.util.clock import Clock
+from synapse.util.json import json_decoder
 from synapse.util.macaroons import MacaroonGenerator, OidcSessionData
 from synapse.util.templates import _localpart_from_email_filter
 

--- a/synapse/handlers/ui_auth/checkers.py
+++ b/synapse/handlers/ui_auth/checkers.py
@@ -27,7 +27,7 @@ from twisted.web.client import PartialDownloadError
 
 from synapse.api.constants import LoginType
 from synapse.api.errors import Codes, LoginError, SynapseError
-from synapse.util import json_decoder
+from synapse.util.json import json_decoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -87,8 +87,8 @@ from synapse.logging.context import make_deferred_yieldable, run_in_background
 from synapse.logging.opentracing import set_tag, start_active_span, tags
 from synapse.metrics import SERVER_NAME_LABEL
 from synapse.types import ISynapseReactor, StrSequence
-from synapse.util import json_decoder
 from synapse.util.async_helpers import timeout_deferred
+from synapse.util.json import json_decoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/http/federation/matrix_federation_agent.py
+++ b/synapse/http/federation/matrix_federation_agent.py
@@ -49,7 +49,7 @@ from synapse.http.federation.well_known_resolver import WellKnownResolver
 from synapse.http.proxyagent import ProxyAgent
 from synapse.logging.context import make_deferred_yieldable, run_in_background
 from synapse.types import ISynapseReactor
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/http/federation/well_known_resolver.py
+++ b/synapse/http/federation/well_known_resolver.py
@@ -27,7 +27,6 @@ from typing import Callable, Dict, Optional, Tuple
 import attr
 
 from twisted.internet import defer
-from twisted.internet.interfaces import IReactorTime
 from twisted.web.client import RedirectAgent
 from twisted.web.http import stringToDatetime
 from twisted.web.http_headers import Headers
@@ -35,6 +34,7 @@ from twisted.web.iweb import IAgent, IResponse
 
 from synapse.http.client import BodyExceededMaxSize, read_body_with_max_size
 from synapse.logging.context import make_deferred_yieldable
+from synapse.types import ISynapseThreadlessReactor
 from synapse.util.caches.ttlcache import TTLCache
 from synapse.util.clock import Clock
 from synapse.util.json import json_decoder
@@ -89,7 +89,7 @@ class WellKnownResolver:
     def __init__(
         self,
         server_name: str,
-        reactor: IReactorTime,
+        reactor: ISynapseThreadlessReactor,
         agent: IAgent,
         user_agent: bytes,
         well_known_cache: Optional[TTLCache[bytes, Optional[bytes]]] = None,

--- a/synapse/http/federation/well_known_resolver.py
+++ b/synapse/http/federation/well_known_resolver.py
@@ -35,8 +35,9 @@ from twisted.web.iweb import IAgent, IResponse
 
 from synapse.http.client import BodyExceededMaxSize, read_body_with_max_size
 from synapse.logging.context import make_deferred_yieldable
-from synapse.util import Clock, json_decoder
 from synapse.util.caches.ttlcache import TTLCache
+from synapse.util.clock import Clock
+from synapse.util.json import json_decoder
 from synapse.util.metrics import Measure
 
 # period to cache .well-known results for by default

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -89,8 +89,8 @@ from synapse.logging.context import make_deferred_yieldable, run_in_background
 from synapse.logging.opentracing import set_tag, start_active_span, tags
 from synapse.metrics import SERVER_NAME_LABEL
 from synapse.types import JsonDict
-from synapse.util import json_decoder
 from synapse.util.async_helpers import AwakenableSleeper, Linearizer, timeout_deferred
+from synapse.util.json import json_decoder
 from synapse.util.metrics import Measure
 from synapse.util.stringutils import parse_and_validate_server_name
 

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -77,10 +77,11 @@ from synapse.api.errors import (
 from synapse.config.homeserver import HomeServerConfig
 from synapse.logging.context import defer_to_thread, preserve_fn, run_in_background
 from synapse.logging.opentracing import active_span, start_active_span, trace_servlet
-from synapse.util import Clock, json_encoder
 from synapse.util.caches import intern_dict
 from synapse.util.cancellation import is_function_cancellable
+from synapse.util.clock import Clock
 from synapse.util.iterutils import chunk_seq
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     import opentracing

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -52,9 +52,10 @@ from zope.interface import implementer
 
 from twisted.internet import defer, interfaces, reactor
 from twisted.internet.defer import CancelledError
-from twisted.internet.interfaces import IReactorTime
 from twisted.python import failure
 from twisted.web import resource
+
+from synapse.types import ISynapseThreadlessReactor
 
 try:
     from twisted.web.pages import notFound
@@ -411,7 +412,7 @@ class DirectServeJsonResource(_AsyncResource):
         clock: Optional[Clock] = None,
     ):
         if clock is None:
-            clock = Clock(cast(IReactorTime, reactor))
+            clock = Clock(cast(ISynapseThreadlessReactor, reactor))
 
         super().__init__(clock, extract_context)
         self.canonical_json = canonical_json
@@ -590,7 +591,7 @@ class DirectServeHtmlResource(_AsyncResource):
         clock: Optional[Clock] = None,
     ):
         if clock is None:
-            clock = Clock(cast(IReactorTime, reactor))
+            clock = Clock(cast(ISynapseThreadlessReactor, reactor))
 
         super().__init__(clock, extract_context)
 

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -51,7 +51,7 @@ from synapse.api.errors import Codes, SynapseError
 from synapse.http import redact_uri
 from synapse.http.server import HttpServer
 from synapse.types import JsonDict, RoomAlias, RoomID, StrCollection
-from synapse.util import json_decoder
+from synapse.util.json import json_decoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/logging/handlers.py
+++ b/synapse/logging/handlers.py
@@ -60,8 +60,18 @@ class PeriodicallyFlushingMemoryHandler(MemoryHandler):
         else:
             reactor_to_use = reactor
 
-        # call our hook when the reactor start up
-        reactor_to_use.callWhenRunning(on_reactor_running)
+        # Call our hook when the reactor start up
+        #
+        # type-ignore: Ideally, we'd use `Clock.call_when_running(...)`, but
+        # `PeriodicallyFlushingMemoryHandler` is instantiated via Python logging
+        # configuration, so it's not straightforward to pass in the homeserver's clock
+        # (and we don't want to burden other peoples logging config with the details).
+        #
+        # The important reason why we want to use `Clock.call_when_running` is so that
+        # the callback runs with a logcontext as we want to know which server the logs
+        # came from. But since we don't log anything in the callback, it's safe to
+        # ignore the lint here.
+        reactor_to_use.callWhenRunning(on_reactor_running)  # type: ignore[prefer-synapse-clock-call-when-running]
 
     def shouldFlush(self, record: LogRecord) -> bool:
         """

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -204,7 +204,7 @@ from twisted.web.http import Request
 from twisted.web.http_headers import Headers
 
 from synapse.config import ConfigError
-from synapse.util import json_decoder, json_encoder
+from synapse.util.json import json_decoder, json_encoder
 
 if TYPE_CHECKING:
     from synapse.http.site import SynapseRequest

--- a/synapse/media/_base.py
+++ b/synapse/media/_base.py
@@ -54,8 +54,8 @@ from synapse.logging.context import (
     make_deferred_yieldable,
     run_in_background,
 )
-from synapse.util import Clock
 from synapse.util.async_helpers import DeferredEvent
+from synapse.util.clock import Clock
 from synapse.util.stringutils import is_ascii
 
 if TYPE_CHECKING:

--- a/synapse/media/media_storage.py
+++ b/synapse/media/media_storage.py
@@ -55,7 +55,7 @@ from synapse.api.errors import NotFoundError
 from synapse.logging.context import defer_to_thread, run_in_background
 from synapse.logging.opentracing import start_active_span, trace, trace_with_opname
 from synapse.media._base import ThreadedFileSender
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.file_consumer import BackgroundFileConsumer
 
 from ..types import JsonDict

--- a/synapse/media/oembed.py
+++ b/synapse/media/oembed.py
@@ -27,7 +27,7 @@ import attr
 
 from synapse.media.preview_html import parse_html_description
 from synapse.types import JsonDict
-from synapse.util import json_decoder
+from synapse.util.json import json_decoder
 
 if TYPE_CHECKING:
     from lxml import etree

--- a/synapse/media/url_previewer.py
+++ b/synapse/media/url_previewer.py
@@ -46,9 +46,9 @@ from synapse.media.oembed import OEmbedProvider
 from synapse.media.preview_html import decode_body, parse_html_to_open_graph
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.types import JsonDict, UserID
-from synapse.util import json_encoder
 from synapse.util.async_helpers import ObservableDeferred
 from synapse.util.caches.expiringcache import ExpiringCache
+from synapse.util.json import json_encoder
 from synapse.util.stringutils import random_string
 
 if TYPE_CHECKING:

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -158,9 +158,9 @@ from synapse.types import (
     create_requester,
 )
 from synapse.types.state import StateFilter
-from synapse.util import Clock
 from synapse.util.async_helpers import maybe_awaitable
 from synapse.util.caches.descriptors import CachedFunction, cached as _cached
+from synapse.util.clock import Clock
 from synapse.util.frozenutils import freeze
 
 if TYPE_CHECKING:

--- a/synapse/replication/tcp/commands.py
+++ b/synapse/replication/tcp/commands.py
@@ -29,7 +29,7 @@ import logging
 from typing import List, Optional, Tuple, Type, TypeVar
 
 from synapse.replication.tcp.streams._base import StreamRow
-from synapse.util import json_decoder, json_encoder
+from synapse.util.json import json_decoder, json_encoder
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/replication/tcp/external_cache.py
+++ b/synapse/replication/tcp/external_cache.py
@@ -27,7 +27,7 @@ from prometheus_client import Counter, Histogram
 from synapse.logging import opentracing
 from synapse.logging.context import make_deferred_yieldable
 from synapse.metrics import SERVER_NAME_LABEL
-from synapse.util import json_decoder, json_encoder
+from synapse.util.json import json_decoder, json_encoder
 
 if TYPE_CHECKING:
     from txredisapi import ConnectionHandler

--- a/synapse/replication/tcp/protocol.py
+++ b/synapse/replication/tcp/protocol.py
@@ -55,7 +55,7 @@ from synapse.replication.tcp.commands import (
     ServerCommand,
     parse_command_from_line,
 )
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.stringutils import random_string
 
 if TYPE_CHECKING:

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -58,8 +58,8 @@ from synapse.logging.opentracing import log_kv, set_tag, trace_with_opname
 from synapse.rest.admin.experimental_features import ExperimentalFeature
 from synapse.types import JsonDict, Requester, SlidingSyncStreamToken, StreamToken
 from synapse.types.rest.client import SlidingSyncBody
-from synapse.util import json_decoder
 from synapse.util.caches.lrucache import LruCache
+from synapse.util.json import json_decoder
 
 from ._base import client_patterns, set_timeline_upper_limit
 

--- a/synapse/rest/key/v2/remote_key_resource.py
+++ b/synapse/rest/key/v2/remote_key_resource.py
@@ -38,8 +38,8 @@ from synapse.http.servlet import (
 from synapse.storage.keys import FetchKeyResultForRemote
 from synapse.types import JsonDict
 from synapse.types.rest import RequestBodyModel
-from synapse.util import json_decoder
 from synapse.util.async_helpers import yieldable_gather_results
+from synapse.util.json import json_decoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/rest/well_known.py
+++ b/synapse/rest/well_known.py
@@ -28,7 +28,7 @@ from synapse.api.errors import NotFoundError
 from synapse.http.server import DirectServeJsonResource
 from synapse.http.site import SynapseRequest
 from synapse.types import JsonDict
-from synapse.util import json_encoder
+from synapse.util.json import json_encoder
 from synapse.util.stringutils import parse_server_name
 
 if TYPE_CHECKING:

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -156,7 +156,7 @@ from synapse.storage.controllers import StorageControllers
 from synapse.streams.events import EventSources
 from synapse.synapse_rust.rendezvous import RendezvousHandler
 from synapse.types import DomainSpecificString, ISynapseReactor
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.distributor import Distributor
 from synapse.util.macaroons import MacaroonGenerator
 from synapse.util.ratelimitutils import FederationRateLimiter

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -29,8 +29,8 @@ from synapse.storage.database import (
     make_in_list_sql_clause,  # noqa: F401
 )
 from synapse.types import get_domain_from_id
-from synapse.util import json_decoder
 from synapse.util.caches.descriptors import CachedFunction
+from synapse.util.json import json_decoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/background_updates.py
+++ b/synapse/storage/background_updates.py
@@ -45,7 +45,8 @@ from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.storage.engines import PostgresEngine
 from synapse.storage.types import Connection, Cursor
 from synapse.types import JsonDict, StrCollection
-from synapse.util import Clock, json_encoder
+from synapse.util.clock import Clock
+from synapse.util.json import json_encoder
 
 from . import engines
 

--- a/synapse/storage/databases/main/account_data.py
+++ b/synapse/storage/databases/main/account_data.py
@@ -48,9 +48,9 @@ from synapse.storage.databases.main.push_rule import PushRulesWorkerStore
 from synapse.storage.invite_rule import InviteRulesConfig
 from synapse.storage.util.id_generators import MultiWriterIdGenerator
 from synapse.types import JsonDict, JsonMapping
-from synapse.util import json_encoder
 from synapse.util.caches.descriptors import cached
 from synapse.util.caches.stream_change_cache import StreamChangeCache
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/databases/main/appservice.py
+++ b/synapse/storage/databases/main/appservice.py
@@ -42,8 +42,8 @@ from synapse.storage.databases.main.roommember import RoomMemberWorkerStore
 from synapse.storage.types import Cursor
 from synapse.storage.util.sequence import build_sequence_generator
 from synapse.types import DeviceListUpdates, JsonMapping
-from synapse.util import json_encoder
 from synapse.util.caches.descriptors import _CacheContext, cached
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/databases/main/censor_events.py
+++ b/synapse/storage/databases/main/censor_events.py
@@ -32,7 +32,7 @@ from synapse.storage.database import (
 )
 from synapse.storage.databases.main.cache import CacheInvalidationWorkerStore
 from synapse.storage.databases.main.events_worker import EventsWorkerStore
-from synapse.util import json_encoder
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/databases/main/delayed_events.py
+++ b/synapse/storage/databases/main/delayed_events.py
@@ -22,7 +22,8 @@ from synapse.storage._base import SQLBaseStore, db_to_json
 from synapse.storage.database import LoggingTransaction, StoreError
 from synapse.storage.engines import PostgresEngine
 from synapse.types import JsonDict, RoomID
-from synapse.util import json_encoder, stringutils as stringutils
+from synapse.util import stringutils
+from synapse.util.json import json_encoder
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -53,10 +53,11 @@ from synapse.storage.database import (
 )
 from synapse.storage.util.id_generators import MultiWriterIdGenerator
 from synapse.types import JsonDict, StrCollection
-from synapse.util import Duration, json_encoder
+from synapse.util import Duration
 from synapse.util.caches.expiringcache import ExpiringCache
 from synapse.util.caches.stream_change_cache import StreamChangeCache
 from synapse.util.iterutils import batch_iter
+from synapse.util.json import json_encoder
 from synapse.util.stringutils import parse_and_validate_server_name
 
 if TYPE_CHECKING:

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -64,11 +64,11 @@ from synapse.types import (
     StrCollection,
     get_verify_key_from_cross_signing_key,
 )
-from synapse.util import json_decoder, json_encoder
 from synapse.util.caches.descriptors import cached, cachedList
 from synapse.util.caches.stream_change_cache import StreamChangeCache
 from synapse.util.cancellation import cancellable
 from synapse.util.iterutils import batch_iter
+from synapse.util.json import json_decoder, json_encoder
 from synapse.util.stringutils import shortstr
 
 if TYPE_CHECKING:

--- a/synapse/storage/databases/main/e2e_room_keys.py
+++ b/synapse/storage/databases/main/e2e_room_keys.py
@@ -41,7 +41,7 @@ from synapse.storage.database import (
     LoggingTransaction,
 )
 from synapse.types import JsonDict, JsonSerializable, StreamKeyType
-from synapse.util import json_encoder
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -61,10 +61,10 @@ from synapse.storage.databases.main.cache import CacheInvalidationWorkerStore
 from synapse.storage.engines import PostgresEngine
 from synapse.storage.util.id_generators import MultiWriterIdGenerator
 from synapse.types import JsonDict, JsonMapping, MultiWriterStreamToken
-from synapse.util import json_decoder, json_encoder
 from synapse.util.caches.descriptors import cached, cachedList
 from synapse.util.cancellation import cancellable
 from synapse.util.iterutils import batch_iter
+from synapse.util.json import json_decoder, json_encoder
 
 if TYPE_CHECKING:
     from synapse.handlers.e2e_keys import SignatureListItem

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -59,11 +59,11 @@ from synapse.storage.databases.main.events_worker import EventsWorkerStore
 from synapse.storage.databases.main.signatures import SignatureWorkerStore
 from synapse.storage.engines import PostgresEngine, Sqlite3Engine
 from synapse.types import JsonDict, StrCollection
-from synapse.util import json_encoder
 from synapse.util.caches.descriptors import cached
 from synapse.util.caches.lrucache import LruCache
 from synapse.util.cancellation import cancellable
 from synapse.util.iterutils import batch_iter
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -107,8 +107,8 @@ from synapse.storage.database import (
 from synapse.storage.databases.main.receipts import ReceiptsWorkerStore
 from synapse.storage.databases.main.stream import StreamWorkerStore
 from synapse.types import JsonDict, StrCollection
-from synapse.util import json_encoder
 from synapse.util.caches.descriptors import cached
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -83,9 +83,9 @@ from synapse.types import (
 )
 from synapse.types.handlers import SLIDING_SYNC_DEFAULT_BUMP_EVENT_TYPES
 from synapse.types.state import StateFilter
-from synapse.util import json_encoder
 from synapse.util.events import get_plain_text_topic_from_event_content
 from synapse.util.iterutils import batch_iter, sorted_topologically
+from synapse.util.json import json_encoder
 from synapse.util.stringutils import non_null_str_or_none
 
 if TYPE_CHECKING:

--- a/synapse/storage/databases/main/events_bg_updates.py
+++ b/synapse/storage/databases/main/events_bg_updates.py
@@ -58,8 +58,8 @@ from synapse.types import JsonDict, RoomStreamToken, StateMap, StrCollection
 from synapse.types.handlers import SLIDING_SYNC_DEFAULT_BUMP_EVENT_TYPES
 from synapse.types.state import StateFilter
 from synapse.types.storage import _BackgroundUpdates
-from synapse.util import json_encoder
 from synapse.util.iterutils import batch_iter
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/databases/main/lock.py
+++ b/synapse/storage/databases/main/lock.py
@@ -38,7 +38,7 @@ from synapse.storage.database import (
     LoggingTransaction,
 )
 from synapse.types import ISynapseReactor
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.stringutils import random_string
 
 if TYPE_CHECKING:

--- a/synapse/storage/databases/main/push_rule.py
+++ b/synapse/storage/databases/main/push_rule.py
@@ -56,10 +56,11 @@ from synapse.storage.push_rule import InconsistentRuleException, RuleNotFoundExc
 from synapse.storage.util.id_generators import IdGenerator, MultiWriterIdGenerator
 from synapse.synapse_rust.push import FilteredPushRules, PushRule, PushRules
 from synapse.types import JsonDict
-from synapse.util import json_encoder, unwrapFirstError
+from synapse.util import unwrapFirstError
 from synapse.util.async_helpers import gather_results
 from synapse.util.caches.descriptors import cached, cachedList
 from synapse.util.caches.stream_change_cache import StreamChangeCache
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/databases/main/pusher.py
+++ b/synapse/storage/databases/main/pusher.py
@@ -42,8 +42,8 @@ from synapse.storage.database import (
 )
 from synapse.storage.util.id_generators import MultiWriterIdGenerator
 from synapse.types import JsonDict
-from synapse.util import json_encoder
 from synapse.util.caches.descriptors import cached
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -55,10 +55,10 @@ from synapse.types import (
     PersistedPosition,
     StrCollection,
 )
-from synapse.util import json_encoder
 from synapse.util.caches.descriptors import cached, cachedList
 from synapse.util.caches.stream_change_cache import StreamChangeCache
 from synapse.util.iterutils import batch_iter
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -65,8 +65,8 @@ from synapse.storage.databases.main.cache import CacheInvalidationWorkerStore
 from synapse.storage.types import Cursor
 from synapse.storage.util.id_generators import IdGenerator, MultiWriterIdGenerator
 from synapse.types import JsonDict, RetentionPolicy, StrCollection, ThirdPartyInstanceID
-from synapse.util import json_encoder
 from synapse.util.caches.descriptors import cached, cachedList
+from synapse.util.json import json_encoder
 from synapse.util.stringutils import MXC_REGEX
 
 if TYPE_CHECKING:

--- a/synapse/storage/databases/main/session.py
+++ b/synapse/storage/databases/main/session.py
@@ -30,7 +30,7 @@ from synapse.storage.database import (
     LoggingTransaction,
 )
 from synapse.types import JsonDict
-from synapse.util import json_encoder
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/databases/main/sliding_sync.py
+++ b/synapse/storage/databases/main/sliding_sync.py
@@ -35,8 +35,8 @@ from synapse.types.handlers.sliding_sync import (
     RoomStatusMap,
     RoomSyncConfig,
 )
-from synapse.util import json_encoder
 from synapse.util.caches.descriptors import cached
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/databases/main/tags.py
+++ b/synapse/storage/databases/main/tags.py
@@ -30,8 +30,8 @@ from synapse.storage.database import LoggingTransaction
 from synapse.storage.databases.main.account_data import AccountDataWorkerStore
 from synapse.storage.util.id_generators import AbstractStreamIdGenerator
 from synapse.types import JsonDict, JsonMapping
-from synapse.util import json_encoder
 from synapse.util.caches.descriptors import cached
+from synapse.util.json import json_encoder
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/storage/databases/main/task_scheduler.py
+++ b/synapse/storage/databases/main/task_scheduler.py
@@ -29,7 +29,7 @@ from synapse.storage.database import (
     make_in_list_sql_clause,
 )
 from synapse.types import JsonDict, JsonMapping, ScheduledTask, TaskStatus
-from synapse.util import json_encoder
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/storage/databases/main/ui_auth.py
+++ b/synapse/storage/databases/main/ui_auth.py
@@ -27,7 +27,8 @@ from synapse.api.errors import StoreError
 from synapse.storage._base import SQLBaseStore, db_to_json
 from synapse.storage.database import LoggingTransaction
 from synapse.types import JsonDict
-from synapse.util import json_encoder, stringutils
+from synapse.util import stringutils
+from synapse.util.json import json_encoder
 
 
 @attr.s(slots=True, auto_attribs=True)

--- a/synapse/types/__init__.py
+++ b/synapse/types/__init__.py
@@ -116,13 +116,27 @@ StrSequence = Union[Tuple[str, ...], List[str]]
 
 # Note that this seems to require inheriting *directly* from Interface in order
 # for mypy-zope to realize it is an interface.
-class ISynapseReactor(
+class ISynapseThreadlessReactor(
     IReactorTCP,
     IReactorSSL,
     IReactorUNIX,
     IReactorPluggableNameResolver,
     IReactorTime,
     IReactorCore,
+    Interface,
+):
+    """
+    The interfaces necessary for Synapse to function (without threads).
+
+    Helpful because we use `twisted.internet.testing.MemoryReactorClock` in tests which
+    doesn't implement `IReactorThreads`.
+    """
+
+
+# Note that this seems to require inheriting *directly* from Interface in order
+# for mypy-zope to realize it is an interface.
+class ISynapseReactor(
+    ISynapseThreadlessReactor,
     IReactorThreads,
     Interface,
 ):

--- a/synapse/util/__init__.py
+++ b/synapse/util/__init__.py
@@ -20,12 +20,9 @@
 #
 
 import collections.abc
-import json
 import logging
 import typing
 from typing import (
-    Any,
-    Callable,
     Dict,
     Iterator,
     Mapping,
@@ -36,16 +33,10 @@ from typing import (
 )
 
 import attr
-from immutabledict import immutabledict
 from matrix_common.versionstring import get_distribution_version_string
-from typing_extensions import ParamSpec
 
-from twisted.internet import defer, task
-from twisted.internet.interfaces import IDelayedCall, IReactorTime
-from twisted.internet.task import LoopingCall
+from twisted.internet import defer
 from twisted.python.failure import Failure
-
-from synapse.logging import context
 
 if typing.TYPE_CHECKING:
     pass
@@ -62,170 +53,12 @@ class Duration:
     DAY_MS = 24 * HOUR_MS
 
 
-def _reject_invalid_json(val: Any) -> None:
-    """Do not allow Infinity, -Infinity, or NaN values in JSON."""
-    raise ValueError("Invalid JSON value: '%s'" % val)
-
-
-def _handle_immutabledict(obj: Any) -> Dict[Any, Any]:
-    """Helper for json_encoder. Makes immutabledicts serializable by returning
-    the underlying dict
-    """
-    if type(obj) is immutabledict:
-        # fishing the protected dict out of the object is a bit nasty,
-        # but we don't really want the overhead of copying the dict.
-        try:
-            # Safety: we catch the AttributeError immediately below.
-            return obj._dict
-        except AttributeError:
-            # If all else fails, resort to making a copy of the immutabledict
-            return dict(obj)
-    raise TypeError(
-        "Object of type %s is not JSON serializable" % obj.__class__.__name__
-    )
-
-
-# A custom JSON encoder which:
-#   * handles immutabledicts
-#   * produces valid JSON (no NaNs etc)
-#   * reduces redundant whitespace
-json_encoder = json.JSONEncoder(
-    allow_nan=False, separators=(",", ":"), default=_handle_immutabledict
-)
-
-# Create a custom decoder to reject Python extensions to JSON.
-json_decoder = json.JSONDecoder(parse_constant=_reject_invalid_json)
-
-
 def unwrapFirstError(failure: Failure) -> Failure:
     # Deprecated: you probably just want to catch defer.FirstError and reraise
     # the subFailure's value, which will do a better job of preserving stacktraces.
     # (actually, you probably want to use yieldable_gather_results anyway)
     failure.trap(defer.FirstError)
     return failure.value.subFailure
-
-
-P = ParamSpec("P")
-
-
-@attr.s(slots=True)
-class Clock:
-    """
-    A Clock wraps a Twisted reactor and provides utilities on top of it.
-
-    Args:
-        reactor: The Twisted reactor to use.
-    """
-
-    _reactor: IReactorTime = attr.ib()
-
-    async def sleep(self, seconds: float) -> None:
-        d: defer.Deferred[float] = defer.Deferred()
-        with context.PreserveLoggingContext():
-            self._reactor.callLater(seconds, d.callback, seconds)
-            await d
-
-    def time(self) -> float:
-        """Returns the current system time in seconds since epoch."""
-        return self._reactor.seconds()
-
-    def time_msec(self) -> int:
-        """Returns the current system time in milliseconds since epoch."""
-        return int(self.time() * 1000)
-
-    def looping_call(
-        self,
-        f: Callable[P, object],
-        msec: float,
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> LoopingCall:
-        """Call a function repeatedly.
-
-        Waits `msec` initially before calling `f` for the first time.
-
-        If the function given to `looping_call` returns an awaitable/deferred, the next
-        call isn't scheduled until after the returned awaitable has finished. We get
-        this functionality thanks to this function being a thin wrapper around
-        `twisted.internet.task.LoopingCall`.
-
-        Note that the function will be called with no logcontext, so if it is anything
-        other than trivial, you probably want to wrap it in run_as_background_process.
-
-        Args:
-            f: The function to call repeatedly.
-            msec: How long to wait between calls in milliseconds.
-            *args: Positional arguments to pass to function.
-            **kwargs: Key arguments to pass to function.
-        """
-        return self._looping_call_common(f, msec, False, *args, **kwargs)
-
-    def looping_call_now(
-        self,
-        f: Callable[P, object],
-        msec: float,
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> LoopingCall:
-        """Call a function immediately, and then repeatedly thereafter.
-
-        As with `looping_call`: subsequent calls are not scheduled until after the
-        the Awaitable returned by a previous call has finished.
-
-        Also as with `looping_call`: the function is called with no logcontext and
-        you probably want to wrap it in `run_as_background_process`.
-
-        Args:
-            f: The function to call repeatedly.
-            msec: How long to wait between calls in milliseconds.
-            *args: Positional arguments to pass to function.
-            **kwargs: Key arguments to pass to function.
-        """
-        return self._looping_call_common(f, msec, True, *args, **kwargs)
-
-    def _looping_call_common(
-        self,
-        f: Callable[P, object],
-        msec: float,
-        now: bool,
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> LoopingCall:
-        """Common functionality for `looping_call` and `looping_call_now`"""
-        call = task.LoopingCall(f, *args, **kwargs)
-        call.clock = self._reactor
-        d = call.start(msec / 1000.0, now=now)
-        d.addErrback(log_failure, "Looping call died", consumeErrors=False)
-        return call
-
-    def call_later(
-        self, delay: float, callback: Callable, *args: Any, **kwargs: Any
-    ) -> IDelayedCall:
-        """Call something later
-
-        Note that the function will be called with no logcontext, so if it is anything
-        other than trivial, you probably want to wrap it in run_as_background_process.
-
-        Args:
-            delay: How long to wait in seconds.
-            callback: Function to call
-            *args: Postional arguments to pass to function.
-            **kwargs: Key arguments to pass to function.
-        """
-
-        def wrapped_callback(*args: Any, **kwargs: Any) -> None:
-            with context.PreserveLoggingContext():
-                callback(*args, **kwargs)
-
-        with context.PreserveLoggingContext():
-            return self._reactor.callLater(delay, wrapped_callback, *args, **kwargs)
-
-    def cancel_call_later(self, timer: IDelayedCall, ignore_errs: bool = False) -> None:
-        try:
-            timer.cancel()
-        except Exception:
-            if not ignore_errs:
-                raise
 
 
 def log_failure(

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -65,7 +65,7 @@ from synapse.logging.context import (
     run_coroutine_in_background,
     run_in_background,
 )
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -65,6 +65,7 @@ from synapse.logging.context import (
     run_coroutine_in_background,
     run_in_background,
 )
+from synapse.types import ISynapseThreadlessReactor
 from synapse.util.clock import Clock
 
 logger = logging.getLogger(__name__)
@@ -566,7 +567,7 @@ class Linearizer:
         if not clock:
             from twisted.internet import reactor
 
-            clock = Clock(cast(IReactorTime, reactor))
+            clock = Clock(cast(ISynapseThreadlessReactor, reactor))
         self._clock = clock
         self.max_count = max_count
 

--- a/synapse/util/batching_queue.py
+++ b/synapse/util/batching_queue.py
@@ -39,7 +39,7 @@ from twisted.internet import defer
 from synapse.logging.context import PreserveLoggingContext, make_deferred_yieldable
 from synapse.metrics import SERVER_NAME_LABEL
 from synapse.metrics.background_process_metrics import run_as_background_process
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/util/caches/expiringcache.py
+++ b/synapse/util/caches/expiringcache.py
@@ -29,8 +29,8 @@ from twisted.internet import defer
 
 from synapse.config import cache as cache_config
 from synapse.metrics.background_process_metrics import run_as_background_process
-from synapse.util import Clock
 from synapse.util.caches import EvictionReason, register_cache
+from synapse.util.clock import Clock
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -46,13 +46,13 @@ from typing import (
 )
 
 from twisted.internet import defer, reactor
-from twisted.internet.interfaces import IReactorTime
 
 from synapse.config import cache as cache_config
 from synapse.metrics.background_process_metrics import (
     run_as_background_process,
 )
 from synapse.metrics.jemalloc import get_jemalloc_stats
+from synapse.types import ISynapseThreadlessReactor
 from synapse.util import caches
 from synapse.util.caches import CacheMetric, EvictionReason, register_cache
 from synapse.util.caches.treecache import (
@@ -497,7 +497,7 @@ class LruCache(Generic[KT, VT]):
         # Default `clock` to something sensible. Note that we rename it to
         # `real_clock` so that mypy doesn't think its still `Optional`.
         if clock is None:
-            real_clock = Clock(cast(IReactorTime, reactor))
+            real_clock = Clock(cast(ISynapseThreadlessReactor, reactor))
         else:
             real_clock = clock
 

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -53,13 +53,14 @@ from synapse.metrics.background_process_metrics import (
     run_as_background_process,
 )
 from synapse.metrics.jemalloc import get_jemalloc_stats
-from synapse.util import Clock, caches
+from synapse.util import caches
 from synapse.util.caches import CacheMetric, EvictionReason, register_cache
 from synapse.util.caches.treecache import (
     TreeCache,
     iterate_tree_cache_entry,
     iterate_tree_cache_items,
 )
+from synapse.util.clock import Clock
 from synapse.util.linked_list import ListNode
 
 if TYPE_CHECKING:

--- a/synapse/util/caches/response_cache.py
+++ b/synapse/util/caches/response_cache.py
@@ -41,9 +41,9 @@ from synapse.logging.opentracing import (
     start_active_span,
     start_active_span_follows_from,
 )
-from synapse.util import Clock
 from synapse.util.async_helpers import AbstractObservableDeferred, ObservableDeferred
 from synapse.util.caches import EvictionReason, register_cache
+from synapse.util.clock import Clock
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/util/clock.py
+++ b/synapse/util/clock.py
@@ -172,7 +172,7 @@ class Clock:
 
         def wrapped_callback(*args: Any, **kwargs: Any) -> None:
             assert context.current_context() is context.SENTINEL_CONTEXT, (
-                "Expected `call_later` callback from the reactor to start with the sentinel logcontext "
+                "Expected `call_when_running` callback from the reactor to start with the sentinel logcontext "
                 f"but saw {context.current_context()}. In other words, another task shouldn't have "
                 "leaked their logcontext to us."
             )
@@ -181,7 +181,7 @@ class Clock:
             # `sentinel` log context at this point. We want the function to log with
             # some logcontext as we want to know which server the logs came from.
             #
-            # We use `PreserveLoggingContext` to prevent our new `call_later`
+            # We use `PreserveLoggingContext` to prevent our new `call_when_running`
             # logcontext from finishing as soon as we exit this function, in case `f`
             # returns an awaitable/deferred which would continue running and may try to
             # restore the `loop_call` context when it's done (because it's trying to

--- a/synapse/util/clock.py
+++ b/synapse/util/clock.py
@@ -171,11 +171,15 @@ class Clock:
         """
 
         def wrapped_callback(*args: Any, **kwargs: Any) -> None:
-            assert context.current_context() is context.SENTINEL_CONTEXT, (
-                "Expected `call_when_running` callback from the reactor to start with the sentinel logcontext "
-                f"but saw {context.current_context()}. In other words, another task shouldn't have "
-                "leaked their logcontext to us."
-            )
+            # Since this callback can be invoked immediately if the reactor is already
+            # running, we can't always assume that we're running in the sentinel
+            # logcontext (i.e. we can't assert that we're in the sentinel context like
+            # we can in other methods).
+            #
+            # We will only be running in the sentinel logcontext if the reactor was not
+            # running when `call_when_running` was invoked and later starts up.
+            #
+            # assert context.current_context() is context.SENTINEL_CONTEXT
 
             # Because this is a callback from the reactor, we will be using the
             # `sentinel` log context at this point. We want the function to log with

--- a/synapse/util/clock.py
+++ b/synapse/util/clock.py
@@ -1,0 +1,152 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2025 New Vector, Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl_3.0.html>.
+#
+#
+
+
+from typing import (
+    Any,
+    Callable,
+)
+
+import attr
+from typing_extensions import ParamSpec
+
+from twisted.internet import defer, task
+from twisted.internet.interfaces import IDelayedCall, IReactorTime
+from twisted.internet.task import LoopingCall
+
+from synapse.logging import context
+from synapse.util import log_failure
+
+P = ParamSpec("P")
+
+
+@attr.s(slots=True)
+class Clock:
+    """
+    A Clock wraps a Twisted reactor and provides utilities on top of it.
+
+    Args:
+        reactor: The Twisted reactor to use.
+    """
+
+    _reactor: IReactorTime = attr.ib()
+
+    async def sleep(self, seconds: float) -> None:
+        d: defer.Deferred[float] = defer.Deferred()
+        with context.PreserveLoggingContext():
+            self._reactor.callLater(seconds, d.callback, seconds)
+            await d
+
+    def time(self) -> float:
+        """Returns the current system time in seconds since epoch."""
+        return self._reactor.seconds()
+
+    def time_msec(self) -> int:
+        """Returns the current system time in milliseconds since epoch."""
+        return int(self.time() * 1000)
+
+    def looping_call(
+        self,
+        f: Callable[P, object],
+        msec: float,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> LoopingCall:
+        """Call a function repeatedly.
+
+        Waits `msec` initially before calling `f` for the first time.
+
+        If the function given to `looping_call` returns an awaitable/deferred, the next
+        call isn't scheduled until after the returned awaitable has finished. We get
+        this functionality thanks to this function being a thin wrapper around
+        `twisted.internet.task.LoopingCall`.
+
+        Note that the function will be called with no logcontext, so if it is anything
+        other than trivial, you probably want to wrap it in run_as_background_process.
+
+        Args:
+            f: The function to call repeatedly.
+            msec: How long to wait between calls in milliseconds.
+            *args: Positional arguments to pass to function.
+            **kwargs: Key arguments to pass to function.
+        """
+        return self._looping_call_common(f, msec, False, *args, **kwargs)
+
+    def looping_call_now(
+        self,
+        f: Callable[P, object],
+        msec: float,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> LoopingCall:
+        """Call a function immediately, and then repeatedly thereafter.
+
+        As with `looping_call`: subsequent calls are not scheduled until after the
+        the Awaitable returned by a previous call has finished.
+
+        Also as with `looping_call`: the function is called with no logcontext and
+        you probably want to wrap it in `run_as_background_process`.
+
+        Args:
+            f: The function to call repeatedly.
+            msec: How long to wait between calls in milliseconds.
+            *args: Positional arguments to pass to function.
+            **kwargs: Key arguments to pass to function.
+        """
+        return self._looping_call_common(f, msec, True, *args, **kwargs)
+
+    def _looping_call_common(
+        self,
+        f: Callable[P, object],
+        msec: float,
+        now: bool,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> LoopingCall:
+        """Common functionality for `looping_call` and `looping_call_now`"""
+        call = task.LoopingCall(f, *args, **kwargs)
+        call.clock = self._reactor
+        d = call.start(msec / 1000.0, now=now)
+        d.addErrback(log_failure, "Looping call died", consumeErrors=False)
+        return call
+
+    def call_later(
+        self, delay: float, callback: Callable, *args: Any, **kwargs: Any
+    ) -> IDelayedCall:
+        """Call something later
+
+        Note that the function will be called with no logcontext, so if it is anything
+        other than trivial, you probably want to wrap it in run_as_background_process.
+
+        Args:
+            delay: How long to wait in seconds.
+            callback: Function to call
+            *args: Postional arguments to pass to function.
+            **kwargs: Key arguments to pass to function.
+        """
+
+        def wrapped_callback(*args: Any, **kwargs: Any) -> None:
+            with context.PreserveLoggingContext():
+                callback(*args, **kwargs)
+
+        with context.PreserveLoggingContext():
+            return self._reactor.callLater(delay, wrapped_callback, *args, **kwargs)
+
+    def cancel_call_later(self, timer: IDelayedCall, ignore_errs: bool = False) -> None:
+        try:
+            timer.cancel()
+        except Exception:
+            if not ignore_errs:
+                raise

--- a/synapse/util/clock.py
+++ b/synapse/util/clock.py
@@ -199,4 +199,6 @@ class Clock:
                 # logcontext to the reactor
                 context.run_in_background(callback, *args, **kwargs)
 
-        self._reactor.callWhenRunning(wrapped_callback, *args, **kwargs)
+        # We can ignore the lint here since this class is the one location
+        # callWhenRunning should be called.
+        self._reactor.callWhenRunning(wrapped_callback, *args, **kwargs)  # type: ignore[prefer-synapse-clock-call-when-running]

--- a/synapse/util/json.py
+++ b/synapse/util/json.py
@@ -1,0 +1,57 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2025 New Vector, Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl_3.0.html>.
+#
+#
+
+import json
+from typing import (
+    Any,
+    Dict,
+)
+
+from immutabledict import immutabledict
+
+
+def _reject_invalid_json(val: Any) -> None:
+    """Do not allow Infinity, -Infinity, or NaN values in JSON."""
+    raise ValueError("Invalid JSON value: '%s'" % val)
+
+
+def _handle_immutabledict(obj: Any) -> Dict[Any, Any]:
+    """Helper for json_encoder. Makes immutabledicts serializable by returning
+    the underlying dict
+    """
+    if type(obj) is immutabledict:
+        # fishing the protected dict out of the object is a bit nasty,
+        # but we don't really want the overhead of copying the dict.
+        try:
+            # Safety: we catch the AttributeError immediately below.
+            return obj._dict
+        except AttributeError:
+            # If all else fails, resort to making a copy of the immutabledict
+            return dict(obj)
+    raise TypeError(
+        "Object of type %s is not JSON serializable" % obj.__class__.__name__
+    )
+
+
+# A custom JSON encoder which:
+#   * handles immutabledicts
+#   * produces valid JSON (no NaNs etc)
+#   * reduces redundant whitespace
+json_encoder = json.JSONEncoder(
+    allow_nan=False, separators=(",", ":"), default=_handle_immutabledict
+)
+
+# Create a custom decoder to reject Python extensions to JSON.
+json_decoder = json.JSONDecoder(parse_constant=_reject_invalid_json)

--- a/synapse/util/macaroons.py
+++ b/synapse/util/macaroons.py
@@ -28,7 +28,8 @@ import attr
 import pymacaroons
 from pymacaroons.exceptions import MacaroonVerificationFailedException
 
-from synapse.util import Clock, stringutils
+from synapse.util import stringutils
+from synapse.util.clock import Clock
 
 MacaroonType = Literal["access", "delete_pusher", "session"]
 

--- a/synapse/util/metrics.py
+++ b/synapse/util/metrics.py
@@ -42,7 +42,7 @@ from synapse.logging.context import (
     current_context,
 )
 from synapse.metrics import SERVER_NAME_LABEL, InFlightGauge
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/util/ratelimitutils.py
+++ b/synapse/util/ratelimitutils.py
@@ -53,7 +53,7 @@ from synapse.logging.context import (
 )
 from synapse.logging.opentracing import start_active_span
 from synapse.metrics import SERVER_NAME_LABEL, Histogram, LaterGauge
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 if typing.TYPE_CHECKING:
     from contextlib import _GeneratorContextManager

--- a/synapse/util/retryutils.py
+++ b/synapse/util/retryutils.py
@@ -27,7 +27,7 @@ from synapse.api.errors import CodeMessageException
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.storage import DataStore
 from synapse.types import StrCollection
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 if TYPE_CHECKING:
     from synapse.notifier import Notifier

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -55,7 +55,7 @@ from synapse.types import (
     get_domain_from_id,
 )
 from synapse.types.state import StateFilter
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 logger = logging.getLogger(__name__)
 filtered_event_logger = logging.getLogger("synapse.visibility.filtered_event_debug")

--- a/synmark/__main__.py
+++ b/synmark/__main__.py
@@ -62,7 +62,10 @@ def make_test(
                 return res
 
             d.addBoth(on_done)
-            reactor.callWhenRunning(lambda: d.callback(True))
+            # type-ignore: This is outside of Synapse (just a utility benchmark script)
+            # so we don't need to worry about  which server the logs are coming from
+            # (`Clock.call_when_running` manages the logcontext for us).
+            reactor.callWhenRunning(lambda: d.callback(True))  # type: ignore[prefer-synapse-clock-call-when-running]
             reactor.run()
 
         # mypy thinks this is an object for some reason.

--- a/synmark/suites/logging.py
+++ b/synmark/suites/logging.py
@@ -37,7 +37,7 @@ from synapse.config.logger import _setup_stdlib_logging
 from synapse.logging import RemoteHandler
 from synapse.synapse_rust import reset_logging_config
 from synapse.types import ISynapseReactor
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 
 class LineCounter(LineOnlyReceiver):

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -39,7 +39,7 @@ from synapse.appservice import ApplicationService
 from synapse.server import HomeServer
 from synapse.storage.databases.main.registration import TokenLookupResult
 from synapse.types import Requester, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/api/test_filtering.py
+++ b/tests/api/test_filtering.py
@@ -33,7 +33,7 @@ from synapse.api.filtering import Filter
 from synapse.api.presence import UserPresenceState
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.frozenutils import freeze
 
 from tests import unittest

--- a/tests/api/test_urls.py
+++ b/tests/api/test_urls.py
@@ -17,7 +17,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.api.urls import LoginSSORedirectURIBuilder
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/app/test_openid_listener.py
+++ b/tests/app/test_openid_listener.py
@@ -29,7 +29,7 @@ from synapse.app.homeserver import SynapseHomeServer
 from synapse.config.server import parse_listener_def
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.server import make_request
 from tests.unittest import HomeserverTestCase

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -2,7 +2,7 @@ import synapse
 from synapse.app.phone_stats_home import start_phone_stats_home
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.server import ThreadedMemoryReactorClock
 from tests.unittest import HomeserverTestCase

--- a/tests/appservice/test_api.py
+++ b/tests/appservice/test_api.py
@@ -26,7 +26,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.appservice import ApplicationService
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/appservice/test_scheduler.py
+++ b/tests/appservice/test_scheduler.py
@@ -41,7 +41,7 @@ from synapse.events import EventBase
 from synapse.logging.context import make_deferred_yieldable
 from synapse.server import HomeServer
 from synapse.types import DeviceListUpdates, JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/config/test_room_directory.py
+++ b/tests/config/test_room_directory.py
@@ -27,7 +27,7 @@ import synapse.rest.client.room
 from synapse.config._base import RootConfig
 from synapse.config.room_directory import RoomDirectoryConfig
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -49,7 +49,7 @@ from synapse.logging.context import (
 from synapse.server import HomeServer
 from synapse.storage.keys import FetchKeyResult
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import logcontext_clean, override_config

--- a/tests/events/test_auto_accept_invites.py
+++ b/tests/events/test_auto_accept_invites.py
@@ -41,7 +41,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.types import StreamToken, UserID, UserInfo, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.handlers.test_sync import generate_sync_config
 from tests.unittest import (

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -34,7 +34,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, presence, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict, StreamToken, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.handlers.test_sync import SyncRequestKey, generate_sync_config
 from tests.unittest import (

--- a/tests/events/test_snapshot.py
+++ b/tests/events/test_snapshot.py
@@ -26,7 +26,7 @@ from synapse.events.snapshot import EventContext
 from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.test_utils.event_injection import create_event

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -16,7 +16,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.retryutils import NotRetryingDestination
 
 from tests.test_utils import event_injection

--- a/tests/federation/test_federation_client.py
+++ b/tests/federation/test_federation_client.py
@@ -30,7 +30,7 @@ from synapse.events import EventBase
 from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.test_utils import FakeResponse, event_injection
 from tests.unittest import FederatingHomeserverTestCase

--- a/tests/federation/test_federation_devices.py
+++ b/tests/federation/test_federation_devices.py
@@ -26,7 +26,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.handlers.device import DeviceListUpdater
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.retryutils import NotRetryingDestination
 
 from tests import unittest

--- a/tests/federation/test_federation_media.py
+++ b/tests/federation/test_federation_media.py
@@ -32,7 +32,7 @@ from synapse.media.storage_provider import (
 )
 from synapse.server import HomeServer
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.media.test_media_storage import small_png

--- a/tests/federation/test_federation_out_of_band_membership.py
+++ b/tests/federation/test_federation_out_of_band_membership.py
@@ -50,7 +50,7 @@ from synapse.types import JsonDict, MutableStateMap, StateMap
 from synapse.types.handlers.sliding_sync import (
     StateValues,
 )
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.utils import test_timeout

--- a/tests/federation/test_federation_sender.py
+++ b/tests/federation/test_federation_sender.py
@@ -36,7 +36,7 @@ from synapse.rest.client import login
 from synapse.server import HomeServer
 from synapse.storage.databases.main.events_worker import EventMetadata
 from synapse.types import JsonDict, ReadReceipt
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -40,7 +40,7 @@ from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.storage.controllers.state import server_acl_evaluator_from_event
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/federation/transport/test_knocking.py
+++ b/tests/federation/transport/test_knocking.py
@@ -31,7 +31,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.types import RoomAlias
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.test_utils import event_injection
 from tests.unittest import FederatingHomeserverTestCase, HomeserverTestCase

--- a/tests/handlers/test_admin.py
+++ b/tests/handlers/test_admin.py
@@ -31,7 +31,7 @@ from synapse.api.room_versions import RoomVersions
 from synapse.rest.client import knock, login, room
 from synapse.server import HomeServer
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -45,7 +45,7 @@ from synapse.types import (
     StreamKeyType,
     UserID,
 )
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.stringutils import random_string
 
 from tests import unittest

--- a/tests/handlers/test_auth.py
+++ b/tests/handlers/test_auth.py
@@ -29,7 +29,7 @@ from synapse.api.errors import AuthError, ResourceLimitError
 from synapse.rest import admin
 from synapse.rest.client import login
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/handlers/test_cas.py
+++ b/tests/handlers/test_cas.py
@@ -25,7 +25,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.handlers.cas import CasResponse
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase, override_config
 

--- a/tests/handlers/test_deactivate_account.py
+++ b/tests/handlers/test_deactivate_account.py
@@ -28,7 +28,7 @@ from synapse.rest.client import account, login, room
 from synapse.server import HomeServer
 from synapse.synapse_rust.push import PushRule
 from synapse.types import UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/handlers/test_device.py
+++ b/tests/handlers/test_device.py
@@ -35,7 +35,7 @@ from synapse.rest.client import devices, login, register
 from synapse.server import HomeServer
 from synapse.storage.databases.main.appservice import _make_exclusive_regex
 from synapse.types import JsonDict, UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.task_scheduler import TaskScheduler
 
 from tests import unittest

--- a/tests/handlers/test_directory.py
+++ b/tests/handlers/test_directory.py
@@ -31,7 +31,7 @@ from synapse.events import EventBase
 from synapse.rest.client import directory, login, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict, RoomAlias, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/handlers/test_e2e_keys.py
+++ b/tests/handlers/test_e2e_keys.py
@@ -35,7 +35,7 @@ from synapse.handlers.device import DeviceWriterHandler
 from synapse.server import HomeServer
 from synapse.storage.databases.main.appservice import _make_exclusive_regex
 from synapse.types import JsonDict, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/handlers/test_e2e_room_keys.py
+++ b/tests/handlers/test_e2e_room_keys.py
@@ -27,7 +27,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.api.errors import SynapseError
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -43,7 +43,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.storage.databases.main.events_worker import EventCacheEntry
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.events import generate_fake_event_id
 
 from tests import unittest

--- a/tests/handlers/test_federation_event.py
+++ b/tests/handlers/test_federation_event.py
@@ -39,7 +39,7 @@ from synapse.server import HomeServer
 from synapse.state import StateResolutionStore
 from synapse.state.v2 import _mainline_sort, _reverse_topological_power_sort
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.test_utils import event_injection

--- a/tests/handlers/test_message.py
+++ b/tests/handlers/test_message.py
@@ -31,7 +31,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.types import create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.stringutils import random_string
 
 from tests import unittest

--- a/tests/handlers/test_oauth_delegation.py
+++ b/tests/handlers/test_oauth_delegation.py
@@ -54,7 +54,7 @@ from synapse.rest import admin
 from synapse.rest.client import account, devices, keys, login, logout, register
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.server import FakeChannel
 from tests.test_utils import get_awaitable_result

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -31,7 +31,7 @@ from synapse.handlers.sso import MappingException
 from synapse.http.site import SynapseRequest
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.macaroons import get_value_from_macaroon
 from synapse.util.stringutils import random_string
 

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -35,7 +35,7 @@ from synapse.module_api import ModuleApi
 from synapse.rest.client import account, devices, login, logout, register
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.server import FakeChannel

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -57,7 +57,7 @@ from synapse.server import HomeServer
 from synapse.storage.database import LoggingDatabaseConnection
 from synapse.storage.keys import FetchKeyResult
 from synapse.types import JsonDict, UserID, get_domain_from_id
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.replication._base import BaseMultiWorkerStreamTestCase

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -30,7 +30,7 @@ from synapse.api.errors import AuthError, SynapseError
 from synapse.rest import admin
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/handlers/test_receipts.py
+++ b/tests/handlers/test_receipts.py
@@ -27,7 +27,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.api.constants import EduTypes, ReceiptTypes
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -43,7 +43,7 @@ from synapse.types import (
     UserID,
     create_requester,
 )
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import override_config
 from tests.utils import mock_getRawHeaders

--- a/tests/handlers/test_room_member.py
+++ b/tests/handlers/test_room_member.py
@@ -15,7 +15,7 @@ from synapse.federation.federation_base import (
 from synapse.federation.federation_client import SendJoinResult
 from synapse.server import HomeServer
 from synapse.types import UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.replication._base import BaseMultiWorkerStreamTestCase
 from tests.server import make_request

--- a/tests/handlers/test_room_policy.py
+++ b/tests/handlers/test_room_policy.py
@@ -23,7 +23,7 @@ from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID
 from synapse.types.handlers.policy_server import RECOMMENDATION_OK, RECOMMENDATION_SPAM
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.test_utils import event_injection

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -42,7 +42,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/handlers/test_saml.py
+++ b/tests/handlers/test_saml.py
@@ -30,7 +30,7 @@ from synapse.api.errors import RedirectException
 from synapse.module_api import ModuleApi
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase, override_config
 

--- a/tests/handlers/test_sliding_sync.py
+++ b/tests/handlers/test_sliding_sync.py
@@ -46,7 +46,7 @@ from synapse.storage.util.id_generators import MultiWriterIdGenerator
 from synapse.types import JsonDict, StateMap, StreamToken, UserID, create_requester
 from synapse.types.handlers.sliding_sync import PerConnectionState, SlidingSyncConfig
 from synapse.types.state import StateFilter
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.replication._base import BaseMultiWorkerStreamTestCase

--- a/tests/handlers/test_sso.py
+++ b/tests/handlers/test_sso.py
@@ -27,7 +27,7 @@ from twisted.web.http_headers import Headers
 from synapse.api.errors import Codes, SynapseError
 from synapse.http.client import RawHeaders
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.test_utils import SMALL_PNG, FakeResponse

--- a/tests/handlers/test_stats.py
+++ b/tests/handlers/test_stats.py
@@ -26,7 +26,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.storage.databases.main import stats
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -50,7 +50,7 @@ from synapse.types import (
     UserID,
     create_requester,
 )
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 import tests.unittest
 import tests.utils

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -36,7 +36,7 @@ from synapse.handlers.typing import FORGET_TIMEOUT, TypingWriterHandler
 from synapse.http.federation.matrix_federation_agent import MatrixFederationAgent
 from synapse.server import HomeServer
 from synapse.types import JsonDict, Requester, StreamKeyType, UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.server import ThreadedMemoryReactorClock

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -32,7 +32,7 @@ from synapse.rest.client import login, register, room, user_directory
 from synapse.server import HomeServer
 from synapse.storage.roommember import ProfileInfo
 from synapse.types import JsonDict, UserID, UserProfile, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.storage.test_user_directory import GetUserDirectoryTables

--- a/tests/handlers/test_worker_lock.py
+++ b/tests/handlers/test_worker_lock.py
@@ -26,7 +26,7 @@ from twisted.internet import defer
 from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.replication._base import BaseMultiWorkerStreamTestCase

--- a/tests/http/test_matrixfederationclient.py
+++ b/tests/http/test_matrixfederationclient.py
@@ -48,7 +48,7 @@ from synapse.logging.context import (
     current_context,
 )
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.replication._base import BaseMultiWorkerStreamTestCase
 from tests.server import FakeTransport

--- a/tests/http/test_simple_client.py
+++ b/tests/http/test_simple_client.py
@@ -29,7 +29,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.http import RequestTimedOutError
 from synapse.http.client import SimpleHttpClient
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/http/test_site.py
+++ b/tests/http/test_site.py
@@ -24,7 +24,7 @@ from twisted.internet.testing import MemoryReactor, StringTransport
 
 from synapse.app.homeserver import SynapseHomeServer
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/logging/test_opentracing.py
+++ b/tests/logging/test_opentracing.py
@@ -159,7 +159,13 @@ class TracingScopeTestCase(TestCase):
     def test_overlapping_spans(self) -> None:
         """Overlapping spans which are not neatly nested should work"""
         reactor = MemoryReactorClock()
-        clock = Clock(reactor)
+        # type-ignore: mypy-zope doesn't seem to recognise that `MemoryReactorClock`
+        # implements `ISynapseThreadlessReactor` (combination of the normal Twisted
+        # Reactor/Clock interfaces), via inheritance from
+        # `twisted.internet.testing.MemoryReactor` and `twisted.internet.testing.Clock`
+        clock = Clock(
+            reactor  # type: ignore[arg-type]
+        )
 
         scopes = []
 
@@ -223,7 +229,13 @@ class TracingScopeTestCase(TestCase):
         parent.
         """
         reactor = MemoryReactorClock()
-        clock = Clock(reactor)
+        # type-ignore: mypy-zope doesn't seem to recognise that `MemoryReactorClock`
+        # implements `ISynapseThreadlessReactor` (combination of the normal Twisted
+        # Reactor/Clock interfaces), via inheritance from
+        # `twisted.internet.testing.MemoryReactor` and `twisted.internet.testing.Clock`
+        clock = Clock(
+            reactor  # type: ignore[arg-type]
+        )
 
         scope_map: Dict[str, opentracing.Scope] = {}
 

--- a/tests/logging/test_opentracing.py
+++ b/tests/logging/test_opentracing.py
@@ -35,7 +35,7 @@ from synapse.logging.opentracing import (
     tag_args,
     trace_with_opname,
 )
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 try:
     import opentracing

--- a/tests/media/test_media_retention.py
+++ b/tests/media/test_media_retention.py
@@ -30,7 +30,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, register, room
 from synapse.server import HomeServer
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.stringutils import (
     random_string,
 )

--- a/tests/media/test_media_storage.py
+++ b/tests/media/test_media_storage.py
@@ -56,7 +56,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, media
 from synapse.server import HomeServer
 from synapse.types import JsonDict, RoomAlias
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.server import FakeChannel

--- a/tests/media/test_oembed.py
+++ b/tests/media/test_oembed.py
@@ -29,7 +29,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.media.oembed import OEmbedProvider, OEmbedResult
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/media/test_url_previewer.py
+++ b/tests/media/test_url_previewer.py
@@ -23,7 +23,7 @@ import os
 from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/metrics/test_phone_home_stats.py
+++ b/tests/metrics/test_phone_home_stats.py
@@ -23,7 +23,7 @@ from synapse.app.phone_stats_home import (
 from synapse.rest import admin, login, register, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.server import ThreadedMemoryReactorClock

--- a/tests/module_api/test_account_data_manager.py
+++ b/tests/module_api/test_account_data_manager.py
@@ -23,7 +23,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.api.errors import SynapseError
 from synapse.rest import admin
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -36,7 +36,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, notifications, presence, profile, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.events.test_presence_router import send_presence_update, sync_presence
 from tests.replication._base import BaseMultiWorkerStreamTestCase

--- a/tests/module_api/test_event_unsigned_addition.py
+++ b/tests/module_api/test_event_unsigned_addition.py
@@ -24,7 +24,7 @@ from synapse.events import EventBase
 from synapse.rest import admin, login, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/module_api/test_spamchecker.py
+++ b/tests/module_api/test_spamchecker.py
@@ -20,7 +20,7 @@ from synapse.config.server import DEFAULT_ROOM_VERSION
 from synapse.rest import admin, login, room, room_upgrade_rest_servlet
 from synapse.server import HomeServer
 from synapse.types import Codes, JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.server import FakeChannel
 from tests.unittest import HomeserverTestCase

--- a/tests/push/test_bulk_push_rule_evaluator.py
+++ b/tests/push/test_bulk_push_rule_evaluator.py
@@ -34,7 +34,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, push_rule, register, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase, override_config
 

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -35,7 +35,7 @@ from synapse.push.emailpusher import EmailPusher
 from synapse.rest.client import login, room
 from synapse.rest.synapse.client.unsubscribe import UnsubscribeResource
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.server import FakeSite, make_request
 from tests.unittest import HomeserverTestCase

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -32,7 +32,7 @@ from synapse.rest.admin.experimental_features import ExperimentalFeature
 from synapse.rest.client import login, push_rule, pusher, receipts, room, versions
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase, override_config
 

--- a/tests/push/test_push_rule_evaluator.py
+++ b/tests/push/test_push_rule_evaluator.py
@@ -36,7 +36,7 @@ from synapse.server import HomeServer
 from synapse.storage.databases.main.appservice import _make_exclusive_regex
 from synapse.synapse_rust.push import PushRuleEvaluator
 from synapse.types import JsonDict, JsonMapping, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.frozenutils import freeze
 
 from tests import unittest

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -38,7 +38,7 @@ from synapse.replication.tcp.protocol import (
 )
 from synapse.replication.tcp.resource import ReplicationStreamProtocolFactory
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.server import FakeTransport

--- a/tests/replication/storage/_base.py
+++ b/tests/replication/storage/_base.py
@@ -25,7 +25,7 @@ from unittest.mock import Mock
 from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.replication._base import BaseStreamTestCase
 

--- a/tests/replication/storage/test_events.py
+++ b/tests/replication/storage/test_events.py
@@ -38,7 +38,7 @@ from synapse.storage.databases.main.event_push_actions import (
 from synapse.storage.databases.main.events_worker import EventsWorkerStore
 from synapse.storage.roommember import RoomsForUser
 from synapse.types import PersistedEventPosition
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from ._base import BaseWorkerStoreTestCase
 

--- a/tests/replication/tcp/streams/test_events.py
+++ b/tests/replication/tcp/streams/test_events.py
@@ -38,7 +38,7 @@ from synapse.replication.tcp.streams.events import (
 from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.replication._base import BaseStreamTestCase
 from tests.test_utils.event_injection import inject_event, inject_member_event

--- a/tests/replication/tcp/streams/test_thread_subscriptions.py
+++ b/tests/replication/tcp/streams/test_thread_subscriptions.py
@@ -20,7 +20,7 @@ from synapse.replication.tcp.streams._base import (
 )
 from synapse.server import HomeServer
 from synapse.storage.database import LoggingTransaction
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.replication._base import BaseStreamTestCase
 

--- a/tests/replication/test_auth.py
+++ b/tests/replication/test_auth.py
@@ -24,7 +24,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.rest.client import register
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.replication._base import BaseMultiWorkerStreamTestCase
 from tests.server import FakeChannel, make_request

--- a/tests/replication/test_federation_ack.py
+++ b/tests/replication/test_federation_ack.py
@@ -28,7 +28,7 @@ from synapse.replication.tcp.commands import FederationAckCommand
 from synapse.replication.tcp.protocol import IReplicationConnection
 from synapse.replication.tcp.streams.federation import FederationStream
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/replication/test_federation_sender_shard.py
+++ b/tests/replication/test_federation_sender_shard.py
@@ -41,7 +41,7 @@ from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.storage.keys import FetchKeyResult
 from synapse.types import JsonDict, UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.replication._base import BaseMultiWorkerStreamTestCase
 from tests.server import get_clock

--- a/tests/replication/test_multi_media_repo.py
+++ b/tests/replication/test_multi_media_repo.py
@@ -30,7 +30,7 @@ from twisted.web.server import Request
 from synapse.rest import admin
 from synapse.rest.client import login, media
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.http import (
     TestServerTLSConnectionFactory,

--- a/tests/replication/test_pusher_shard.py
+++ b/tests/replication/test_pusher_shard.py
@@ -27,7 +27,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.replication._base import BaseMultiWorkerStreamTestCase
 

--- a/tests/replication/test_sharded_event_persister.py
+++ b/tests/replication/test_sharded_event_persister.py
@@ -27,7 +27,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
 from synapse.storage.util.id_generators import MultiWriterIdGenerator
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.replication._base import BaseMultiWorkerStreamTestCase
 from tests.server import make_request

--- a/tests/replication/test_sharded_receipts.py
+++ b/tests/replication/test_sharded_receipts.py
@@ -28,7 +28,7 @@ from synapse.rest.client import login, receipts, room, sync
 from synapse.server import HomeServer
 from synapse.storage.util.id_generators import MultiWriterIdGenerator
 from synapse.types import StreamToken
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.replication._base import BaseMultiWorkerStreamTestCase
 from tests.server import make_request

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -33,7 +33,7 @@ from synapse.rest.admin import VersionServlet
 from synapse.rest.client import login, media, room
 from synapse.server import HomeServer
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.test_utils import SMALL_PNG

--- a/tests/rest/admin/test_background_updates.py
+++ b/tests/rest/admin/test_background_updates.py
@@ -30,7 +30,7 @@ from synapse.rest.client import login
 from synapse.server import HomeServer
 from synapse.storage.background_updates import BackgroundUpdater
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/admin/test_device.py
+++ b/tests/rest/admin/test_device.py
@@ -29,7 +29,7 @@ from synapse.api.errors import Codes
 from synapse.handlers.device import DeviceWriterHandler
 from synapse.rest.client import devices, login
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/admin/test_event_reports.py
+++ b/tests/rest/admin/test_event_reports.py
@@ -27,7 +27,7 @@ from synapse.api.errors import Codes
 from synapse.rest.client import login, reporting, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/admin/test_federation.py
+++ b/tests/rest/admin/test_federation.py
@@ -29,7 +29,7 @@ from synapse.api.errors import Codes
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/admin/test_media.py
+++ b/tests/rest/admin/test_media.py
@@ -32,7 +32,7 @@ from synapse.api.errors import Codes
 from synapse.media.filepath import MediaFilePaths
 from synapse.rest.client import login, profile, room
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.test_utils import SMALL_CMYK_JPEG, SMALL_PNG

--- a/tests/rest/admin/test_registration_tokens.py
+++ b/tests/rest/admin/test_registration_tokens.py
@@ -28,7 +28,7 @@ import synapse.rest.admin
 from synapse.api.errors import Codes
 from synapse.rest.client import login
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -45,7 +45,7 @@ from synapse.storage.databases.main.purge_events import (
     purge_room_tables_with_room_id_column,
 )
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.task_scheduler import TaskScheduler
 
 from tests import unittest

--- a/tests/rest/admin/test_scheduled_tasks.py
+++ b/tests/rest/admin/test_scheduled_tasks.py
@@ -22,7 +22,7 @@ from synapse.api.errors import Codes
 from synapse.rest.client import login
 from synapse.server import HomeServer
 from synapse.types import JsonMapping, ScheduledTask, TaskStatus
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/admin/test_server_notice.py
+++ b/tests/rest/admin/test_server_notice.py
@@ -28,7 +28,7 @@ from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
 from synapse.storage.roommember import RoomsForUser
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.stringutils import random_string
 
 from tests import unittest

--- a/tests/rest/admin/test_statistics.py
+++ b/tests/rest/admin/test_statistics.py
@@ -29,7 +29,7 @@ from synapse.api.errors import Codes
 from synapse.rest.client import login
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.test_utils import SMALL_PNG

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -61,7 +61,7 @@ from synapse.rest.client import (
 from synapse.server import HomeServer
 from synapse.storage.databases.main.client_ips import LAST_SEEN_GRANULARITY
 from synapse.types import JsonDict, UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.replication._base import BaseMultiWorkerStreamTestCase

--- a/tests/rest/admin/test_username_available.py
+++ b/tests/rest/admin/test_username_available.py
@@ -26,7 +26,7 @@ import synapse.rest.admin
 from synapse.api.errors import Codes, SynapseError
 from synapse.rest.client import login
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/client/sliding_sync/test_connection_tracking.py
+++ b/tests/rest/client/sliding_sync/test_connection_tracking.py
@@ -21,7 +21,7 @@ import synapse.rest.admin
 from synapse.api.constants import EventTypes
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 

--- a/tests/rest/client/sliding_sync/test_extension_account_data.py
+++ b/tests/rest/client/sliding_sync/test_extension_account_data.py
@@ -24,7 +24,7 @@ from synapse.api.constants import AccountDataTypes
 from synapse.rest.client import login, room, sendtodevice, sync
 from synapse.server import HomeServer
 from synapse.types import StreamKeyType
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 from tests.server import TimedOutException

--- a/tests/rest/client/sliding_sync/test_extension_e2ee.py
+++ b/tests/rest/client/sliding_sync/test_extension_e2ee.py
@@ -21,7 +21,7 @@ import synapse.rest.admin
 from synapse.rest.client import devices, login, room, sync
 from synapse.server import HomeServer
 from synapse.types import JsonDict, StreamKeyType
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 from tests.server import TimedOutException

--- a/tests/rest/client/sliding_sync/test_extension_receipts.py
+++ b/tests/rest/client/sliding_sync/test_extension_receipts.py
@@ -22,7 +22,7 @@ from synapse.api.constants import EduTypes, ReceiptTypes
 from synapse.rest.client import login, receipts, room, sync
 from synapse.server import HomeServer
 from synapse.types import StreamKeyType
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 from tests.server import TimedOutException

--- a/tests/rest/client/sliding_sync/test_extension_thread_subscriptions.py
+++ b/tests/rest/client/sliding_sync/test_extension_thread_subscriptions.py
@@ -21,7 +21,7 @@ import synapse.rest.admin
 from synapse.rest.client import login, room, sync, thread_subscriptions
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 

--- a/tests/rest/client/sliding_sync/test_extension_to_device.py
+++ b/tests/rest/client/sliding_sync/test_extension_to_device.py
@@ -22,7 +22,7 @@ import synapse.rest.admin
 from synapse.rest.client import login, sendtodevice, sync
 from synapse.server import HomeServer
 from synapse.types import JsonDict, StreamKeyType
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 from tests.server import TimedOutException

--- a/tests/rest/client/sliding_sync/test_extension_typing.py
+++ b/tests/rest/client/sliding_sync/test_extension_typing.py
@@ -22,7 +22,7 @@ from synapse.api.constants import EduTypes
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
 from synapse.types import StreamKeyType
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 from tests.server import TimedOutException

--- a/tests/rest/client/sliding_sync/test_extensions.py
+++ b/tests/rest/client/sliding_sync/test_extensions.py
@@ -23,7 +23,7 @@ import synapse.rest.admin
 from synapse.api.constants import ReceiptTypes
 from synapse.rest.client import login, receipts, room, sync
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 

--- a/tests/rest/client/sliding_sync/test_lists_filters.py
+++ b/tests/rest/client/sliding_sync/test_lists_filters.py
@@ -28,7 +28,7 @@ from synapse.events import StrippedStateEvent
 from synapse.rest.client import login, room, sync, tags
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 

--- a/tests/rest/client/sliding_sync/test_room_subscriptions.py
+++ b/tests/rest/client/sliding_sync/test_room_subscriptions.py
@@ -22,7 +22,7 @@ import synapse.rest.admin
 from synapse.api.constants import EventTypes, HistoryVisibility
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 

--- a/tests/rest/client/sliding_sync/test_rooms_invites.py
+++ b/tests/rest/client/sliding_sync/test_rooms_invites.py
@@ -22,7 +22,7 @@ from synapse.api.constants import EventTypes, HistoryVisibility
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 

--- a/tests/rest/client/sliding_sync/test_rooms_meta.py
+++ b/tests/rest/client/sliding_sync/test_rooms_meta.py
@@ -22,7 +22,7 @@ from synapse.api.constants import EventContentFields, EventTypes, Membership
 from synapse.api.room_versions import RoomVersions
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 from tests.test_utils.event_injection import create_event

--- a/tests/rest/client/sliding_sync/test_rooms_required_state.py
+++ b/tests/rest/client/sliding_sync/test_rooms_required_state.py
@@ -23,7 +23,7 @@ from synapse.api.constants import EventContentFields, EventTypes, JoinRules, Mem
 from synapse.handlers.sliding_sync import StateValues
 from synapse.rest.client import knock, login, room, sync
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 from tests.test_utils.event_injection import mark_event_as_partial_state

--- a/tests/rest/client/sliding_sync/test_rooms_timeline.py
+++ b/tests/rest/client/sliding_sync/test_rooms_timeline.py
@@ -23,7 +23,7 @@ from synapse.api.constants import EventTypes
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
 from synapse.types import StrSequence
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
 

--- a/tests/rest/client/sliding_sync/test_sliding_sync.py
+++ b/tests/rest/client/sliding_sync/test_sliding_sync.py
@@ -42,7 +42,7 @@ from synapse.types import (
     StreamKeyType,
     StreamToken,
 )
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.stringutils import random_string
 
 from tests import unittest

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -39,7 +39,7 @@ from synapse.rest.synapse.client.password_reset import PasswordResetSubmitTokenR
 from synapse.server import HomeServer
 from synapse.storage._base import db_to_json
 from synapse.types import JsonDict, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.server import FakeSite, make_request

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -35,7 +35,7 @@ from synapse.rest.synapse.client import build_synapse_client_resource_tree
 from synapse.server import HomeServer
 from synapse.storage.database import LoggingTransaction
 from synapse.types import JsonDict, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.handlers.test_oidc import HAS_OIDC

--- a/tests/rest/client/test_capabilities.py
+++ b/tests/rest/client/test_capabilities.py
@@ -25,7 +25,7 @@ import synapse.rest.admin
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS
 from synapse.rest.client import capabilities, login
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/rest/client/test_consent.py
+++ b/tests/rest/client/test_consent.py
@@ -28,7 +28,7 @@ from synapse.api.urls import ConsentURIBuilder
 from synapse.rest.client import login, room
 from synapse.rest.consent import consent_resource
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.server import FakeSite, make_request

--- a/tests/rest/client/test_delayed_events.py
+++ b/tests/rest/client/test_delayed_events.py
@@ -26,7 +26,7 @@ from synapse.rest import admin
 from synapse.rest.client import delayed_events, login, room, versions
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import HomeserverTestCase

--- a/tests/rest/client/test_devices.py
+++ b/tests/rest/client/test_devices.py
@@ -29,7 +29,7 @@ from synapse.rest import admin, devices, sync
 from synapse.rest.client import keys, login, register
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/client/test_directory.py
+++ b/tests/rest/client/test_directory.py
@@ -26,7 +26,7 @@ from synapse.rest import admin
 from synapse.rest.client import directory, login, room
 from synapse.server import HomeServer
 from synapse.types import RoomAlias, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.stringutils import random_string
 
 from tests import unittest

--- a/tests/rest/client/test_ephemeral_message.py
+++ b/tests/rest/client/test_ephemeral_message.py
@@ -26,7 +26,7 @@ from synapse.rest import admin
 from synapse.rest.client import room
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/client/test_events.py
+++ b/tests/rest/client/test_events.py
@@ -29,7 +29,7 @@ import synapse.rest.admin
 from synapse.api.constants import EduTypes
 from synapse.rest.client import events, login, room
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/client/test_filter.py
+++ b/tests/rest/client/test_filter.py
@@ -25,7 +25,7 @@ from synapse.api.errors import Codes
 from synapse.rest.client import filter
 from synapse.server import HomeServer
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/client/test_identity.py
+++ b/tests/rest/client/test_identity.py
@@ -25,7 +25,7 @@ from twisted.internet.testing import MemoryReactor
 import synapse.rest.admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/client/test_login.py
+++ b/tests/rest/client/test_login.py
@@ -52,7 +52,7 @@ from synapse.rest.client.account import WhoamiRestServlet
 from synapse.rest.synapse.client import build_synapse_client_resource_tree
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.handlers.test_oidc import HAS_OIDC

--- a/tests/rest/client/test_login_token_request.py
+++ b/tests/rest/client/test_login_token_request.py
@@ -24,7 +24,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.rest import admin
 from synapse.rest.client import login, login_token_request, versions
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/rest/client/test_media.py
+++ b/tests/rest/client/test_media.py
@@ -59,7 +59,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, media
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.stringutils import parse_and_validate_mxc_uri
 
 from tests import unittest

--- a/tests/rest/client/test_mutual_rooms.py
+++ b/tests/rest/client/test_mutual_rooms.py
@@ -25,7 +25,7 @@ from twisted.internet.testing import MemoryReactor
 import synapse.rest.admin
 from synapse.rest.client import login, mutual_rooms, room
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.server import FakeChannel

--- a/tests/rest/client/test_notifications.py
+++ b/tests/rest/client/test_notifications.py
@@ -26,7 +26,7 @@ from twisted.internet.testing import MemoryReactor
 import synapse.rest.admin
 from synapse.rest.client import login, notifications, receipts, room
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/rest/client/test_owned_state.py
+++ b/tests/rest/client/test_owned_state.py
@@ -10,7 +10,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/rest/client/test_password_policy.py
+++ b/tests/rest/client/test_password_policy.py
@@ -28,7 +28,7 @@ from synapse.api.errors import Codes
 from synapse.rest import admin
 from synapse.rest.client import account, login, password_policy, register
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/client/test_power_levels.py
+++ b/tests/rest/client/test_power_levels.py
@@ -27,7 +27,7 @@ from synapse.events.utils import CANONICALJSON_MAX_INT, CANONICALJSON_MIN_INT
 from synapse.rest import admin
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/rest/client/test_presence.py
+++ b/tests/rest/client/test_presence.py
@@ -26,7 +26,7 @@ from synapse.handlers.presence import PresenceHandler
 from synapse.rest.client import presence
 from synapse.server import HomeServer
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/rest/client/test_profile.py
+++ b/tests/rest/client/test_profile.py
@@ -36,7 +36,7 @@ from synapse.rest.client import login, profile, room
 from synapse.server import HomeServer
 from synapse.storage.databases.main.profile import MAX_PROFILE_SIZE
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.utils import USE_POSTGRES_FOR_TESTS

--- a/tests/rest/client/test_read_marker.py
+++ b/tests/rest/client/test_read_marker.py
@@ -25,7 +25,7 @@ from synapse.api.constants import EventTypes
 from synapse.rest import admin
 from synapse.rest.client import login, read_marker, register, room
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/client/test_receipts.py
+++ b/tests/rest/client/test_receipts.py
@@ -28,7 +28,7 @@ from synapse.api.constants import EduTypes, EventTypes, HistoryVisibility, Recei
 from synapse.rest.client import login, receipts, room, sync
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/client/test_redactions.py
+++ b/tests/rest/client/test_redactions.py
@@ -32,7 +32,7 @@ from synapse.server import HomeServer
 from synapse.storage._base import db_to_json
 from synapse.storage.database import LoggingTransaction
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase, override_config
 

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -39,7 +39,7 @@ from synapse.rest.client import account, account_validity, login, logout, regist
 from synapse.server import HomeServer
 from synapse.storage._base import db_to_json
 from synapse.types import JsonDict, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.server import ThreadedMemoryReactorClock

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -30,7 +30,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, register, relations, room, sync
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.server import FakeChannel

--- a/tests/rest/client/test_rendezvous.py
+++ b/tests/rest/client/test_rendezvous.py
@@ -28,7 +28,7 @@ from twisted.web.resource import Resource
 from synapse.rest.client import rendezvous
 from synapse.rest.synapse.client.rendezvous import MSC4108RendezvousSessionResource
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/rest/client/test_reporting.py
+++ b/tests/rest/client/test_reporting.py
@@ -26,7 +26,7 @@ import synapse.rest.admin
 from synapse.rest.client import login, reporting, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/rest/client/test_retention.py
+++ b/tests/rest/client/test_retention.py
@@ -27,7 +27,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.visibility import filter_events_for_client
 
 from tests import unittest

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -60,7 +60,7 @@ from synapse.rest.client import (
 )
 from synapse.server import HomeServer
 from synapse.types import JsonDict, RoomAlias, UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.stringutils import random_string
 
 from tests import unittest

--- a/tests/rest/client/test_shadow_banned.py
+++ b/tests/rest/client/test_shadow_banned.py
@@ -34,7 +34,7 @@ from synapse.rest.client import (
 )
 from synapse.server import HomeServer
 from synapse.types import UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -36,7 +36,7 @@ from synapse.api.constants import (
 from synapse.rest.client import devices, knock, login, read_marker, receipts, room, sync
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.federation.transport.test_knocking import (

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -36,7 +36,7 @@ from synapse.rest import admin
 from synapse.rest.client import account, login, profile, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict, Requester, StateMap
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.frozenutils import unfreeze
 
 from tests import unittest

--- a/tests/rest/client/test_thread_subscriptions.py
+++ b/tests/rest/client/test_thread_subscriptions.py
@@ -20,7 +20,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, profile, room, thread_subscriptions
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/client/test_transactions.py
+++ b/tests/rest/client/test_transactions.py
@@ -28,7 +28,7 @@ from twisted.internet import defer, reactor as _reactor
 from synapse.logging.context import SENTINEL_CONTEXT, LoggingContext, current_context
 from synapse.rest.client.transactions import CLEANUP_PERIOD_MS, HttpTransactionCache
 from synapse.types import ISynapseReactor, JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.utils import MockClock

--- a/tests/rest/client/test_typing.py
+++ b/tests/rest/client/test_typing.py
@@ -27,7 +27,7 @@ from synapse.api.constants import EduTypes
 from synapse.rest.client import room
 from synapse.server import HomeServer
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/rest/client/test_upgrade_room.py
+++ b/tests/rest/client/test_upgrade_room.py
@@ -28,7 +28,7 @@ from synapse.config.server import DEFAULT_ROOM_VERSION
 from synapse.rest import admin
 from synapse.rest.client import login, room, room_upgrade_rest_servlet
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.server import FakeChannel

--- a/tests/rest/key/v2/test_remote_key_resource.py
+++ b/tests/rest/key/v2/test_remote_key_resource.py
@@ -36,7 +36,7 @@ from synapse.rest.key.v2 import KeyResource
 from synapse.server import HomeServer
 from synapse.storage.keys import FetchKeyResult
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.httpresourcetree import create_resource_tree
 from synapse.util.stringutils import random_string
 

--- a/tests/rest/media/test_domain_blocking.py
+++ b/tests/rest/media/test_domain_blocking.py
@@ -25,7 +25,7 @@ from twisted.web.resource import Resource
 
 from synapse.media._base import FileInfo
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.test_utils import SMALL_PNG

--- a/tests/rest/media/test_url_preview.py
+++ b/tests/rest/media/test_url_preview.py
@@ -36,7 +36,7 @@ from synapse.config.oembed import OEmbedEndpointConfig
 from synapse.media.url_previewer import IMAGE_CACHE_EXPIRY_MS
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.stringutils import parse_and_validate_mxc_uri
 
 from tests import unittest

--- a/tests/rest/synapse/mas/test_devices.py
+++ b/tests/rest/synapse/mas/test_devices.py
@@ -15,7 +15,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import skip_unless
 from tests.utils import HAS_AUTHLIB

--- a/tests/rest/synapse/mas/test_users.py
+++ b/tests/rest/synapse/mas/test_users.py
@@ -18,7 +18,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.appservice import ApplicationService
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import skip_unless
 from tests.utils import HAS_AUTHLIB

--- a/tests/server.py
+++ b/tests/server.py
@@ -103,7 +103,7 @@ from synapse.storage.database import LoggingDatabaseConnection, make_pool
 from synapse.storage.engines import BaseDatabaseEngine, create_engine
 from synapse.storage.prepare_database import prepare_database
 from synapse.types import ISynapseReactor, JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.utils import (
     LEAVE_DB,

--- a/tests/server_notices/__init__.py
+++ b/tests/server_notices/__init__.py
@@ -19,7 +19,7 @@ import synapse.rest.admin
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/server_notices/test_consent.py
+++ b/tests/server_notices/test_consent.py
@@ -25,7 +25,7 @@ from twisted.internet.testing import MemoryReactor
 import synapse.rest.admin
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -32,7 +32,7 @@ from synapse.server_notices.resource_limits_server_notices import (
 )
 from synapse.server_notices.server_notices_sender import ServerNoticesSender
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/state/test_v21.py
+++ b/tests/state/test_v21.py
@@ -38,7 +38,7 @@ from synapse.state.v2 import (
     resolve_events_with_store,
 )
 from synapse.types import StateMap
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.state.test_v2 import TestStateResolutionStore

--- a/tests/storage/databases/main/test_deviceinbox.py
+++ b/tests/storage/databases/main/test_deviceinbox.py
@@ -30,7 +30,7 @@ from synapse.server import HomeServer
 from synapse.storage.databases.main.deviceinbox import (
     DEVICE_FEDERATION_INBOX_CLEANUP_DELAY_MS,
 )
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/databases/main/test_end_to_end_keys.py
+++ b/tests/storage/databases/main/test_end_to_end_keys.py
@@ -26,7 +26,7 @@ from synapse.server import HomeServer
 from synapse.storage._base import db_to_json
 from synapse.storage.database import LoggingTransaction
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -38,8 +38,8 @@ from synapse.storage.databases.main.events_worker import (
     EventsWorkerStore,
 )
 from synapse.storage.types import Connection
-from synapse.util import Clock
 from synapse.util.async_helpers import yieldable_gather_results
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.test_utils.event_injection import create_event, inject_event

--- a/tests/storage/databases/main/test_lock.py
+++ b/tests/storage/databases/main/test_lock.py
@@ -27,7 +27,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.databases.main.lock import _LOCK_TIMEOUT_MS, _RENEWAL_INTERVAL_MS
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/storage/databases/main/test_receipts.py
+++ b/tests/storage/databases/main/test_receipts.py
@@ -27,7 +27,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.storage.database import LoggingTransaction
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/databases/main/test_room.py
+++ b/tests/storage/databases/main/test_room.py
@@ -28,7 +28,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.storage.databases.main.room import _BackgroundUpdates
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test__base.py
+++ b/tests/storage/test__base.py
@@ -25,7 +25,7 @@ from typing import Generator, List, Tuple, cast
 from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/storage/test_account_data.py
+++ b/tests/storage/test_account_data.py
@@ -26,7 +26,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.api.constants import AccountDataTypes
 from synapse.api.errors import Codes, SynapseError
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/storage/test_appservice.py
+++ b/tests/storage/test_appservice.py
@@ -39,7 +39,7 @@ from synapse.storage.databases.main.appservice import (
     ApplicationServiceTransactionStore,
 )
 from synapse.types import DeviceListUpdates
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/storage/test_background_update.py
+++ b/tests/storage/test_background_update.py
@@ -37,7 +37,7 @@ from synapse.storage.background_updates import (
 from synapse.storage.database import LoggingTransaction
 from synapse.storage.engines import PostgresEngine, Sqlite3Engine
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/storage/test_cleanup_extrems.py
+++ b/tests/storage/test_cleanup_extrems.py
@@ -31,7 +31,7 @@ from synapse.server import HomeServer
 from synapse.storage import prepare_database
 from synapse.storage.types import Cursor
 from synapse.types import UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_client_ips.py
+++ b/tests/storage/test_client_ips.py
@@ -35,7 +35,7 @@ from synapse.storage.databases.main.client_ips import (
     DeviceLastConnectionInfo,
 )
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.server import make_request

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -33,7 +33,7 @@ from synapse.storage.database import (
     LoggingTransaction,
     make_tuple_comparison_clause,
 )
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/storage/test_devices.py
+++ b/tests/storage/test_devices.py
@@ -27,7 +27,7 @@ import synapse.api.errors
 from synapse.api.constants import EduTypes
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_directory.py
+++ b/tests/storage/test_directory.py
@@ -23,7 +23,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.types import RoomAlias, RoomID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_e2e_room_keys.py
+++ b/tests/storage/test_e2e_room_keys.py
@@ -23,7 +23,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.databases.main.e2e_room_keys import RoomKey
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/storage/test_end_to_end_keys.py
+++ b/tests/storage/test_end_to_end_keys.py
@@ -22,7 +22,7 @@
 from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_event_chain.py
+++ b/tests/storage/test_event_chain.py
@@ -37,7 +37,7 @@ from synapse.storage.database import LoggingTransaction
 from synapse.storage.databases.main.events import _LinkMap
 from synapse.storage.types import Cursor
 from synapse.types import create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -53,7 +53,8 @@ from synapse.storage.database import LoggingTransaction
 from synapse.storage.types import Cursor
 from synapse.synapse_rust.events import EventInternalMetadata
 from synapse.types import JsonDict
-from synapse.util import Clock, json_encoder
+from synapse.util.clock import Clock
+from synapse.util.json import json_encoder
 
 import tests.unittest
 import tests.utils

--- a/tests/storage/test_event_push_actions.py
+++ b/tests/storage/test_event_push_actions.py
@@ -29,7 +29,7 @@ from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.storage.databases.main.event_push_actions import NotifCounts
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -32,7 +32,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.types import StateMap
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_events_bg_updates.py
+++ b/tests/storage/test_events_bg_updates.py
@@ -20,7 +20,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.api.constants import MAX_DEPTH
 from synapse.api.room_versions import RoomVersion, RoomVersions
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_id_generators.py
+++ b/tests/storage/test_id_generators.py
@@ -35,7 +35,7 @@ from synapse.storage.util.sequence import (
     PostgresSequenceGenerator,
     SequenceGenerator,
 )
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 from tests.utils import USE_POSTGRES_FOR_TESTS

--- a/tests/storage/test_monthly_active_users.py
+++ b/tests/storage/test_monthly_active_users.py
@@ -24,7 +24,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import UserTypes
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import default_config, override_config

--- a/tests/storage/test_profile.py
+++ b/tests/storage/test_profile.py
@@ -25,7 +25,7 @@ from synapse.server import HomeServer
 from synapse.storage.database import LoggingTransaction
 from synapse.storage.engines import PostgresEngine
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/storage/test_purge.py
+++ b/tests/storage/test_purge.py
@@ -25,7 +25,7 @@ from synapse.rest.client import room
 from synapse.server import HomeServer
 from synapse.types.state import StateFilter
 from synapse.types.storage import _BackgroundUpdates
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_receipts.py
+++ b/tests/storage/test_receipts.py
@@ -26,7 +26,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.api.constants import ReceiptTypes
 from synapse.server import HomeServer
 from synapse.types import UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.test_utils.event_injection import create_event
 from tests.unittest import HomeserverTestCase

--- a/tests/storage/test_redaction.py
+++ b/tests/storage/test_redaction.py
@@ -31,7 +31,7 @@ from synapse.events.builder import EventBuilder
 from synapse.server import HomeServer
 from synapse.synapse_rust.events import EventInternalMetadata
 from synapse.types import JsonDict, RoomID, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.utils import create_room

--- a/tests/storage/test_registration.py
+++ b/tests/storage/test_registration.py
@@ -24,7 +24,7 @@ from synapse.api.constants import UserTypes
 from synapse.api.errors import ThreepidValidationError
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID, UserInfo
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase, override_config
 

--- a/tests/storage/test_relations.py
+++ b/tests/storage/test_relations.py
@@ -23,7 +23,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import MAIN_TIMELINE
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/storage/test_rollback_worker.py
+++ b/tests/storage/test_rollback_worker.py
@@ -29,7 +29,7 @@ from synapse.storage.database import LoggingDatabaseConnection
 from synapse.storage.prepare_database import PrepareDatabaseException, prepare_database
 from synapse.storage.schema import SCHEMA_VERSION
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_room.py
+++ b/tests/storage/test_room.py
@@ -24,7 +24,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.api.room_versions import RoomVersions
 from synapse.server import HomeServer
 from synapse.types import RoomAlias, RoomID, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_room_search.py
+++ b/tests/storage/test_room_search.py
@@ -33,7 +33,7 @@ from synapse.storage.databases.main import DataStore
 from synapse.storage.databases.main.search import Phrase, SearchToken, _tokenize_query
 from synapse.storage.engines import PostgresEngine
 from synapse.storage.engines.sqlite import Sqlite3Engine
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase, skip_unless
 from tests.utils import USE_POSTGRES_FOR_TESTS

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -33,7 +33,7 @@ from synapse.server import HomeServer
 from synapse.storage.databases.main.roommember import extract_heroes_from_room_summary
 from synapse.storage.roommember import MemberSummary
 from synapse.types import UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.server import TestHomeServer

--- a/tests/storage/test_sliding_sync_tables.py
+++ b/tests/storage/test_sliding_sync_tables.py
@@ -39,7 +39,7 @@ from synapse.storage.databases.main.events_bg_updates import (
 )
 from synapse.types import create_requester
 from synapse.types.storage import _BackgroundUpdates
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.test_utils.event_injection import create_event
 from tests.unittest import HomeserverTestCase

--- a/tests/storage/test_state.py
+++ b/tests/storage/test_state.py
@@ -32,7 +32,7 @@ from synapse.events import EventBase
 from synapse.server import HomeServer
 from synapse.types import JsonDict, RoomID, StateMap, UserID
 from synapse.types.state import StateFilter
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_state_deletion.py
+++ b/tests/storage/test_state_deletion.py
@@ -20,7 +20,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.test_utils.event_injection import create_event
 from tests.unittest import HomeserverTestCase

--- a/tests/storage/test_stream.py
+++ b/tests/storage/test_stream.py
@@ -49,7 +49,7 @@ from synapse.types import (
     UserID,
     create_requester,
 )
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.test_utils.event_injection import create_event
 from tests.unittest import FederatingHomeserverTestCase, HomeserverTestCase

--- a/tests/storage/test_thread_subscriptions.py
+++ b/tests/storage/test_thread_subscriptions.py
@@ -24,7 +24,7 @@ from synapse.storage.databases.main.thread_subscriptions import (
 )
 from synapse.storage.engines.sqlite import Sqlite3Engine
 from synapse.types import EventOrderings
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/storage/test_transactions.py
+++ b/tests/storage/test_transactions.py
@@ -22,7 +22,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.databases.main.transactions import DestinationRetryTimings
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_txn_limit.py
+++ b/tests/storage/test_txn_limit.py
@@ -23,7 +23,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.storage.types import Cursor
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -37,7 +37,7 @@ from synapse.storage.databases.main.user_directory import (
 )
 from synapse.storage.roommember import ProfileInfo
 from synapse.types import UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.server import ThreadedMemoryReactorClock
 from tests.test_utils.event_injection import inject_member_event

--- a/tests/storage/test_user_filters.py
+++ b/tests/storage/test_user_filters.py
@@ -25,7 +25,7 @@ from twisted.internet.testing import MemoryReactor
 from synapse.server import HomeServer
 from synapse.storage.database import LoggingTransaction
 from synapse.storage.engines import PostgresEngine
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/test_mau.py
+++ b/tests/test_mau.py
@@ -30,7 +30,7 @@ from synapse.appservice import ApplicationService
 from synapse.rest.client import register, sync
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/test_phone_home.py
+++ b/tests/test_phone_home.py
@@ -29,7 +29,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, sync
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,8 +36,8 @@ from synapse.http.server import (
 from synapse.http.site import SynapseRequest, SynapseSite
 from synapse.logging.context import make_deferred_yieldable
 from synapse.types import JsonDict
-from synapse.util import Clock
 from synapse.util.cancellation import cancellable
+from synapse.util.clock import Clock
 
 from tests import unittest
 from tests.http.server._base import test_disconnect

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -43,7 +43,7 @@ from synapse.events.snapshot import EventContext
 from synapse.state import StateHandler, StateResolutionHandler, _make_state_cache_entry
 from synapse.types import MutableStateMap, StateMap
 from synapse.types.state import StateFilter
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.macaroons import MacaroonGenerator
 
 from tests import unittest

--- a/tests/test_terms_auth.py
+++ b/tests/test_terms_auth.py
@@ -26,7 +26,7 @@ from twisted.internet.testing import MemoryReactor, MemoryReactorClock
 from synapse.rest.client.register import register_servlets
 from synapse.server import HomeServer
 from synapse.types import JsonDict
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from tests import unittest
 

--- a/tests/test_terms_auth.py
+++ b/tests/test_terms_auth.py
@@ -20,8 +20,7 @@
 
 from unittest.mock import Mock
 
-from twisted.internet.interfaces import IReactorTime
-from twisted.internet.testing import MemoryReactor, MemoryReactorClock
+from twisted.internet.testing import MemoryReactor
 
 from synapse.rest.client.register import register_servlets
 from synapse.server import HomeServer
@@ -49,13 +48,7 @@ class TermsTestCase(unittest.HomeserverTestCase):
         )
         return config
 
-    def prepare(
-        self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
-    ) -> None:
-        # type-ignore: mypy-zope doesn't seem to recognise that MemoryReactorClock
-        # implements IReactorTime, via inheritance from twisted.internet.testing.Clock
-        self.clock: IReactorTime = MemoryReactorClock()  # type: ignore[assignment]
-        self.hs_clock = Clock(self.clock)
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.url = "/_matrix/client/r0/register"
         self.registration_handler = Mock()
         self.auth_handler = Mock()

--- a/tests/test_utils/oidc.py
+++ b/tests/test_utils/oidc.py
@@ -33,7 +33,7 @@ from twisted.web.http_headers import Headers
 from twisted.web.iweb import IResponse
 
 from synapse.server import HomeServer
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.stringutils import random_string
 
 from tests.test_utils import FakeResponse

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -31,7 +31,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.types import create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.visibility import filter_events_for_client, filter_events_for_server
 
 from tests import unittest

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -81,7 +81,7 @@ from synapse.rest import RegisterServletsFunc
 from synapse.server import HomeServer
 from synapse.storage.keys import FetchKeyResult
 from synapse.types import JsonDict, Requester, UserID, create_requester
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.httpresourcetree import create_resource_tree
 
 from tests.server import (

--- a/tests/util/test_expiring_cache.py
+++ b/tests/util/test_expiring_cache.py
@@ -21,8 +21,8 @@
 
 from typing import List, cast
 
-from synapse.util import Clock
 from synapse.util.caches.expiringcache import ExpiringCache
+from synapse.util.clock import Clock
 
 from tests.utils import MockClock
 

--- a/tests/util/test_logcontext.py
+++ b/tests/util/test_logcontext.py
@@ -34,7 +34,7 @@ from synapse.logging.context import (
     run_in_background,
 )
 from synapse.types import ISynapseReactor
-from synapse.util import Clock
+from synapse.util.clock import Clock
 
 from .. import unittest
 

--- a/tests/util/test_task_scheduler.py
+++ b/tests/util/test_task_scheduler.py
@@ -25,7 +25,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.server import HomeServer
 from synapse.types import JsonMapping, ScheduledTask, TaskStatus
-from synapse.util import Clock
+from synapse.util.clock import Clock
 from synapse.util.task_scheduler import TaskScheduler
 
 from tests.replication._base import BaseMultiWorkerStreamTestCase


### PR DESCRIPTION
**This PR can be reviewed commit-by-commit.**

Introduce `Clock.call_when_running(...)` to wrap startup code in a logcontext, ensuring we can identify which server generated the logs.

Background:

https://github.com/element-hq/synapse/blob/9cc400177822805e2a08d4d934daad6f3bc2a4df/docs/log_contexts.md#L71-L81

Also adds a lint to prefer `Clock.call_when_running(...)` over `reactor.callWhenRunning(...)`

Part of https://github.com/element-hq/synapse/issues/18905


### Dev notes

Originally, we covered Synapse startup by manually adding a logcontext, see https://github.com/element-hq/synapse/pull/18870

Adding logcontext to `looping_call` and `call_later` in https://github.com/element-hq/synapse/pull/18907

Mypy lint pattern came from https://github.com/element-hq/synapse/pull/18828


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
