### PR TITLE
Remove requirement on transitive dep, and require jsonschema>=4.26.0 for Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,12 @@ classifiers = [
 
 # Mandatory Dependencies
 dependencies = [
-    # we use the TYPE_CHECKER.redefine method added in jsonschema 3.0.0
-    "jsonschema>=3.0.0",
-    # 0.25.0 is the first version to support Python 3.14.
-    # We can remove this once https://github.com/python-jsonschema/jsonschema/issues/1426 is fixed
-    # and included in a release.
-    "rpds-py>=0.25.0",
+    # jsonschema==4.26.0 was the first version to require rpds-py>=0.25.0, which
+    # is the first version of rpds-py to support Python 3.14.
+    #
+    # Otherwise, we use the TYPE_CHECKER.redefine method added in jsonschema 3.0.0
+    "jsonschema>=4.26.0;python_version >= '3.14'",
+    "jsonschema>=3.0.0;python_version < '3.14'",
     # We choose 2.0 as a lower bound: the most recent backwards incompatible release.
     # It seems generally available, judging by https://pkgs.org/search/?q=immutabledict
     "immutabledict>=2.0",


### PR DESCRIPTION
Removes the transitive dependency bounds on `rpds-py` by introducing a bound on `jsonschema` instead.

Unfortunately, I don't think most distros actually have `jsonschema>=4.26.0`. So the transitive dependency may be preferable after all?

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
