### PR TITLE
Propagate the logging and tracing contexts in database queries

### DIFF
--- a/changelog.d/19605.misc
+++ b/changelog.d/19605.misc
@@ -1,0 +1,1 @@
+Propagate the logging and tracing contexts in database queries.

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -850,6 +850,30 @@ def get_active_span_text_map(destination: str | None = None) -> dict[str, str]:
     return carrier
 
 
+@ensure_active_span("get the active span's traceparent", ret=None)
+def get_active_span_traceparent() -> str | None:
+    """
+    Get the W3C Trace Context traceparent string for the currently active span.
+
+    Returns the traceparent in the format ``00-<trace_id>-<span_id>-<flags>``
+    if there is an active Jaeger span, or None otherwise.
+
+    See https://www.w3.org/TR/trace-context/#traceparent-header-field-values
+    """
+    # Jaeger spans expose trace_id, span_id, and flags as int attributes.
+    # Other OpenTracing implementations may not have these.
+    assert opentracing.tracer.active_span is not None
+    ctx = opentracing.tracer.active_span.context
+    trace_id = getattr(ctx, "trace_id", None)
+    span_id = getattr(ctx, "span_id", None)
+    flags = getattr(ctx, "flags", 0)
+
+    if trace_id is None or span_id is None:
+        return None
+
+    return f"00-{trace_id:032x}-{span_id:016x}-{flags:02x}"
+
+
 @ensure_active_span("get the span context as a string.", ret={})
 def active_span_context_as_string() -> str:
     """

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, Mapping, NoReturn, cast
 
 import psycopg2.extensions
 
+from synapse.logging import opentracing
 from synapse.storage.engines._base import (
     AUTO_INCREMENT_PRIMARY_KEYPLACEHOLDER,
     BaseDatabaseEngine,
@@ -38,6 +39,44 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+class _SqlCommenterCursor(psycopg2.extensions.cursor):
+    """A psycopg2 cursor that appends W3C trace context to SQL statements
+    as SQLCommenter comments when OpenTracing is active.
+
+    This propagates the active span's trace context to PostgreSQL, enabling
+    database-side tracing tools to correlate server-side spans with
+    application-level traces.
+
+    See:
+        - https://google.github.io/sqlcommenter/spec/
+        - https://opentelemetry.io/docs/specs/semconv/db/database-spans/#context-propagation
+    """
+
+    def execute(  # type: ignore[override]
+        self,
+        query: str | bytes,
+        vars: Any = None,  # noqa: A002
+    ) -> None:
+        # The traceparent is only added when a trace is actively being
+        # sampled, so untraced queries are not affected.
+        if isinstance(query, str):
+            traceparent = opentracing.get_active_span_traceparent()
+            if traceparent is not None:
+                query = f"{query} /*traceparent='{traceparent}'*/"
+        return super().execute(query, vars)
+
+    def executemany(  # type: ignore[override]
+        self,
+        query: str | bytes,
+        vars_list: Any,  # noqa: A002
+    ) -> None:
+        if isinstance(query, str):
+            traceparent = opentracing.get_active_span_traceparent()
+            if traceparent is not None:
+                query = f"{query} /*traceparent='{traceparent}'*/"
+        return super().executemany(query, vars_list)
 
 
 class PostgresEngine(
@@ -172,6 +211,10 @@ class PostgresEngine(
 
     def on_new_connection(self, db_conn: "LoggingDatabaseConnection") -> None:
         db_conn.set_isolation_level(self.default_isolation_level)
+
+        # Use a cursor factory that appends W3C trace context to queries
+        # as SQLCommenter comments, propagating spans to the database.
+        db_conn.conn.cursor_factory = _SqlCommenterCursor  # type: ignore[attr-defined]
 
         # Set the bytea output to escape, vs the default of hex
         cursor = db_conn.cursor()

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -21,10 +21,12 @@
 
 import logging
 from typing import TYPE_CHECKING, Any, Mapping, NoReturn, cast
+from urllib.parse import quote
 
 import psycopg2.extensions
 
 from synapse.logging import opentracing
+from synapse.logging.context import current_context
 from synapse.storage.engines._base import (
     AUTO_INCREMENT_PRIMARY_KEYPLACEHOLDER,
     BaseDatabaseEngine,
@@ -41,17 +43,38 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class _SqlCommenterCursor(psycopg2.extensions.cursor):
-    """A psycopg2 cursor that appends W3C trace context to SQL statements
-    as SQLCommenter comments when OpenTracing is active.
+def _build_sqlcommenter_comment() -> str:
+    """Build a SQLCommenter comment with the logging context and trace context.
 
-    This propagates the active span's trace context to PostgreSQL, enabling
-    database-side tracing tools to correlate server-side spans with
-    application-level traces.
+    Returns a ``/*...*/`` comment string to append to a SQL query. The
+    ``traceparent`` field is only included when a trace is actively being
+    sampled; the ``log_context`` field is always included.
 
     See:
         - https://google.github.io/sqlcommenter/spec/
         - https://opentelemetry.io/docs/specs/semconv/db/database-spans/#context-propagation
+    """
+    # Per the SQLCommenter spec, keys are sorted and values are URL-encoded
+    # then wrapped in single quotes.
+    pairs: dict[str, str] = {
+        "log_context": str(current_context()),
+    }
+
+    traceparent = opentracing.get_active_span_traceparent()
+    if traceparent is not None:
+        pairs["traceparent"] = traceparent
+
+    comment = ",".join(f"{k}='{quote(v)}'" for k, v in sorted(pairs.items()))
+    return f" /*{comment}*/"
+
+
+class _SqlCommenterCursor(psycopg2.extensions.cursor):
+    """A psycopg2 cursor that appends the logging context and W3C trace context
+    to SQL statements as SQLCommenter comments.
+
+    This propagates the active span's trace context to PostgreSQL, enabling
+    database-side tracing tools to correlate server-side spans with
+    application-level traces.
     """
 
     def execute(  # type: ignore[override]
@@ -59,12 +82,8 @@ class _SqlCommenterCursor(psycopg2.extensions.cursor):
         query: str | bytes,
         vars: Any = None,  # noqa: A002
     ) -> None:
