### PR TITLE
Add state key to invite and knock rooms in sync response for MSC4319

### DIFF
--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -599,3 +599,6 @@ class ExperimentalConfig(Config):
 
         # MSC4380: Invite blocking
         self.msc4380_enabled: bool = experimental.get("msc4380_enabled", False)
+
+        # MSC4319: Room member events for invite and knock rooms in the /sync response
+        self.msc4319_enabled: bool = experimental.get("msc4319_enabled", False)

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -123,6 +123,7 @@ class SyncRestServlet(RestServlet):
         self._event_serializer = hs.get_event_client_serializer()
         self._msc2654_enabled = hs.config.experimental.msc2654_enabled
         self._msc3773_enabled = hs.config.experimental.msc3773_enabled
+        self._msc4319_enabled = hs.config.experimental.msc4319_enabled
 
         self._json_filter_cache: LruCache[str, bool] = LruCache(
             max_size=1000,
@@ -457,7 +458,13 @@ class SyncRestServlet(RestServlet):
 
             invited_state = list(invited_state)
             invited_state.append(invite)
-            invited[room.room_id] = {"invite_state": {"events": invited_state}}
+            invited_room = {"invite_state": {"events": invited_state}}
+
+            if self._msc4319_enabled:
+                # Add the invite event to the `state` dictionary, using an unstable prefix.
+                invited_room["org.matrix.msc4319.state"] = {"events": [invite]}
+
+            invited[room.room_id] = invited_room
 
         return invited
 
@@ -509,7 +516,13 @@ class SyncRestServlet(RestServlet):
 
             # Build the `knock_state` dictionary, which will contain the state of the
             # room that the client has knocked on
-            knocked[room.room_id] = {"knock_state": {"events": knocked_state}}
+            knocked_room = {"knock_state": {"events": knocked_state}}
+
+            if self._msc4319_enabled:
+                # Add the knock event to the `state` dictionary, using an unstable prefix.
+                knocked_room["org.matrix.msc4319.state"] = {"events": [knock]}
+
+            knocked[room.room_id] = knocked_room
 
         return knocked
 


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
