### PR TITLE
Allow UTF-8 user IDs when requesting mutual rooms with another user

### DIFF
--- a/changelog.d/19029.bugfix
+++ b/changelog.d/19029.bugfix
@@ -1,0 +1,1 @@
+Allow UTF-8 user IDs when requesting mutual rooms with another user.

--- a/synapse/rest/client/mutual_rooms.py
+++ b/synapse/rest/client/mutual_rooms.py
@@ -55,7 +55,7 @@ class UserMutualRoomsServlet(RestServlet):
         # twisted.web.server.Request.args is incorrectly defined as Optional[Any]
         args: Dict[bytes, List[bytes]] = request.args  # type: ignore
 
-        user_ids = parse_strings_from_args(args, "user_id", required=True)
+        user_ids = parse_strings_from_args(args, "user_id", required=True, encoding="utf-8")
 
         if len(user_ids) > 1:
             raise SynapseError(


### PR DESCRIPTION
This solves #18958 

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [X] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
