### PR TITLE
Fix bad merge with `start_background_tasks`

### DIFF
--- a/changelog.d/19013.misc
+++ b/changelog.d/19013.misc
@@ -1,0 +1,1 @@
+Remove duplicate call to `hs.start_background_tasks()` introduced from a bad merge.

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -613,12 +613,6 @@ class HomeServer(metaclass=abc.ABCMeta):
         self.datastores = Databases(self.DATASTORE_CLASS, self)
         logger.info("Finished setting up.")
 
-        # Register background tasks required by this server. This must be done
-        # somewhat manually due to the background tasks not being registered
-        # unless handlers are instantiated.
-        if self.config.worker.run_background_tasks:
-            self.start_background_tasks()
-
     # def __del__(self) -> None:
     #    """
     #    Called when an the homeserver is garbage collected.


### PR DESCRIPTION
Fix bad merge with `start_background_tasks`

This was originally removed in https://github.com/element-hq/synapse/pull/18886 but it looks like it snuck back in https://github.com/element-hq/synapse/pull/18828 during a [bad merge](https://github.com/element-hq/synapse/commit/4cd3d9172ed7b87e509746851a376c861a27820e).

Noticed while looking at Synapse setup and startup (just by happen stance).

I don't think this has adverse effects on Synapse actually working and `start_background_tasks()` can be called multiple times.


### Is there a good way to audit all of these merges?

As I would like to see the conflicts for each merge.

This works but it's still hard to notice anything is wrong:

```
git log --remerge-diff <commit-sha>
```

> shows the difference from mechanical merge result and the result that is actually recorded in a merge commit

via https://stackoverflow.com/questions/15277708/how-do-you-see-show-a-git-merge-conflict-resolution-that-was-done-given-a-mer/71181334#71181334

The following better. Specify the version range to the commit right before the merge to the merge. And can even specify which file to look at to make it more obvious with the hindsight we have now.

```
git log --remerge-diff <merge-commit-sha>~1..<merge-commit-sha> -- synapse/server.py
```

Example:
```
git log --remerge-diff 4cd3d9172ed7b87e509746851a376c861a27820e~1..4cd3d9172ed7b87e509746851a376c861a27820e -- synapse/server.py
```



### Dev notes

`Merge branch 'develop'` commits from https://github.com/element-hq/synapse/pull/18828
```
5a4dd914c95f63ff3be5978b861468ddb063bb53
4f1603d12710eb210aa00773f07a53b95e7b67fa
5188a784ffb9937601d0729ae04f5087a6193672
23e587f655d17fcd8130a794b055edfca0389bea
4cd3d9172ed7b87e509746851a376c861a27820e
f8a5bed8f83358486a6521ffe876934fc19cf84f
d0555f9abc02afb2b2d92945bba95e8e16f6b69d
8184e9b599decadfe84ea3662491912dc669e551
25c4ba8ec8dd3c6266df2c0a1635cbda4f53830e
b1f29a49fadc82d9c2b248d388c0eb9aa20d464e
99c3559fb92b12d20fb9410abb933dfb72164314
ee612c5fd56ab9ea14e46e03ab46326c075adb23
```

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
