### PR TITLE
docs: fix redaction status typo 'completed' -> 'complete'

### DIFF
--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -1594,7 +1594,7 @@ The following parameters should be set in the URL:
 
 The following fields are returned in the JSON response body:
 
-- `status` - string - one of scheduled/active/completed/failed, indicating the status of the redaction job
+- `status` - string - one of scheduled/active/complete/failed, indicating the status of the redaction job
 - `failed_redactions` - dictionary - the keys of the dict are event ids the process was unable to redact, if any, and the values are 
   the corresponding error that caused the redaction to fail
 


### PR DESCRIPTION
The `TaskStatus` enum in `synapse/types/__init__.py` defines the value as `"complete"`, but the user admin API documentation listed `"completed"` as one of the valid status values for the redaction job endpoint.

This aligns the docs with the actual enum.

Fixes #18338