### PR TITLE
docs: fix redaction status typo 'completed' -> 'complete'

### DIFF
--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -1593,7 +1593,7 @@ The following parameters should be set in the URL:
 
 The following fields are returned in the JSON response body:
 
-- `status` - string - one of scheduled/active/completed/failed, indicating the status of the redaction job
+- `status` - string - one of scheduled/active/complete/failed, indicating the status of the redaction job
 - `failed_redactions` - dictionary - the keys of the dict are event ids the process was unable to redact, if any, and the values are 
   the corresponding error that caused the redaction to fail
 


### PR DESCRIPTION
## Summary

Fixes a documentation typo in the user redaction endpoint documentation.

The docs listed `completed` as a valid status value for the redaction job status, but the actual enum `RedactionStatus` in `synapse/types/__init__.py` (line 1554) defines the value as `complete` (without the 'd').

## Changes

- `docs/admin_api/user_admin_api.md`: Changed `completed` to `complete` in the status field description

Fixes #18338

Signed-off-by: roberthallers <roberthallers@users.noreply.github.com>