### PR TITLE
No need to have `version_string` as an argument since it's always the same

### DIFF
--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -98,7 +98,6 @@ from synapse.storage.databases.state.bg_updates import StateBackgroundUpdateStor
 from synapse.storage.engines import create_engine
 from synapse.storage.prepare_database import prepare_database
 from synapse.types import ISynapseReactor
-from synapse.util import SYNAPSE_VERSION
 
 # Cast safety: Twisted does some naughty magic which replaces the
 # twisted.internet.reactor module with a Reactor instance at runtime.
@@ -325,7 +324,6 @@ class MockHomeserver(HomeServer):
             hostname=config.server.server_name,
             config=config,
             reactor=reactor,
-            version_string=f"Synapse/{SYNAPSE_VERSION}",
         )
 
 

--- a/synapse/_scripts/update_synapse_database.py
+++ b/synapse/_scripts/update_synapse_database.py
@@ -31,7 +31,6 @@ from synapse.config.homeserver import HomeServerConfig
 from synapse.server import HomeServer
 from synapse.storage import DataStore
 from synapse.types import ISynapseReactor
-from synapse.util import SYNAPSE_VERSION
 
 # Cast safety: Twisted does some naughty magic which replaces the
 # twisted.internet.reactor module with a Reactor instance at runtime.
@@ -47,7 +46,6 @@ class MockHomeserver(HomeServer):
             hostname=config.server.server_name,
             config=config,
             reactor=reactor,
-            version_string=f"Synapse/{SYNAPSE_VERSION}",
         )
 
 

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -421,17 +421,26 @@ def listen_http(
     context_factory: Optional[IOpenSSLContextFactory],
     reactor: ISynapseReactor = reactor,
 ) -> List[Port]:
+    """
+    Args:
+        listener_config: TODO
+        root_resource: TODO
+        version_string: A string to present for the Server header
+        max_request_body_size: TODO
+        context_factory: TODO
+        reactor: TODO
+    """
     assert listener_config.http_options is not None
 
     site_tag = listener_config.get_site_tag()
 
     site = SynapseSite(
-        "synapse.access.%s.%s"
+        logger_name="synapse.access.%s.%s"
         % ("https" if listener_config.is_tls() else "http", site_tag),
-        site_tag,
-        listener_config,
-        root_resource,
-        version_string,
+        site_tag=site_tag,
+        config=listener_config,
+        resource=root_resource,
+        server_version_string=version_string,
         max_request_body_size=max_request_body_size,
         reactor=reactor,
         hs=hs,

--- a/synapse/app/admin_cmd.py
+++ b/synapse/app/admin_cmd.py
@@ -65,7 +65,6 @@ from synapse.storage.databases.main.stream import StreamWorkerStore
 from synapse.storage.databases.main.tags import TagsWorkerStore
 from synapse.storage.databases.main.user_erasure_store import UserErasureWorkerStore
 from synapse.types import JsonMapping, StateMap
-from synapse.util import SYNAPSE_VERSION
 from synapse.util.logcontext import LoggingContext
 
 logger = logging.getLogger("synapse.app.admin_cmd")
@@ -316,7 +315,6 @@ def start(config: HomeServerConfig, args: argparse.Namespace) -> None:
     ss = AdminCmdServer(
         config.server.server_name,
         config=config,
-        version_string=f"Synapse/{SYNAPSE_VERSION}",
     )
 
     setup_logging(ss, config, use_worker_options=True)

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -112,7 +112,6 @@ from synapse.storage.databases.main.transactions import TransactionWorkerStore
 from synapse.storage.databases.main.ui_auth import UIAuthWorkerStore
 from synapse.storage.databases.main.user_directory import UserDirectoryStore
 from synapse.storage.databases.main.user_erasure_store import UserErasureWorkerStore
-from synapse.util import SYNAPSE_VERSION
 from synapse.util.httpresourcetree import create_resource_tree
 
 logger = logging.getLogger("synapse.app.generic_worker")
@@ -359,7 +358,6 @@ def start(config: HomeServerConfig) -> None:
     hs = GenericWorkerServer(
         config.server.server_name,
         config=config,
-        version_string=f"Synapse/{SYNAPSE_VERSION}",
     )
 
     setup_logging(hs, config, use_worker_options=True)

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -71,7 +71,7 @@ from synapse.rest.well_known import well_known_resource
 from synapse.server import HomeServer
 from synapse.storage import DataStore
 from synapse.types import ISynapseReactor
-from synapse.util.check_dependencies import VERSION, check_requirements
+from synapse.util.check_dependencies import check_requirements
 from synapse.util.httpresourcetree import create_resource_tree
 from synapse.util.module_loader import load_module
 
@@ -399,7 +399,6 @@ def setup(
     hs = SynapseHomeServer(
         config.server.server_name,
         config=config,
-        version_string=f"Synapse/{VERSION}",
         reactor=reactor,
     )
 

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -741,6 +741,7 @@ class SynapseSite(ProxySite):
 
     def __init__(
         self,
+        *,
         logger_name: str,
         site_tag: str,
         config: ListenerConfig,

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -175,6 +175,7 @@ from synapse.storage.controllers import StorageControllers
 from synapse.streams.events import EventSources
 from synapse.synapse_rust.rendezvous import RendezvousHandler
 from synapse.types import DomainSpecificString, ISynapseReactor
+from synapse.util import SYNAPSE_VERSION
 from synapse.util.caches import CACHE_METRIC_REGISTRY
 from synapse.util.clock import Clock
 from synapse.util.distributor import Distributor
@@ -322,7 +323,6 @@ class HomeServer(metaclass=abc.ABCMeta):
         hostname: str,
         config: HomeServerConfig,
         reactor: Optional[ISynapseReactor] = None,
-        version_string: str = "Synapse",
     ):
         """
         Args:
@@ -347,7 +347,7 @@ class HomeServer(metaclass=abc.ABCMeta):
         self._instance_id = random_string(5)
         self._instance_name = config.worker.instance_name
 
-        self.version_string = version_string
+        self.version_string = f"Synapse/{SYNAPSE_VERSION}"
 
         self.datastores: Optional[Databases] = None
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -1198,7 +1198,6 @@ def setup_test_homeserver(
     hs = homeserver_to_use(
         server_name,
         config=config,
-        version_string="Synapse/tests",
         reactor=reactor,
     )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -236,17 +236,17 @@ class OptionsResourceTests(unittest.TestCase):
         """Create a request from the method/path and return a channel with the response."""
         # Create a site and query for the resource.
         site = SynapseSite(
-            "test",
-            "site_tag",
-            parse_listener_def(
+            logger_name="test",
+            site_tag="site_tag",
+            config=parse_listener_def(
                 0,
                 {
                     "type": "http",
                     "port": 0,
                 },
             ),
-            self.resource,
-            "1.0",
+            resource=self.resource,
+            server_version_string="1",
             max_request_body_size=4096,
             reactor=self.reactor,
             hs=self.homeserver,


### PR DESCRIPTION
No need to have `version_string` as an argument since it's always the same.

Assuming, we're happy with https://github.com/element-hq/synapse/pull/19011, this PR makes sense. But we should leave the decision and context of having them be the same to that PR first.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
