### PR TITLE
srv_resolver: add 15s timeout to DNS lookups

### DIFF
--- a/changelog.d/19026.misc
+++ b/changelog.d/19026.misc
@@ -1,0 +1,1 @@
+Shorten DNS resolver timeout/retry sequence from 60s to 15s to ensure DNS failures are visible before federation HTTP request timeouts.

--- a/synapse/http/federation/srv_resolver.py
+++ b/synapse/http/federation/srv_resolver.py
@@ -26,6 +26,7 @@ from typing import Any, Callable, Dict, List
 
 import attr
 
+from twisted.internet import defer
 from twisted.internet.error import ConnectError
 from twisted.names import client, dns
 from twisted.names.error import DNSNameError, DNSNotImplementedError, DomainError
@@ -35,6 +36,20 @@ from synapse.logging.context import make_deferred_yieldable
 logger = logging.getLogger(__name__)
 
 SERVER_CACHE: Dict[bytes, List["Server"]] = {}
+
+DNS_LOOKUP_TIMEOUTS = (
+    1,  # Quick retry for packet loss/scenarios
+    3,  # Still reasonable for slow responders
+    3,  # ...
+    3,  # Already catching 99.9% of successful queries at 10s
+    # Final attempt for extreme edge cases.
+    #
+    # TODO: In the future (after 2026-01-01), we could consider removing this extra
+    # time if we don't see complaints. For comparison, the Windows
+    # DNS resolver gives up after 10s using `(1, 1, 2, 4, 2)`, see
+    # https://learn.microsoft.com/en-us/troubleshoot/windows-server/networking/dns-client-resolution-timeouts
+    5,
+)
 
 
 @attr.s(auto_attribs=True, slots=True, frozen=True)
@@ -145,7 +160,25 @@ class SrvResolver:
 
         try:
             answers, _, _ = await make_deferred_yieldable(
-                self._dns_client.lookupService(service_name)
+                self._dns_client.lookupService(
+                    service_name,
+                    # This is a sequence of ints that represent the "number of seconds
+                    # after which to reissue the query. When the last timeout expires,
+                    # the query is considered failed." The default value in Twisted is
+                    # `timeout=(1, 3, 11, 45)` (60s total) which is an "arbitrary"
+                    # exponential backoff sequence and is too long (see below).
+                    #
+                    # We want the total timeout to be below the overarching HTTP request
+                    # timeout (60s for federation requests) that spurred on this lookup.
+                    # This way, we can see the underlying DNS failure and move on
+                    # instead of the user ending up with a generic HTTP request timeout.
+                    #
+                    # Since these DNS queries are done over UDP (unreliable transport),
+                    # by it's nature, it's bound to occasionally fail (dropped packets,
+                    # etc). We want a list that starts small and re-issues DNS queries
+                    # multiple times until we get a response or timeout.
+                    timeout=DNS_LOOKUP_TIMEOUTS,
+                )
             )
         except DNSNameError:
             # TODO: cache this. We can get the SOA out of the exception, and use
@@ -165,6 +198,10 @@ class SrvResolver:
                 return list(cache_entry)
             else:
                 raise e
+        except defer.TimeoutError as e:
+            raise defer.TimeoutError(
+                f"Timed out while trying to resolve DNS for SRV record for {service_name!r} (timeout={sum(DNS_LOOKUP_TIMEOUTS)}s)"
+            ) from e
 
         if (
             len(answers) == 1

--- a/tests/http/federation/test_srv_resolver.py
+++ b/tests/http/federation/test_srv_resolver.py
@@ -68,7 +68,9 @@ class SrvResolverTestCase(unittest.TestCase):
         test_d = do_lookup()
         self.assertNoResult(test_d)
 
-        dns_client_mock.lookupService.assert_called_once_with(service_name)
+        dns_client_mock.lookupService.assert_called_once_with(
+            service_name, timeout=(1, 3, 3, 3, 5)
+        )
 
         result_deferred.callback(([answer_srv], None, None))
 
@@ -98,7 +100,9 @@ class SrvResolverTestCase(unittest.TestCase):
         servers: List[Server]
         servers = yield defer.ensureDeferred(resolver.resolve_service(service_name))  # type: ignore[assignment]
 
-        dns_client_mock.lookupService.assert_called_once_with(service_name)
+        dns_client_mock.lookupService.assert_called_once_with(
+            service_name, timeout=(1, 3, 3, 3, 5)
+        )
 
         self.assertEqual(len(servers), 1)
         self.assertEqual(servers, cache[service_name])


### PR DESCRIPTION
- Closes #9774

### Problem

The default timeout when looking up SRV records for the dns client is 60 seconds, which is quite long and can be problematic as that's the value of the default http client timeout, thus the error surfaced is the http error and not the underlying DNS error.

### Solution

I've added a more aggressive timeout of 15 seconds total (with retries after 1, 3, 3, 3, and 5 seconds) for the SRV lookup. I've also re-labeled the `defer.TimeoutError, as that was done in the prior [synapse PR](https://github.com/matrix-org/synapse/pull/9776), and makes the error more clear to users.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
