### PR TITLE
Allow overriding max background task count

### DIFF
--- a/scripts-dev/get_sched_tasks.sql
+++ b/scripts-dev/get_sched_tasks.sql
@@ -1,0 +1,1 @@
+select * from scheduled_tasks where status != 'complete';

--- a/synapse/config/ratelimiting.py
+++ b/synapse/config/ratelimiting.py
@@ -84,6 +84,7 @@ class RatelimitConfig(Config):
     section = "ratelimiting"
 
     def read_config(self, config: JsonDict, **kwargs: Any) -> None:
+        self.override_max_concurrent_running_tasks = config.get("ratelimiting", {}).get("override_max_concurrent_running_tasks", None)
         # Load the new-style messages config if it exists. Otherwise fall back
         # to the old method.
         if "rc_message" in config:

--- a/synapse/util/task_scheduler.py
+++ b/synapse/util/task_scheduler.py
@@ -139,6 +139,12 @@ class TaskScheduler:
             hook=lambda: {(self.server_name,): len(self._running_tasks)},
         )
 
+        if hs.config.ratelimiting.override_max_concurrent_running_tasks is not None:
+            TaskScheduler.MAX_CONCURRENT_RUNNING_TASKS = (
+                hs.config.ratelimiting.override_max_concurrent_running_tasks
+            )
+        logger.warning("Max concurrent running tasks: %s, override: %s", TaskScheduler.MAX_CONCURRENT_RUNNING_TASKS, hs.config.ratelimiting.override_max_concurrent_running_tasks)
+
     def register_action(
         self,
         function: Callable[


### PR DESCRIPTION
This probably is in the wrong config section, also missing docs at the moment.

This setting can be useful to configure depending on deployment size: Some servers I manage struggle with any value above 2, while some don't appear to have negative side effects from values as high as 64.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
