### PR TITLE
Grace period to wait for background updates to finish with `synapse_port_db`

### DIFF
--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -94,6 +94,7 @@ from synapse.storage.databases.state.bg_updates import StateBackgroundUpdateStor
 from synapse.storage.engines import create_engine
 from synapse.storage.prepare_database import prepare_database
 from synapse.types import ISynapseReactor
+from synapse.util.duration import Duration
 
 # Cast safety: Twisted does some naughty magic which replaces the
 # twisted.internet.reactor module with a Reactor instance at runtime.
@@ -232,6 +233,11 @@ IGNORED_BACKGROUND_UPDATES = {
     "mark_unreferenced_state_groups_for_deletion_bg_update",
 }
 
+
+STARTUP_BACKGROUND_UPDATE_GRACE_PERIOD = Duration(seconds=5)
+"""
+The ammount of time we will wait for background updates to complete before giving up.
+"""
 
 # Error returned by the run function. Used at the top-level part of the script to
 # handle errors and return codes.
@@ -762,6 +768,23 @@ class Porter:
                     " VACUUM;"
                 )
                 return
+
+            # Give a grace period of 5 seconds for any background tasks that get added
+            # on startup to resolve themselves (like the ones added by
+            # `_resolve_stale_data_in_sliding_sync_tables`)
+            background_updates_done_check_start_time_seconds = (
+                self.hs.get_clock().time()
+            )
+            while not await self.sqlite_store.db_pool.updates.has_completed_background_updates():
+                if (
+                    self.hs.get_clock().time()
+                    - background_updates_done_check_start_time_seconds
+                    > STARTUP_BACKGROUND_UPDATE_GRACE_PERIOD.as_secs()
+                ):
+                    break
+
+                # Sleep to give a chance for the reactor to do other work
+                await self.hs.get_clock().sleep(Duration(seconds=1))
 
             # Check if all background updates are done, abort if not.
             updates_complete = await self.sqlite_store.db_pool.updates.has_completed_background_updates()


### PR DESCRIPTION
Grace period to wait for background updates to finish with `synapse_port_db`

~~Fix https://github.com/element-hq/synapse/issues/19298~~


### Testing strategy

 1. Start a Synapse homeserver using SQLite, `poetry run synapse_homeserver --config-path ~/Downloads/synapse-port-db-testing-sqlite-homeserver.yml`
    ```yaml
    # Configuration file used for testing the 'synapse_port_db' script.
    server_name: "localhost:8800"
    
    signing_key_path: /home/eric/Downloads/synapse-port-db-testing.signing.key
    
    report_stats: false
    
    database:
       name: sqlite3
       args:
         database: /home/eric/Downloads/synapse-port-db-sqlite3-homeserver.db
    
    listeners:
      - port: 8008
        bind_addresses: [
          #'::1',
          # '127.0.0.1'
          # '::',
          '0.0.0.0'
        ]
        tls: false
        type: http
        x_forwarded: true
        resources:
          - names: [client, federation, metrics]
            compress: false
    
    # Suppress the key server warning.
    trusted_key_servers: []
    
    registration_shared_secret: "4QgpBDjWiUL5mOVqzWmzNshtM8NJQE"
    ```
 1. Wait for the background updates to finish (until you see `No more background updates to do. Unscheduling background update task.` in the logs)
 1. To add some data
    1. Register a new user: `poetry run register_new_matrix_user --config ~/Downloads/synapse-port-db-testing-sqlite-homeserver.yml --user admin1 --password adminpassword1 --admin`
    1. Get a personal access token:
        ```
        curl --header "Content-Type: application/json" \
          --request POST \
          --data '{ "identifier": { "type": "m.id.user", "user": "admin1" }, "password": "adminpassword1", "type": "m.login.password", "initial_device_display_name": "Jungle Phone" }' \
          http://localhost:8008/_matrix/client/v3/login
        ```
    1. Create a room:
        ```
        curl --header "Content-Type: application/json" \
          --header "Authorization: Bearer xxx" \
          --request POST \
          --data '{ "name": "test" }' \
          http://localhost:8008/_matrix/client/v3/createRoom
        ```
 1. Create an empty Postgres database: `createdb --username=postgres --encoding=UTF8 --locale=C --template=template0 --owner=postgres synapse-testing` ([per the docs](https://github.com/element-hq/synapse/blob/develop/docs/postgres.md#set-up-database))
 1. Minimal `homeserver.yaml`: `~/Downloads/synapse-port-db-testing-postgres-homeserver.yml`
     ```yaml
    # Configuration file used for testing the 'synapse_port_db' script.
    server_name: "localhost:8800"
    
    signing_key_path: /home/eric/Downloads/synapse-port-db-testing.signing.key
    
    report_stats: false
    
    database:
      name: "psycopg2"
      args:
        user: postgres
        # If we use `localhost`, `psycopg2` will try to connect to `127.0.0.1` (IPv4) AND
        # fallback to `::1` (IPv6) when the database isn't available. Trying to connect to
        # IPv6 on my system with IPv6 disabled, causes massive timeout delays and the Python
        # process is unresponsive during this time. See
        # https://github.com/element-hq/synapse/issues/19115
        #
        # host: localhost
        host: 127.0.0.1
        sslmode: disable
        database: synapse-testing
    
    listeners:
      - port: 8008
        bind_addresses: [
          #'::1',
          # '127.0.0.1'
          # '::',
          '0.0.0.0'
        ]
        tls: false
        type: http
        x_forwarded: true
        resources:
          - names: [client, federation, metrics]
            compress: false
    
    # Suppress the key server warning.
    trusted_key_servers: []
    
    registration_shared_secret: "4QgpBDjWiUL5mOVqzWmzNshtM8NJQE"
    ```
 1. `poetry run synapse_port_db --sqlite-database ~/Downloads/synapse-port-db-sqlite3-homeserver.db --postgres-config ~/Downloads/synapse-port-db-testing-postgres-homeserver.yml`
 1. To delete the Postgres database and start over: `dropdb --username=postgres synapse-testing`


### Dev notes


```
sqlite3 /home/eric/Downloads/synapse-port-db-sqlite3-homeserver.db
```

```
SELECT * FROM background_updates;
```
 
 ```
 SELECT * FROM sliding_sync_joined_rooms;
 ```


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
