### PR TITLE
Revert "Fix `/sync` missing membership in `state_after`"

### DIFF
--- a/changelog.d/19463.bugfix
+++ b/changelog.d/19463.bugfix
@@ -1,1 +1,0 @@
-Fix `/sync` missing membership event in `state_after` (experimental [MSC4222](https://github.com/matrix-org/matrix-spec-proposals/pull/4222) implementation) in some scenarios.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1041,18 +1041,9 @@ class SyncHandler:
                     if event.sender not in first_event_by_sender_map:
                         first_event_by_sender_map[event.sender] = event
 
-                    # When using `state_after`, there is no special treatment with
-                    # regards to state also being in the `timeline`. Always fetch
-                    # relevant membership regardless of whether the state event is in
-                    # the `timeline`.
-                    if sync_config.use_state_after:
-                        members_to_fetch.add(event.sender)
-                    # For `state`, the client is supposed to do a flawed re-construction
-                    # of state over time by starting with the given `state` and layering
-                    # on state from the `timeline` as you go (flawed because state
-                    # resolution). In this case, we only need their membership in
-                    # `state` when their membership isn't already in the `timeline`.
-                    elif (EventTypes.Member, event.sender) not in timeline_state:
+                    # We need the event's sender, unless their membership was in a
+                    # previous timeline event.
+                    if (EventTypes.Member, event.sender) not in timeline_state:
                         members_to_fetch.add(event.sender)
                     # FIXME: we also care about invite targets etc.
 


### PR DESCRIPTION
Reverts element-hq/synapse#19463

The complement tests haven't been reviewed and require more testing. Discussed in the internal [backend team lobby](https://matrix.to/#/!SGNQGPGUwtcPBUotTL:matrix.org/$XDARK2u2iLL5wWaxiL6tJYkLg80Sn6yWWEQib8ahl5Q?via=jki.re&via=element.io&via=matrix.org) room.