### PR TITLE
Warn for PostgreSQL 13 deprecation (#19170)

### DIFF
--- a/.ci/scripts/calculate_jobs.py
+++ b/.ci/scripts/calculate_jobs.py
@@ -72,7 +72,7 @@ trial_postgres_tests = [
     {
         "python-version": "3.10",
         "database": "postgres",
-        "postgres-version": "14",
+        "postgres-version": "13",
         "extras": "all",
     },
     {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -618,7 +618,7 @@ jobs:
       matrix:
         include:
           - python-version: "3.10"
-            postgres-version: "14"
+            postgres-version: "13"
 
           - python-version: "3.14"
             postgres-version: "17"

--- a/changelog.d/19236.feature
+++ b/changelog.d/19236.feature
@@ -1,0 +1,1 @@
+Temporarily reintroduce PostgreSQL 13 support (removed in #19170).

--- a/docker/complement/Dockerfile
+++ b/docker/complement/Dockerfile
@@ -11,7 +11,7 @@ ARG SYNAPSE_VERSION=latest
 ARG FROM=matrixdotorg/synapse-workers:$SYNAPSE_VERSION
 ARG DEBIAN_VERSION=trixie
 
-FROM docker.io/library/postgres:14-${DEBIAN_VERSION} AS postgres_base
+FROM docker.io/library/postgres:13-${DEBIAN_VERSION} AS postgres_base
 
 FROM $FROM
 # First of all, we copy postgres server from the official postgres image,
@@ -26,7 +26,7 @@ RUN adduser --system --uid 999 postgres --home /var/lib/postgresql
 COPY --from=postgres_base /usr/lib/postgresql /usr/lib/postgresql
 COPY --from=postgres_base /usr/share/postgresql /usr/share/postgresql
 COPY --from=postgres_base --chown=postgres /var/run/postgresql /var/run/postgresql
-ENV PATH="${PATH}:/usr/lib/postgresql/14/bin"
+ENV PATH="${PATH}:/usr/lib/postgresql/13/bin"
 ENV PGDATA=/var/lib/postgresql/data
 
 # We also initialize the database at build time, rather than runtime, so that it's faster to spin up the image.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -136,6 +136,15 @@ disabled by default.  If you rely on this unstable endpoint, you must now set
 `experimental_features.msc2666_enabled: true` in your configuration to keep
 using it.
 
+# Upgrading to v1.143.1
+
+## PostgreSQL 13 support
+
+While in line with our [deprecation policy](deprecation_policy.md), we will be
+dropping support for PostgreSQL 13 as it is no longer supported upstream, synapse
+will log a warning when detecting PostgreSQL 13. Fully removing support will be done
+in an upcoming release.
+
 # Upgrading to v1.143.0
 
 ## Dropping support for PostgreSQL 13

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -100,7 +100,9 @@ class PostgresEngine(
 
         # Are we on a supported PostgreSQL version?
         if not allow_outdated_version and self._version < 140000:
-            raise RuntimeError("Synapse requires PostgreSQL 14 or above.")
+            if self._version < 130000:
+                raise RuntimeError("Synapse requires PostgreSQL 13 or above.")
+            logger.warning("Synapse will soon require PostgreSQL 14 or above.")
 
         with db_conn.cursor() as txn:
             txn.execute("SHOW SERVER_ENCODING")


### PR DESCRIPTION
This reverts commit 5d545d16260288154a6e36b410beca9cbdb925d6 and introduces a deprecation warning for PostgreSQL 13.

Would give users some heads-up and unblock upgrading synapse for now.

https://github.com/element-hq/synapse/pull/19170#issuecomment-3587486557

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
