### PR TITLE
Add support for boolean values in SSO attribute requirements

### DIFF
--- a/changelog.d/19388.feature
+++ b/changelog.d/19388.feature
@@ -1,0 +1,1 @@
+Add support for boolean values in SSO attribute requirements.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3459,9 +3459,9 @@ This setting has the following sub-options:
 
   * `attribute` (string): SAML attribute for which to allow logins.
 
-  * `value` (string): Value the SAML attribute must match.
+  * `value` (boolean|string): Value the SAML attribute must match.
 
-  * `one_of` (array): List of values the SAML attribute must all match.
+  * `one_of` (array): List of values, one of which the claim must match
 
 * `idp_entityid` (string|null): If the metadata XML contains multiple IdP entities then the `idp_entityid` option must be set to the entity to redirect users to. Most deployments only have a single IdP entity and so should omit this option. Defaults to `null`.
 
@@ -3677,6 +3677,16 @@ Options for each entry include:
     * `email_template`: Jinja2 template for the email address of the user. If unset, no email address will be added to the account.
 
     * `extra_attributes`: a map of Jinja2 templates for extra attributes to send back to the client during login. Note that these are non-standard and clients will ignore them without modifications.
+
+* `attribute_requirements` (array): It is possible to configure Synapse to only allow logins if OIDC claims match particular values. The requirements can be listed under `attribute_requirements` as shown in the example. All of the listed attributes must match for the login to be permitted. Values can be specified in a `one_of` list to allow multiple values for a claim.
+
+  Options for each entry include:
+
+  * `attribute` (string): OIDC claim for which to allow logins.
+
+  * `value` (boolean|string): Value the claim must match.
+
+  * `one_of` (array): List of values, one of which the claim must match
 
 * `backchannel_logout_enabled` (boolean): Set to `true` to process OIDC Back-Channel Logout notifications. Those notifications are expected to be received on `/_synapse/client/oidc/backchannel_logout`. Defaults to `false`.
 

--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -3986,13 +3986,13 @@ properties:
               type: string
               description: SAML attribute for which to allow logins.
             value:
-              type: string
+              type: ["boolean", "string"]
               description: Value the SAML attribute must match.
             one_of:
               type: array
-              description: List of values the SAML attribute must all match.
+              description: List of values, one of which the claim must match
               items:
-                type: string
+                type: ["boolean", "string"]
           required:
             - attribute
       idp_entityid:
@@ -4424,6 +4424,31 @@ properties:
                 attributes to send back to the client during login. Note that
                 these are non-standard and clients will ignore them without
                 modifications.
+        attribute_requirements:
+          type: array
+          description: >-
+            It is possible to configure Synapse to only allow logins if OIDC
+            claims match particular values. The requirements can be listed under
+            `attribute_requirements` as shown in the example. All of the listed
+            attributes must match for the login to be permitted. Values can be
+            specified in a `one_of` list to allow multiple values for a claim.
+          items:
+            type: object
+            description: Item allowing a specific OIDC claim
+            properties:
+              attribute:
+                type: string
+                description: OIDC claim for which to allow logins.
+              value:
+                type: ["boolean", "string"]
+                description: Value the claim must match.
+              one_of:
+                type: array
+                description: List of values, one of which the claim must match
+                items:
+                  type: ["boolean", "string"]
+            required:
+              - attribute
         backchannel_logout_enabled:
           type: boolean
           description: >-

--- a/synapse/config/sso.py
+++ b/synapse/config/sso.py
@@ -44,15 +44,18 @@ class SsoAttributeRequirement:
 
     attribute: str
     # If neither `value` nor `one_of` is given, the attribute must simply exist.
-    value: str | None = None
-    one_of: list[str] | None = None
+    value: str | bool | None = None
+    one_of: list[str | bool] | None = None
 
     JSON_SCHEMA = {
         "type": "object",
         "properties": {
             "attribute": {"type": "string"},
-            "value": {"type": "string"},
-            "one_of": {"type": "array", "items": {"type": "string"}},
+            "value": {"oneOf": [{"type": "string"}, {"type": "boolean"}]},
+            "one_of": {
+                "type": "array",
+                "items": {"oneOf": [{"type": "string"}, {"type": "boolean"}]},
+            },
         },
         "required": ["attribute"],
     }

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -1417,6 +1417,66 @@ class OidcHandlerTestCase(HomeserverTestCase):
         {
             "oidc_config": {
                 **DEFAULT_CONFIG,
+                "attribute_requirements": [{"attribute": "verified", "value": True}],
+            }
+        }
+    )
+    def test_attribute_requirements_boolean(self) -> None:
+        """The required boolean attributes must be met from the OIDC userinfo response."""
+        # userinfo with incorrect `verified` value should fail (according to
+        # `attribute_requirements`)
+        userinfo = {
+            "sub": "tester",
+            "username": "tester",
+            "verified": False,
+        }
+        request, _ = self.start_authorization(userinfo)
+        self.get_success(self.handler.handle_oidc_callback(request))
+        self.complete_sso_login.assert_not_called()
+
+        # userinfo with missing "verified" attribute should fail.
+        userinfo = {
+            "sub": "tester",
+            "username": "tester",
+        }
+        request, _ = self.start_authorization(userinfo)
+        self.get_success(self.handler.handle_oidc_callback(request))
+        self.complete_sso_login.assert_not_called()
+
+        # userinfo with string attribute should fail.
+        userinfo = {
+            "sub": "tester",
+            "username": "tester",
+            "verified": "true",
+        }
+        request, _ = self.start_authorization(userinfo)
+        self.get_success(self.handler.handle_oidc_callback(request))
+        self.complete_sso_login.assert_not_called()
+
+        # userinfo with "verified": true attribute should succeed.
+        userinfo = {
+            "sub": "tester",
+            "username": "tester",
+            "verified": True,
+        }
+        request, _ = self.start_authorization(userinfo)
+        self.get_success(self.handler.handle_oidc_callback(request))
+
+        # check that the auth handler got called as expected
+        self.complete_sso_login.assert_called_once_with(
+            "@tester:test",
+            self.provider.idp_id,
+            request,
+            ANY,
+            None,
+            new_user=True,
+            auth_provider_session_id=None,
+        )
+
+    @override_config(
+        {
+            "oidc_config": {
+                **DEFAULT_CONFIG,
                 "attribute_requirements": [{"attribute": "test", "value": "foobar"}],
             }
         }


### PR DESCRIPTION
Add support for boolean values in SSO attribute requirements.
This makes it possible to check, in example, if a `mail_verified` or `verified` attribute is true, to only allow verified users to sign in.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
