### PR TITLE
Allow using MSC4190 features without opt-in

### DIFF
--- a/changelog.d/19031.feature
+++ b/changelog.d/19031.feature
@@ -1,0 +1,1 @@
+Allow using [MSC4190](https://github.com/matrix-org/matrix-spec-proposals/pull/4190) behavior without the opt-in registration flag. Contributed by @tulir @ Beeper.

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -112,7 +112,7 @@ class DeleteDevicesRestServlet(RestServlet):
             else:
                 raise e
 
-        if requester.app_service and requester.app_service.msc4190_device_management:
+        if requester.app_service:
             # MSC4190 can skip UIA for this endpoint
             pass
         else:
@@ -192,7 +192,7 @@ class DeviceRestServlet(RestServlet):
             else:
                 raise
 
-        if requester.app_service and requester.app_service.msc4190_device_management:
+        if requester.app_service:
             # MSC4190 allows appservices to delete devices through this endpoint without UIA
             # It's also allowed with MSC3861 enabled
             pass
@@ -227,7 +227,7 @@ class DeviceRestServlet(RestServlet):
         body = parse_and_validate_json_object_from_request(request, self.PutBody)
 
         # MSC4190 allows appservices to create devices through this endpoint
-        if requester.app_service and requester.app_service.msc4190_device_management:
+        if requester.app_service:
             created = await self.device_handler.upsert_device(
                 user_id=requester.user.to_string(),
                 device_id=device_id,

--- a/synapse/rest/client/keys.py
+++ b/synapse/rest/client/keys.py
@@ -543,15 +543,11 @@ class SigningKeyUploadServlet(RestServlet):
         if not keys_are_different:
             return 200, {}
 
-        # MSC4190 can skip UIA for replacing cross-signing keys as well.
-        is_appservice_with_msc4190 = (
-            requester.app_service and requester.app_service.msc4190_device_management
-        )
-
         # The keys are different; is x-signing set up? If no, then this is first-time
         # setup, and that is allowed without UIA, per MSC3967.
         # If yes, then we need to authenticate the change.
-        if is_cross_signing_setup and not is_appservice_with_msc4190:
+        # MSC4190 can skip UIA for replacing cross-signing keys as well.
+        if is_cross_signing_setup and not requester.app_service:
             # With MSC3861, UIA is not possible. Instead, the auth service has to
             # explicitly mark the master key as replaceable.
             if self.hs.config.mas.enabled:


### PR DESCRIPTION
I didn't bother adding an experimental_features flag, so this should only be merged once MSC4190 passes FCP