### PR TITLE
Have the release script warn if a workflow is queued for >15m

### DIFF
--- a/changelog.d/19084.misc
+++ b/changelog.d/19084.misc
@@ -1,0 +1,1 @@
+Warn the developer when they are releasing Synapse if a release workflow has been queued for over 15 minutes.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -600,7 +600,9 @@ def _wait_for_actions(gh_token: Optional[str]) -> None:
         if any(workflow["status"] == "queued" for workflow in resp["workflow_runs"]):
             _notify("Warning: at least one release workflow is still queued...")
             if not click.confirm("Continue waiting for queued assets?", default=True):
-                click.echo("Continuing on with the release. Note that you may need to upload missing assets manually later.")
+                click.echo(
+                    "Continuing on with the release. Note that you may need to upload missing assets manually later."
+                )
                 break
             continue
 

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -599,6 +599,9 @@ def _wait_for_actions(gh_token: Optional[str]) -> None:
         # Warn the user if any workflows are still queued. They might need to fix something.
         if any(workflow["status"] == "queued" for workflow in resp["workflow_runs"]):
             _notify("Warning: at least one release workflow is still queued...")
+            if not click.confirm("Continue waiting for queued assets?", default=True):
+                click.echo("Continuing on with the release. Note that you may need to upload missing assets manually later.")
+                break
             continue
 
         if all(

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -596,6 +596,11 @@ def _wait_for_actions(gh_token: Optional[str]) -> None:
         if len(resp["workflow_runs"]) == 0:
             continue
 
+        # Warn the user if any workflows are still queued. They might need to fix something.
+        if any(workflow["status"] == "queued" for workflow in resp["workflow_runs"]):
+            _notify("Warning: at least one release workflow is still queued...")
+            continue
+
         if all(
             workflow["status"] != "in_progress" for workflow in resp["workflow_runs"]
         ):


### PR DESCRIPTION
Currently the script will just emit "Workflows failed" if a workflow is queued for over 15m (which has been happening recently due to MacOS runners being slow to get).

After this change, the release manager will be warned that a workflow is still queued, prompting them to go and do something about it.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
