### PR TITLE
Allow Synapse modules to specify their own threadpool when calling `defer_to_thread`

### DIFF
--- a/changelog.d/19024.feature
+++ b/changelog.d/19024.feature
@@ -1,0 +1,1 @@
+Allow Synapse modules to specify a custom threadpool when calling `defer_to_thread`.


### PR DESCRIPTION
Spurred on by https://github.com/matrix-org/synapse-s3-storage-provider/pull/134#discussion_r2410150352. Should be backwards-compatible with all modules.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
