### PR TITLE
Provide same `servers` list in s2s alias results as c2s.

### DIFF
--- a/changelog.d/18970.misc
+++ b/changelog.d/18970.misc
@@ -1,0 +1,1 @@
+Provide additional servers with federation room directory results.

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -321,16 +321,7 @@ class DirectoryHandler:
         if not self.hs.is_mine(room_alias):
             raise SynapseError(400, "Room Alias is not hosted on this homeserver")
 
-        result = await self.get_association_from_room_alias(room_alias)
-
-        if result is not None:
-            return {"room_id": result.room_id, "servers": result.servers}
-        else:
-            raise SynapseError(
-                404,
-                "Room alias %r not found" % (room_alias.to_string(),),
-                Codes.NOT_FOUND,
-            )
+        return await self.get_association(room_alias)
 
     async def _update_canonical_alias(
         self, requester: Requester, user_id: str, room_id: str, room_alias: RoomAlias


### PR DESCRIPTION
This change lifts the restriction on `servers` provided with federation alias resolution by providing the same `servers` already returned with client alias resolution.

The problem is that users favor joining rooms via coveted matrix.org aliases which are the most reliably resolved yet the least reliably joined. The abridged list of `servers` in the above case often yields a cloudflare 524 customer-timeout.

An attempt was made to allay the blame placed upon us from users suffering join failures by shuffling matrix.org to the back of the servers list. This solution is ineffective with `servers` lists abridged to a single element.

If this patch is declined the server will have no choice but to fallback to resolving aliases via the client-server endpoint to obtain the unabridged list; obviously not intended and easily preventable with this patch.

If the disposition is to accept I can look into providing the changelog and any additional signoffs as requested.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
