### PR TITLE
Allow configuring the Rust HTTP client to use HTTP/2 only

### DIFF
--- a/changelog.d/19457.misc
+++ b/changelog.d/19457.misc
@@ -1,0 +1,1 @@
+Allow configuring the Rust HTTP client to use HTTP/2 only.

--- a/rust/src/http_client.rs
+++ b/rust/src/http_client.rs
@@ -171,15 +171,27 @@ struct HttpClient {
 #[pymethods]
 impl HttpClient {
     #[new]
-    pub fn py_new(reactor: Bound<PyAny>, user_agent: &str) -> PyResult<HttpClient> {
+    #[pyo3(signature = (reactor, user_agent, http2_only = false))]
+    pub fn py_new(
+        reactor: Bound<PyAny>,
+        user_agent: &str,
+        http2_only: bool,
+    ) -> PyResult<HttpClient> {
         // Make sure the runtime gets installed
         let _ = runtime(&reactor)?;
 
+        let mut builder = reqwest::Client::builder().user_agent(user_agent);
+
+        if http2_only {
+            // Create the client with 'HTTP/2 prior knowledge' enabled, which
+            // means it will always use HTTP/2 for unencrypted connections
+            builder = builder.http2_prior_knowledge();
+        }
+
+        let client = builder.build().context("building reqwest client")?;
+
         Ok(HttpClient {
-            client: reqwest::Client::builder()
-                .user_agent(user_agent)
-                .build()
-                .context("building reqwest client")?,
+            client,
             reactor: reactor.unbind(),
         })
     }

--- a/synapse/synapse_rust/http_client.pyi
+++ b/synapse/synapse_rust/http_client.pyi
@@ -21,7 +21,25 @@ class HttpClient:
     The returned deferreds follow Synapse logcontext rules.
     """
 
-    def __init__(self, reactor: ISynapseReactor, user_agent: str) -> None: ...
+    def __init__(
+        self,
+        reactor: ISynapseReactor,
+        user_agent: str,
+        http2_only: bool = False,
+    ) -> None:
+        """
+        Create a new HTTP client backed by reqwest.
+
+        Args:
+            reactor: The Twisted reactor to coordinate with
+            user_agent: The user agent to use for requests
+            http2_only: Whether to use HTTP/2 only, even on unencrypted connections. By
+                default, it will always use HTTP/1.1 over unencrypted connections, and
+                rely on TLS ALPN to negotiate HTTP/2.
+
+                Ensure the upstream server supports HTTP/2 before enabling this.
+        """
+
     def get(self, url: str, response_limit: int) -> Deferred[bytes]: ...
     def post(
         self,


### PR DESCRIPTION
This allows the Rust HTTP client to be configured to force HTTP/2 even on plaintext connections. This is useful in contexts where the remote server is known to server HTTP/2 over plain text.

Added because we use the Synapse Rust HTTP client with the Synapse Pro `event-cache` module. We use this because it's independent from the Python reactor which makes things slower than expected.

Currently, the Synapse Rust HTTP client uses HTTP/1 which means a new connection for every request. With HTTP/2, we can share the connection across requests.

We want to see if this will make a performance difference and less stress on the database connection situation, see https://github.com/element-hq/synapse-rust-apps/issues/452#issuecomment-3897717599

Here is the sibling PR for using HTTP/2 on the Synapse Pro `event-cache` module side: https://github.com/element-hq/synapse-pro-modules/pull/35