### PR TITLE
Don't include debug logs in `Clock` unless explicitly enabled

### DIFF
--- a/changelog.d/19278.misc
+++ b/changelog.d/19278.misc
@@ -1,1 +1,1 @@
-Turn off log stack traces in `clock.looping_call` and `clock.call_later`.
+Don't include debug logs in `Clock` unless explicitly enabled.

--- a/synapse/util/clock.py
+++ b/synapse/util/clock.py
@@ -46,13 +46,14 @@ clock_debug_logger = logging.getLogger("synapse.util.clock.debug")
 """
 A logger for debugging what is scheduling calls.
 
-Including logs from this logger would be helpful to track when things are being scheduled.
-However, for these logs to be meaningful, they need to include a stack trace to show what
-initiated the call in the first place.
+Ideally, these wouldn't be gated behind an `ExplicitlyConfiguredLogger` as including logs
+from this logger would be helpful to track when things are being scheduled. However, for
+these logs to be meaningful, they need to include a stack trace to show what initiated the
+call in the first place.
 
-Since this can create a lot of noise and make the logs hard to read (unless you're specifically
-debugging scheduling issues) we want users to opt-in to seeing these logs. To enable this,
-they must explicitly set `synapse.util.clock.debug` in the logging configuration. Note that
+Since the stack traces can create a lot of noise and make the logs hard to read (unless you're
+specifically debugging scheduling issues) we want users to opt-in to seeing these logs. To enable
+this, they must explicitly set `synapse.util.clock.debug` in the logging configuration. Note that
 this setting won't inherit the log level from the parent logger.
 """
 # Restore the original logger class


### PR DESCRIPTION
Fixes #19276

This log with stack traces results in a ton of noise in the logs and is confusing to users since it looks like it's an error in the logs.
This PR removes the stack trace from the log. This can be re-enabled on demand if it is deemed necessary in the future.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [X] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
