### PR TITLE
Add `Access-Control-Max-Age` header to CORS responses

### DIFF
--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -973,6 +973,10 @@ def set_cors_headers(request: "SynapseRequest") -> None:
     request.setHeader(
         b"Access-Control-Allow-Methods", b"GET, HEAD, POST, PUT, DELETE, OPTIONS"
     )
+
+    # Allow browsers to cache preflight responses for 10 minutes
+    request.setHeader(b"Access-Control-Max-Age", b"600")
+
     if request.path is not None and (
         request.path == b"/_matrix/client/unstable/org.matrix.msc4108/rendezvous"
         or request.path.startswith(b"/_synapse/client/rendezvous")


### PR DESCRIPTION
This PR adds the `Access-Control-Max-Age` header to CORS responses to allow browsers to cache the results of preflight requests for 10 minutes.

By doing so, clients, especially during startup, will avoid sending repeated OPTIONS requests for each endpoint. This can noticeably improve performance and shave off more than a full second in many cases during startup:

<img width="1323" height="367" alt="image" src="https://github.com/user-attachments/assets/d2c2de23-afbd-4380-a6af-5674b804f96c" />