-        # The traceparent is only added when a trace is actively being
-        # sampled, so untraced queries are not affected.
         if isinstance(query, str):
-            traceparent = opentracing.get_active_span_traceparent()
-            if traceparent is not None:
-                query = f"{query} /*traceparent='{traceparent}'*/"
+            query = f"{query}{_build_sqlcommenter_comment()}"
         return super().execute(query, vars)
 
     def executemany(  # type: ignore[override]
@@ -73,9 +92,7 @@ class _SqlCommenterCursor(psycopg2.extensions.cursor):
         vars_list: Any,  # noqa: A002
     ) -> None:
         if isinstance(query, str):
-            traceparent = opentracing.get_active_span_traceparent()
-            if traceparent is not None:
-                query = f"{query} /*traceparent='{traceparent}'*/"
+            query = f"{query}{_build_sqlcommenter_comment()}"
         return super().executemany(query, vars_list)
 
 


### PR DESCRIPTION
This adds the trace context and log context name to database statements as comments.
This follows the [SQLCommenter spec](https://google.github.io/sqlcommenter/spec/), which can be consumed by tools like the [`pg_tracing` extension](https://github.com/DataDog/pg_tracing).

This will be useful to correlate Postgres statement logs or statements in `pg_stat_activity` to traces and application logs.

Note that the trace context is added *only* if the trace is active and sampled; so, if you see a trace context in a statement, you can look up in the trace in Jaeger! The log context on the other hand is always added.

Spawning from a [discussion](https://docs.google.com/document/d/15h4901gAzGMAol2n1b71OAcesVMNhgQbPNb55xouluw/edit?tab=t.0#bookmark=id.h4rpevbub4hx) on 2026-03-25 around performance on `matrix.org` and having end-to-end traces.