### PR TITLE
fix: Compute user last seen timestamp from last seen devices

### DIFF
--- a/changelog.d/18948.bugfix
+++ b/changelog.d/18948.bugfix
@@ -1,0 +1,1 @@
+Compute a user's last seen timestamp from their devices' last seen timestamps instead of IPs, because the latter are automatically cleared according to `user_ips_max_age`.


### PR DESCRIPTION
## Fix last seen timestamp in `/_synapse/admin/v2/users` response

Fixes #18955

The last seen timestamps contained in `/_synapse/admin/v2/users` responses were computed as follows:

```sql
                [...]
                LEFT JOIN (
                    SELECT user_id, MAX(last_seen) AS last_seen_ts
                    FROM user_ips GROUP BY user_id
                ) ls ON u.name = ls.user_id
                [...]
```
https://github.com/element-hq/synapse/blob/4367fb2d078c52959aeca0fe6874539c53e8360d/synapse/storage/databases/main/__init__.py#L302C1-L305C44

This leads to empty timestamps (as in: user was never seen) if users are inactive for longer than [`user_ips_max_age`](https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#user_ips_max_age).

The fix is quite trivial: Use the `devices` table, as this one also contains last seen timestamps but is *not* periodically purged.

We are using this for automatic user account deletion (via [synadm](https://codeberg.org/synadm/synadm)) and the patched code works as intended, whereas the unpatched version wants to delete users during long vacations. :face_with_peeking_eye: 


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
