### PR TITLE
Add `delayed_events` table to boolean column port

### DIFF
--- a/changelog.d/19155.bugfix
+++ b/changelog.d/19155.bugfix
@@ -1,0 +1,1 @@
+Let the SQLite-to-PostgreSQL migration script correctly migrate a boolean column in the `delayed_events` table.

--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -107,6 +107,7 @@ logger = logging.getLogger("synapse_port_db")
 BOOLEAN_COLUMNS = {
     "access_tokens": ["used"],
     "account_validity": ["email_sent"],
+    "delayed_events": ["is_processed"],
     "device_lists_changes_in_room": ["converted_to_destinations"],
     "device_lists_outbound_pokes": ["sent"],
     "devices": ["hidden"],


### PR DESCRIPTION
The `delayed_events` table has a boolean column that should be handled by the SQLite->PostgreSQL migration script.

MSC4140

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
