### PR TITLE
Update list of `status` available for the `/redact_status` Admin API

### DIFF
--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -1544,7 +1544,7 @@ The following parameters should be set in the URL:
 
 The following fields are returned in the JSON response body:
 
-- `status` - string - one of scheduled/active/complete/failed, indicating the status of the redaction job
+- `status` - string - one of `scheduled`/`active`/`complete`/`failed`, indicating the status of the redaction job
 - `failed_redactions` - dictionary - the keys of the dict are event ids the process was unable to redact, if any, and the values are 
   the corresponding error that caused the redaction to fail
 


### PR DESCRIPTION
## Just fixed a typo .

Fix https://github.com/element-hq/synapse/issues/18338

Change `completed` to `complete`.

Contributed by @neuark .
