### PR TITLE
Fix `rc_room_creation` and `rc_reports` docs - remove `per_user` typo

### DIFF
--- a/changelog.d/18998.doc
+++ b/changelog.d/18998.doc
@@ -1,0 +1,1 @@
+Fix documentation for `rc_room_creation` and `rc_reports` to clarify that a `per_user` rate limit is not supported.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -2006,9 +2006,8 @@ This setting has the following sub-options:
 Default configuration:
 ```yaml
 rc_reports:
-  per_user:
-    per_second: 1.0
-    burst_count: 5.0
+  per_second: 1.0
+  burst_count: 5.0
 ```
 
 Example configuration:
@@ -2031,9 +2030,8 @@ This setting has the following sub-options:
 Default configuration:
 ```yaml
 rc_room_creation:
-  per_user:
-    per_second: 0.016
-    burst_count: 10.0
+  per_second: 0.016
+  burst_count: 10.0
 ```
 
 Example configuration:

--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -2259,9 +2259,8 @@ properties:
       Setting this to a high value allows users to report content quickly, possibly in
       duplicate. This can result in higher database usage.
     default:
-      per_user:
-        per_second: 1.0
-        burst_count: 5.0
+      per_second: 1.0
+      burst_count: 5.0
     examples:
       - per_second: 2.0
         burst_count: 20.0
@@ -2270,9 +2269,8 @@ properties:
     description: >-
       Sets rate limits for how often users are able to create rooms.
     default:
-      per_user:
-        per_second: 0.016
-        burst_count: 10.0
+      per_second: 0.016
+      burst_count: 10.0
     examples:
       - per_second: 1.0
         burst_count: 5.0


### PR DESCRIPTION
*Spawning from a [discussion in `#synapse-dev:matrix.org`](https://matrix.to/#/!vcyiEtMVHIhWXcJAfl:sw1v.org/$f3ftdeEREjwlH7fdMezFLlcF-Zd5-l6rsR3unPZ6FEY?via=matrix.org&via=node.marinchik.ink&via=element.io),*


https://github.com/element-hq/synapse/commit/8344c944b1f6ee2f398369fcde7e6f643a1ad6e8 introduced the option `rc_room_creation` and the docs are inconsistent, the default is given as:

```yaml
rc_room_creation:
  per_user:
    per_second: ....
```

while the example shows:

```yaml
rc_room_cration:
  per_second: ...
```

Looking at the source code , and the worker example config file, the latter is correct. So simply remove the stray `per_user:` and let's pretend it never existed.