### PR TITLE
Reorder rooms by read receipts to update most important rooms first

### DIFF
--- a/changelog.d/19613.feature
+++ b/changelog.d/19613.feature
@@ -1,0 +1,1 @@
+Reorder rooms by read receipts to update most important rooms first.

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -20,7 +20,6 @@
 #
 import logging
 import random
-from bisect import bisect_right
 from typing import TYPE_CHECKING
 
 from twisted.internet.defer import CancelledError
@@ -671,6 +670,27 @@ class ProfileHandler:
 
         target_user_str = target_user.to_string()
 
+        # Compute the ordered list of rooms upfront to ensure consistency across restarts
+        all_room_ids = await self.store.get_rooms_for_user(target_user_str)
+
+        # Get the user's latest read receipts for all rooms
+        user_receipts = await self.store.get_receipts_for_user_with_orderings(
+            target_user_str,
+            [ReceiptTypes.READ, ReceiptTypes.READ_PRIVATE],
+        )
+
+        # Sort rooms by most recent read receipt (highest stream_ordering first),
+        # with fallback to alphabetical ordering for rooms without receipts
+        def sort_key(room_id: str) -> tuple[int, str]:
+            if room_id in user_receipts:
+                # Rooms with receipts: sort by stream_ordering (descending) then by room_id
+                return (-user_receipts[room_id]["stream_ordering"], room_id)
+            else:
+                # Rooms without receipts: sort alphabetically after all rooms with receipts
+                return (0, room_id)
+
+        room_ids = sorted(all_room_ids, key=sort_key)
+
         # Cancel any ongoing profile membership updates for this user,
         # and start a new one.
         async with self._worker_locks.acquire_lock(
@@ -691,6 +711,7 @@ class ProfileHandler:
                 resource_id=target_user_str,
                 params={
                     "requester_authenticated_entity": requester.authenticated_entity,
+                    "ordered_room_ids": room_ids,
                 },
             )
 
@@ -702,33 +723,16 @@ class ProfileHandler:
         assert task.params
 
         target_user = UserID.from_string(task.resource_id)
-        all_room_ids = await self.store.get_rooms_for_user(target_user.to_string())
 
-        # Get the user's latest read receipts for all rooms
-        user_receipts = await self.store.get_receipts_for_user_with_orderings(
-            target_user.to_string(),
-            [ReceiptTypes.READ, ReceiptTypes.READ_PRIVATE],
-        )
-
-        # Sort rooms by most recent read receipt (highest stream_ordering first),
-        # with fallback to alphabetical ordering for rooms without receipts
-        def sort_key(room_id: str) -> tuple[int, str]:
-            if room_id in user_receipts:
-                # Rooms with receipts: sort by stream_ordering (descending) then by room_id
-                return (-user_receipts[room_id]["stream_ordering"], room_id)
-            else:
-                # Rooms without receipts: sort alphabetically after all rooms with receipts
-                return (0, room_id)
-
-        room_ids = sorted(all_room_ids, key=sort_key)
+        # Use the precomputed room ordering from task params to ensure consistency
+        room_ids = task.params.get("ordered_room_ids", [])
 
         last_room_id = task.result.get("last_room_id", None) if task.result else None
 
         if last_room_id:
             # Filter out room IDs that have already been handled
-            # by finding the first room ID greater than the last handled room ID
-            # and slicing the list from that point onwards.
-            room_ids = room_ids[bisect_right(room_ids, last_room_id) :]
+            last_index = room_ids.index(last_room_id, 0)
+            room_ids = room_ids[last_index + 1 :]
 
         requester = create_requester(
             user_id=target_user,

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 
 from twisted.internet.defer import CancelledError
 
-from synapse.api.constants import ProfileFields
+from synapse.api.constants import ProfileFields, ReceiptTypes
 from synapse.api.errors import (
     AuthError,
     Codes,
@@ -702,7 +702,25 @@ class ProfileHandler:
         assert task.params
 
         target_user = UserID.from_string(task.resource_id)
-        room_ids = sorted(await self.store.get_rooms_for_user(target_user.to_string()))
+        all_room_ids = await self.store.get_rooms_for_user(target_user.to_string())
+
+        # Get the user's latest read receipts for all rooms
+        user_receipts = await self.store.get_receipts_for_user_with_orderings(
+            target_user.to_string(),
+            [ReceiptTypes.READ, ReceiptTypes.READ_PRIVATE],
+        )
+
+        # Sort rooms by most recent read receipt (highest stream_ordering first),
+        # with fallback to alphabetical ordering for rooms without receipts
+        def sort_key(room_id: str) -> tuple[int, str]:
+            if room_id in user_receipts:
+                # Rooms with receipts: sort by stream_ordering (descending) then by room_id
+                return (-user_receipts[room_id]["stream_ordering"], room_id)
+            else:
+                # Rooms without receipts: sort alphabetically after all rooms with receipts
+                return (0, room_id)
+
+        room_ids = sorted(all_room_ids, key=sort_key)
 
         last_room_id = task.result.get("last_room_id", None) if task.result else None
 

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -20,7 +20,6 @@
 #
 import logging
 import random
-from bisect import bisect_right
 from typing import TYPE_CHECKING
 
 from twisted.internet.defer import CancelledError
@@ -875,6 +874,27 @@ class ProfileHandler:
 
         target_user_str = target_user.to_string()
 
+        # Compute the ordered list of rooms upfront to ensure consistency across restarts
+        all_room_ids = await self.store.get_rooms_for_user(target_user_str)
+
+        # Get the user's latest read receipts for all rooms
+        user_receipts = await self.store.get_receipts_for_user_with_orderings(
+            target_user_str,
+            [ReceiptTypes.READ, ReceiptTypes.READ_PRIVATE],
+        )
+
+        # Sort rooms by most recent read receipt (highest stream_ordering first),
+        # with fallback to alphabetical ordering for rooms without receipts
+        def sort_key(room_id: str) -> tuple[int, str]:
+            if room_id in user_receipts:
+                # Rooms with receipts: sort by stream_ordering (descending) then by room_id
+                return (-user_receipts[room_id]["stream_ordering"], room_id)
+            else:
+                # Rooms without receipts: sort alphabetically after all rooms with receipts
+                return (0, room_id)
+
+        room_ids = sorted(all_room_ids, key=sort_key)
+
         # Cancel any ongoing profile membership updates for this user,
         # and start a new one.
         async with self._worker_locks.acquire_lock(
@@ -895,6 +915,7 @@ class ProfileHandler:
                 resource_id=target_user_str,
                 params={
                     "requester_authenticated_entity": requester.authenticated_entity,
+                    "ordered_room_ids": room_ids,
                 },
             )
 
@@ -906,33 +927,16 @@ class ProfileHandler:
         assert task.params
 
         target_user = UserID.from_string(task.resource_id)
-        all_room_ids = await self.store.get_rooms_for_user(target_user.to_string())
 
-        # Get the user's latest read receipts for all rooms
-        user_receipts = await self.store.get_receipts_for_user_with_orderings(
-            target_user.to_string(),
-            [ReceiptTypes.READ, ReceiptTypes.READ_PRIVATE],
-        )
-
-        # Sort rooms by most recent read receipt (highest stream_ordering first),
-        # with fallback to alphabetical ordering for rooms without receipts
-        def sort_key(room_id: str) -> tuple[int, str]:
-            if room_id in user_receipts:
-                # Rooms with receipts: sort by stream_ordering (descending) then by room_id
-                return (-user_receipts[room_id]["stream_ordering"], room_id)
-            else:
-                # Rooms without receipts: sort alphabetically after all rooms with receipts
-                return (0, room_id)
-
-        room_ids = sorted(all_room_ids, key=sort_key)
+        # Use the precomputed room ordering from task params to ensure consistency
+        room_ids = task.params.get("ordered_room_ids", [])
 
         last_room_id = task.result.get("last_room_id", None) if task.result else None
 
         if last_room_id:
             # Filter out room IDs that have already been handled
-            # by finding the first room ID greater than the last handled room ID
-            # and slicing the list from that point onwards.
-            room_ids = room_ids[bisect_right(room_ids, last_room_id) :]
+            last_index = room_ids.index(last_room_id, 0)
+            room_ids = room_ids[last_index + 1 :]
 
         requester = create_requester(
             user_id=target_user,

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 
 from twisted.internet.defer import CancelledError
 
-from synapse.api.constants import ProfileFields
+from synapse.api.constants import ProfileFields, ReceiptTypes
 from synapse.api.errors import (
     AuthError,
     Codes,
@@ -906,7 +906,25 @@ class ProfileHandler:
         assert task.params
 
         target_user = UserID.from_string(task.resource_id)
-        room_ids = sorted(await self.store.get_rooms_for_user(target_user.to_string()))
+        all_room_ids = await self.store.get_rooms_for_user(target_user.to_string())
+
+        # Get the user's latest read receipts for all rooms
+        user_receipts = await self.store.get_receipts_for_user_with_orderings(
+            target_user.to_string(),
+            [ReceiptTypes.READ, ReceiptTypes.READ_PRIVATE],
+        )
+
+        # Sort rooms by most recent read receipt (highest stream_ordering first),
+        # with fallback to alphabetical ordering for rooms without receipts
+        def sort_key(room_id: str) -> tuple[int, str]:
+            if room_id in user_receipts:
+                # Rooms with receipts: sort by stream_ordering (descending) then by room_id
+                return (-user_receipts[room_id]["stream_ordering"], room_id)
+            else:
+                # Rooms without receipts: sort alphabetically after all rooms with receipts
+                return (0, room_id)
+
+        room_ids = sorted(all_room_ids, key=sort_key)
 
         last_room_id = task.result.get("last_room_id", None) if task.result else None
 

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 
 from twisted.internet.defer import CancelledError
 
-from synapse.api.constants import ProfileFields
+from synapse.api.constants import ProfileFields, ReceiptTypes
 from synapse.api.errors import (
     AuthError,
     Codes,
@@ -724,7 +724,25 @@ class ProfileHandler:
         assert task.params
 
         target_user = UserID.from_string(task.resource_id)
-        room_ids = sorted(await self.store.get_rooms_for_user(target_user.to_string()))
+        all_room_ids = await self.store.get_rooms_for_user(target_user.to_string())
+
+        # Get the user's latest read receipts for all rooms
+        user_receipts = await self.store.get_receipts_for_user_with_orderings(
+            target_user.to_string(),
+            [ReceiptTypes.READ, ReceiptTypes.READ_PRIVATE],
+        )
+
+        # Sort rooms by most recent read receipt (highest stream_ordering first),
+        # with fallback to alphabetical ordering for rooms without receipts
+        def sort_key(room_id: str) -> tuple[int, str]:
+            if room_id in user_receipts:
+                # Rooms with receipts: sort by stream_ordering (descending) then by room_id
+                return (-user_receipts[room_id]["stream_ordering"], room_id)
+            else:
+                # Rooms without receipts: sort alphabetically after all rooms with receipts
+                return (0, room_id)
+
+        room_ids = sorted(all_room_ids, key=sort_key)
 
         last_room_id = task.result.get("last_room_id", None) if task.result else None
 

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -26,7 +26,7 @@ from parameterized import parameterized
 from twisted.internet.testing import MemoryReactor
 
 import synapse.types
-from synapse.api.constants import EventTypes
+from synapse.api.constants import EventTypes, ReceiptTypes
 from synapse.api.errors import AuthError, SynapseError
 from synapse.rest import admin
 from synapse.rest.client import login, room
@@ -232,6 +232,8 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         if room_id_1 > room_id_2:
             room_id_1, room_id_2 = room_id_2, room_id_1
 
+        # Without read receipts, both rooms should be processed in alphabetical order
+
         original_update_membership = self.hs.get_room_member_handler().update_membership
 
         room_1_updated = False
@@ -314,6 +316,232 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             self.assertEqual(
                 membership[state_tuple].content["displayname"], "Frank Jr."
             )
+
+    def test_room_update_ordering_by_read_receipt(self) -> None:
+        """Test that rooms are updated in order of most recent read receipt."""
+        self.get_success(
+            self.handler.set_displayname(
+                self.frank, synapse.types.create_requester(self.frank), "Frank"
+            )
+        )
+
+        # Create three rooms
+        room_id_1 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_id_2 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_id_3 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+
+        # Send an event in each room to create something to mark as read
+        event_1 = self.helper.send(room_id_1, "Hello 1", tok=self.frank_token)
+        event_2 = self.helper.send(room_id_2, "Hello 2", tok=self.frank_token)
+        event_3 = self.helper.send(room_id_3, "Hello 3", tok=self.frank_token)
+
+        # Set read receipts with different timestamps (simulate different read times)
+        # Room 2 should be most recent, then room 3, then room 1
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_1,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_1["event_id"]],
+                thread_id=None,
+                data={"ts": 100},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_3,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_3["event_id"]],
+                thread_id=None,
+                data={"ts": 200},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_2,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_2["event_id"]],
+                thread_id=None,
+                data={"ts": 300},
+            )
+        )
+
+        # Track the order in which rooms are updated
+        room_update_order = []
+        original_update_membership = self.hs.get_room_member_handler().update_membership
+
+        async def track_update_membership(*args: Any, **kwargs: Any) -> tuple[str, int]:
+            room_id = args[2]
+            room_update_order.append(room_id)
+            return await original_update_membership(*args, **kwargs)
+
+        with patch.object(
+            self.hs.get_room_member_handler(),
+            "update_membership",
+            side_effect=track_update_membership,
+        ):
+            self.get_success(
+                self.handler.set_displayname(
+                    self.frank,
+                    synapse.types.create_requester(self.frank),
+                    "Frank Updated",
+                )
+            )
+
+        # Wait for background task to complete
+        self.get_success(self.clock.sleep(Duration(milliseconds=50)), by=1)
+
+        # Get receipts to understand the actual stream ordering
+        user_receipts = self.get_success(
+            self.store.get_receipts_for_user_with_orderings(
+                self.frank.to_string(),
+                [ReceiptTypes.READ, ReceiptTypes.READ_PRIVATE],
+            )
+        )
+
+        # Sort rooms by stream_ordering (descending) to get expected order
+        rooms_by_stream_ordering = sorted(
+            user_receipts.keys(),
+            key=lambda room_id: -user_receipts[room_id]["stream_ordering"],
+        )
+
+        # Verify rooms were updated in order of most recent read receipt (highest stream_ordering first)
+        self.assertEqual(len(room_update_order), 3)
+        self.assertEqual(room_update_order, rooms_by_stream_ordering)
+
+    def test_room_update_ordering_with_no_receipts_fallback(self) -> None:
+        """Test that rooms without read receipts fall back to alphabetical ordering."""
+        self.get_success(
+            self.handler.set_displayname(
+                self.frank, synapse.types.create_requester(self.frank), "Frank"
+            )
+        )
+
+        # Create two rooms - ensure we know their alphabetical order
+        room_id_a = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_id_b = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+
+        # Ensure room_id_a comes before room_id_b alphabetically
+        if room_id_a > room_id_b:
+            room_id_a, room_id_b = room_id_b, room_id_a
+
+        # Don't set any read receipts - should fall back to alphabetical
+
+        # Track the order in which rooms are updated
+        room_update_order = []
+        original_update_membership = self.hs.get_room_member_handler().update_membership
+
+        async def track_update_membership(*args: Any, **kwargs: Any) -> tuple[str, int]:
+            room_id = args[2]
+            room_update_order.append(room_id)
+            return await original_update_membership(*args, **kwargs)
+
+        with patch.object(
+            self.hs.get_room_member_handler(),
+            "update_membership",
+            side_effect=track_update_membership,
+        ):
+            self.get_success(
+                self.handler.set_displayname(
+                    self.frank,
+                    synapse.types.create_requester(self.frank),
+                    "Frank Updated",
+                )
+            )
+
+        # Wait for background task to complete
+        self.get_success(self.clock.sleep(Duration(milliseconds=50)), by=1)
+
+        # Verify rooms were updated in alphabetical order
+        self.assertEqual(len(room_update_order), 2)
+        self.assertEqual(room_update_order[0], room_id_a)  # Alphabetically first
+        self.assertEqual(room_update_order[1], room_id_b)  # Alphabetically second
+
+    def test_room_update_ordering_mixed_receipts_and_no_receipts(self) -> None:
+        """Test ordering when some rooms have receipts and others don't."""
+        self.get_success(
+            self.handler.set_displayname(
+                self.frank, synapse.types.create_requester(self.frank), "Frank"
+            )
+        )
+
+        # Create three rooms
+        room_with_receipt = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_without_receipt_1 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_without_receipt_2 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+
+        # Ensure we know the alphabetical order of rooms without receipts
+        if room_without_receipt_1 > room_without_receipt_2:
+            room_without_receipt_1, room_without_receipt_2 = (
+                room_without_receipt_2,
+                room_without_receipt_1,
+            )
+
+        # Send an event and set a read receipt for one room only
+        event = self.helper.send(room_with_receipt, "Hello", tok=self.frank_token)
+        self.get_success(
+            self.store.insert_receipt(
+                room_with_receipt,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event["event_id"]],
+                thread_id=None,
+                data={"ts": 100},
+            )
+        )
+
+        # Track the order in which rooms are updated
+        room_update_order = []
+        original_update_membership = self.hs.get_room_member_handler().update_membership
+
+        async def track_update_membership(*args: Any, **kwargs: Any) -> tuple[str, int]:
+            room_id = args[2]
+            room_update_order.append(room_id)
+            return await original_update_membership(*args, **kwargs)
+
+        with patch.object(
+            self.hs.get_room_member_handler(),
+            "update_membership",
+            side_effect=track_update_membership,
+        ):
+            self.get_success(
+                self.handler.set_displayname(
+                    self.frank,
+                    synapse.types.create_requester(self.frank),
+                    "Frank Updated",
+                )
+            )
+
+        # Wait for background task to complete
+        self.get_success(self.clock.sleep(Duration(milliseconds=50)), by=1)
+
+        # Verify ordering: room with receipt first, then others alphabetically
+        self.assertEqual(len(room_update_order), 3)
+        self.assertEqual(room_update_order[0], room_with_receipt)  # Has receipt - first
+        self.assertEqual(
+            room_update_order[1], room_without_receipt_1
+        )  # No receipt - alphabetically first
+        self.assertEqual(
+            room_update_order[2], room_without_receipt_2
+        )  # No receipt - alphabetically second
 
     @override_config({"enable_set_displayname": False})
     def test_set_my_name_if_disabled(self) -> None:

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -227,12 +227,46 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         room_id_2 = self.helper.create_room_as(
             self.frank.to_string(), tok=self.frank_token
         )
+        room_id_3 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
 
-        # Ensure `room_id_1` comes before `room_id_2` alphabetically
-        if room_id_1 > room_id_2:
-            room_id_1, room_id_2 = room_id_2, room_id_1
 
-        # Without read receipts, both rooms should be processed in alphabetical order
+        # Set read receipts with different timestamps (simulate different read times)
+        # Room 1 should be most recent, then room 2, then room 3
+        event_3 = self.helper.send(room_id_3, "Hello 3", tok=self.frank_token)
+        event_2 = self.helper.send(room_id_2, "Hello 2", tok=self.frank_token)
+        event_1 = self.helper.send(room_id_1, "Hello 1", tok=self.frank_token)
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_3,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_3["event_id"]],
+                thread_id=None,
+                data={"ts": 100},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_2,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_2["event_id"]],
+                thread_id=None,
+                data={"ts": 200},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_1,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_1["event_id"]],
+                thread_id=None,
+                data={"ts": 300},
+            )
+        )
 
         original_update_membership = self.hs.get_room_member_handler().update_membership
 
@@ -241,7 +275,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         async def potentially_slow_update_membership(
             *args: Any, **kwargs: Any
         ) -> tuple[str, int]:
-            if args[2] == room_id_2:
+            if args[2] == room_id_2 or args[2] == room_id_3:
                 await self.clock.sleep(Duration(milliseconds=10))
             if args[2] == room_id_1:
                 nonlocal room_1_updated
@@ -316,6 +350,15 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             self.assertEqual(
                 membership[state_tuple].content["displayname"], "Frank Jr."
             )
+            membership = self.get_success(
+                self.storage_controllers.state.get_current_state(
+                    room_id_3, StateFilter.from_types([state_tuple])
+                )
+            )
+            self.assertEqual(
+                membership[state_tuple].content["displayname"], "Frank Jr."
+            )
+
 
     def test_room_update_ordering_by_read_receipt(self) -> None:
         """Test that rooms are updated in order of most recent read receipt."""

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -215,59 +215,9 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         """Test that room membership updates triggered by changing the avatar or the display name are resumed after a restart."""
         initial_displayname = "Frank"
         updated_displayname = "Frank Jr."
-        self.get_success(
-            self.handler.set_displayname(
-                self.frank,
-                synapse.types.create_requester(self.frank),
-                initial_displayname,
-            )
-        )
 
-        room_id_1 = self.helper.create_room_as(
-            self.frank.to_string(), tok=self.frank_token
-        )
-
-        room_id_2 = self.helper.create_room_as(
-            self.frank.to_string(), tok=self.frank_token
-        )
-        room_id_3 = self.helper.create_room_as(
-            self.frank.to_string(), tok=self.frank_token
-        )
-
-        # Set read receipts with different timestamps (simulate different read times)
-        # Room 1 should be most recent, then room 2, then room 3
-        event_3 = self.helper.send(room_id_3, "Hello 3", tok=self.frank_token)
-        event_2 = self.helper.send(room_id_2, "Hello 2", tok=self.frank_token)
-        event_1 = self.helper.send(room_id_1, "Hello 1", tok=self.frank_token)
-        self.get_success(
-            self.store.insert_receipt(
-                room_id_3,
-                ReceiptTypes.READ,
-                user_id=self.frank.to_string(),
-                event_ids=[event_3["event_id"]],
-                thread_id=None,
-                data={"ts": 100},
-            )
-        )
-        self.get_success(
-            self.store.insert_receipt(
-                room_id_2,
-                ReceiptTypes.READ,
-                user_id=self.frank.to_string(),
-                event_ids=[event_2["event_id"]],
-                thread_id=None,
-                data={"ts": 200},
-            )
-        )
-        self.get_success(
-            self.store.insert_receipt(
-                room_id_1,
-                ReceiptTypes.READ,
-                user_id=self.frank.to_string(),
-                event_ids=[event_1["event_id"]],
-                thread_id=None,
-                data={"ts": 300},
-            )
+        room_id_1, room_id_2, room_id_3 = self._setup_displayname_and_rooms(
+            initial_displayname
         )
 
         original_update_membership = self.hs.get_room_member_handler().update_membership
@@ -369,62 +319,8 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         """Test that rooms are updated in order of most recent read receipt."""
         initial_displayname = "Frank"
         updated_displayname = "Frank Jr."
-        self.get_success(
-            self.handler.set_displayname(
-                self.frank,
-                synapse.types.create_requester(self.frank),
-                initial_displayname,
-            )
-        )
 
-        # Create three rooms
-        room_id_1 = self.helper.create_room_as(
-            self.frank.to_string(), tok=self.frank_token
-        )
-        room_id_2 = self.helper.create_room_as(
-            self.frank.to_string(), tok=self.frank_token
-        )
-        room_id_3 = self.helper.create_room_as(
-            self.frank.to_string(), tok=self.frank_token
-        )
-
-        # Send an event in each room to create something to mark as read
-        event_1 = self.helper.send(room_id_1, "Hello 1", tok=self.frank_token)
-        event_2 = self.helper.send(room_id_2, "Hello 2", tok=self.frank_token)
-        event_3 = self.helper.send(room_id_3, "Hello 3", tok=self.frank_token)
-
-        # Set read receipts with different timestamps (simulate different read times)
-        # Room 3 is the most recent, then room 2, then room 1
-        self.get_success(
-            self.store.insert_receipt(
-                room_id_1,
-                ReceiptTypes.READ,
-                user_id=self.frank.to_string(),
-                event_ids=[event_1["event_id"]],
-                thread_id=None,
-                data={"ts": 100},
-            )
-        )
-        self.get_success(
-            self.store.insert_receipt(
-                room_id_2,
-                ReceiptTypes.READ,
-                user_id=self.frank.to_string(),
-                event_ids=[event_2["event_id"]],
-                thread_id=None,
-                data={"ts": 200},
-            )
-        )
-        self.get_success(
-            self.store.insert_receipt(
-                room_id_3,
-                ReceiptTypes.READ,
-                user_id=self.frank.to_string(),
-                event_ids=[event_3["event_id"]],
-                thread_id=None,
-                data={"ts": 300},
-            )
-        )
+        self._setup_displayname_and_rooms(initial_displayname)
 
         # Track the order in which rooms are updated
         room_update_order = []
@@ -468,6 +364,67 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         # Verify rooms were updated in order of most recent read receipt (highest stream_ordering first)
         self.assertEqual(len(room_update_order), 3)
         self.assertEqual(room_update_order, rooms_by_stream_ordering)
+
+    def _setup_displayname_and_rooms(
+        self, initial_displayname: str
+    ) -> tuple[str, str, str]:
+        """Helper to set up initial displayname and create three rooms.
+        Returns tuples of (room_id_1, room_id_2, room_id_3) where room_id_1
+        is the room with the most recent read receipt, then room_id_2, then room_id_3."""
+        self.get_success(
+            self.handler.set_displayname(
+                self.frank,
+                synapse.types.create_requester(self.frank),
+                initial_displayname,
+            )
+        )
+
+        # Create three rooms
+        room_id_1 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_id_2 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_id_3 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        # Set read receipts with different timestamps (simulate different read times)
+        # Room 1 should be most recent, then room 2, then room 3
+        event_3 = self.helper.send(room_id_3, "Hello 3", tok=self.frank_token)
+        event_2 = self.helper.send(room_id_2, "Hello 2", tok=self.frank_token)
+        event_1 = self.helper.send(room_id_1, "Hello 1", tok=self.frank_token)
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_3,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_3["event_id"]],
+                thread_id=None,
+                data={"ts": 100},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_2,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_2["event_id"]],
+                thread_id=None,
+                data={"ts": 200},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_1,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_1["event_id"]],
+                thread_id=None,
+                data={"ts": 300},
+            )
+        )
+        return room_id_1, room_id_2, room_id_3
 
     def test_room_update_ordering_with_no_receipts_fallback(self) -> None:
         """Test that rooms without read receipts fall back to alphabetical ordering."""

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -213,10 +213,13 @@ class ProfileTestCase(unittest.HomeserverTestCase):
 
     def test_background_update_room_membership_resume_after_restart(self) -> None:
         """Test that room membership updates triggered by changing the avatar or the display name are resumed after a restart."""
-
+        initial_displayname = "Frank"
+        updated_displayname = "Frank Jr."
         self.get_success(
             self.handler.set_displayname(
-                self.frank, synapse.types.create_requester(self.frank), "Frank"
+                self.frank,
+                synapse.types.create_requester(self.frank),
+                initial_displayname,
             )
         )
 
@@ -230,7 +233,6 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         room_id_3 = self.helper.create_room_as(
             self.frank.to_string(), tok=self.frank_token
         )
-
 
         # Set read receipts with different timestamps (simulate different read times)
         # Room 1 should be most recent, then room 2, then room 3
@@ -290,7 +292,9 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             state_tuple = (EventTypes.Member, self.frank.to_string())
             self.get_success(
                 self.handler.set_displayname(
-                    self.frank, synapse.types.create_requester(self.frank), "Frank Jr."
+                    self.frank,
+                    synapse.types.create_requester(self.frank),
+                    updated_displayname,
                 )
             )
 
@@ -301,7 +305,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                 )
             )
             self.assertEqual(
-                membership[state_tuple].content["displayname"], "Frank Jr."
+                membership[state_tuple].content["displayname"], updated_displayname
             )
 
             # Simulate a synapse restart by emptying the list of running tasks
@@ -321,7 +325,9 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                     room_id_2, StateFilter.from_types([state_tuple])
                 )
             )
-            self.assertEqual(membership[state_tuple].content["displayname"], "Frank")
+            self.assertEqual(
+                membership[state_tuple].content["displayname"], initial_displayname
+            )
 
             cancelled_task = self.get_success(
                 self.task_scheduler.get_tasks(
@@ -348,7 +354,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                 )
             )
             self.assertEqual(
-                membership[state_tuple].content["displayname"], "Frank Jr."
+                membership[state_tuple].content["displayname"], updated_displayname
             )
             membership = self.get_success(
                 self.storage_controllers.state.get_current_state(
@@ -356,9 +362,8 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                 )
             )
             self.assertEqual(
-                membership[state_tuple].content["displayname"], "Frank Jr."
+                membership[state_tuple].content["displayname"], updated_displayname
             )
-
 
     def test_room_update_ordering_by_read_receipt(self) -> None:
         """Test that rooms are updated in order of most recent read receipt."""
@@ -385,7 +390,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         event_3 = self.helper.send(room_id_3, "Hello 3", tok=self.frank_token)
 
         # Set read receipts with different timestamps (simulate different read times)
-        # Room 2 should be most recent, then room 3, then room 1
+        # Room 3 is the most recent, then room 2, then room 1
         self.get_success(
             self.store.insert_receipt(
                 room_id_1,
@@ -398,20 +403,20 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         )
         self.get_success(
             self.store.insert_receipt(
-                room_id_3,
+                room_id_2,
                 ReceiptTypes.READ,
                 user_id=self.frank.to_string(),
-                event_ids=[event_3["event_id"]],
+                event_ids=[event_2["event_id"]],
                 thread_id=None,
                 data={"ts": 200},
             )
         )
         self.get_success(
             self.store.insert_receipt(
-                room_id_2,
+                room_id_3,
                 ReceiptTypes.READ,
                 user_id=self.frank.to_string(),
-                event_ids=[event_2["event_id"]],
+                event_ids=[event_3["event_id"]],
                 thread_id=None,
                 data={"ts": 300},
             )

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -367,9 +367,13 @@ class ProfileTestCase(unittest.HomeserverTestCase):
 
     def test_room_update_ordering_by_read_receipt(self) -> None:
         """Test that rooms are updated in order of most recent read receipt."""
+        initial_displayname = "Frank"
+        updated_displayname = "Frank Jr."
         self.get_success(
             self.handler.set_displayname(
-                self.frank, synapse.types.create_requester(self.frank), "Frank"
+                self.frank,
+                synapse.types.create_requester(self.frank),
+                initial_displayname,
             )
         )
 
@@ -440,7 +444,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                 self.handler.set_displayname(
                     self.frank,
                     synapse.types.create_requester(self.frank),
-                    "Frank Updated",
+                    updated_displayname,
                 )
             )
 

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -747,13 +747,14 @@ class ProfileTestCase(unittest.HomeserverTestCase):
 
     def test_background_update_room_membership_resume_after_restart(self) -> None:
         """Test that room membership updates triggered by changing the avatar or the display name are resumed after a restart."""
-
+        initial_displayname = "Frank"
+        updated_displayname = "Frank Jr."
         self.get_success(
             self.handler.set_field(
                 target_user=self.frank,
                 requester=synapse.types.create_requester(self.frank),
                 field_name=ProfileFields.DISPLAYNAME,
-                new_value="Frank",
+                new_value=initial_displayname,
             )
         )
 
@@ -767,7 +768,6 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         room_id_3 = self.helper.create_room_as(
             self.frank.to_string(), tok=self.frank_token
         )
-
 
         # Set read receipts with different timestamps (simulate different read times)
         # Room 1 should be most recent, then room 2, then room 3
@@ -830,7 +830,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                     target_user=self.frank,
                     requester=synapse.types.create_requester(self.frank),
                     field_name=ProfileFields.DISPLAYNAME,
-                    new_value="Frank Jr.",
+                    new_value=updated_displayname,
                 )
             )
 
@@ -841,7 +841,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                 )
             )
             self.assertEqual(
-                membership[state_tuple].content["displayname"], "Frank Jr."
+                membership[state_tuple].content["displayname"], updated_displayname
             )
 
             # Simulate a synapse restart by emptying the list of running tasks
@@ -861,7 +861,9 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                     room_id_2, StateFilter.from_types([state_tuple])
                 )
             )
-            self.assertEqual(membership[state_tuple].content["displayname"], "Frank")
+            self.assertEqual(
+                membership[state_tuple].content["displayname"], initial_displayname
+            )
 
             cancelled_task = self.get_success(
                 self.task_scheduler.get_tasks(
@@ -890,7 +892,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                 )
             )
             self.assertEqual(
-                membership[state_tuple].content["displayname"], "Frank Jr."
+                membership[state_tuple].content["displayname"], updated_displayname
             )
             membership = self.get_success(
                 self.storage_controllers.state.get_current_state(
@@ -898,9 +900,8 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                 )
             )
             self.assertEqual(
-                membership[state_tuple].content["displayname"], "Frank Jr."
+                membership[state_tuple].content["displayname"], updated_displayname
             )
-
 
     def test_room_update_ordering_by_read_receipt(self) -> None:
         """Test that rooms are updated in order of most recent read receipt."""
@@ -927,7 +928,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         event_3 = self.helper.send(room_id_3, "Hello 3", tok=self.frank_token)
 
         # Set read receipts with different timestamps (simulate different read times)
-        # Room 2 should be most recent, then room 3, then room 1
+        # Room 3 is the most recent, then room 2, then room 1
         self.get_success(
             self.store.insert_receipt(
                 room_id_1,
@@ -940,20 +941,20 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         )
         self.get_success(
             self.store.insert_receipt(
-                room_id_3,
+                room_id_2,
                 ReceiptTypes.READ,
                 user_id=self.frank.to_string(),
-                event_ids=[event_3["event_id"]],
+                event_ids=[event_2["event_id"]],
                 thread_id=None,
                 data={"ts": 200},
             )
         )
         self.get_success(
             self.store.insert_receipt(
-                room_id_2,
+                room_id_3,
                 ReceiptTypes.READ,
                 user_id=self.frank.to_string(),
-                event_ids=[event_2["event_id"]],
+                event_ids=[event_3["event_id"]],
                 thread_id=None,
                 data={"ts": 300},
             )

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 from parameterized import parameterized
 
+from twisted.internet.defer import ensureDeferred
 from twisted.internet.testing import MemoryReactor
 
 import synapse.types
@@ -749,60 +750,9 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         """Test that room membership updates triggered by changing the avatar or the display name are resumed after a restart."""
         initial_displayname = "Frank"
         updated_displayname = "Frank Jr."
-        self.get_success(
-            self.handler.set_field(
-                target_user=self.frank,
-                requester=synapse.types.create_requester(self.frank),
-                field_name=ProfileFields.DISPLAYNAME,
-                new_value=initial_displayname,
-            )
-        )
 
-        room_id_1 = self.helper.create_room_as(
-            self.frank.to_string(), tok=self.frank_token
-        )
-
-        room_id_2 = self.helper.create_room_as(
-            self.frank.to_string(), tok=self.frank_token
-        )
-        room_id_3 = self.helper.create_room_as(
-            self.frank.to_string(), tok=self.frank_token
-        )
-
-        # Set read receipts with different timestamps (simulate different read times)
-        # Room 1 should be most recent, then room 2, then room 3
-        event_3 = self.helper.send(room_id_3, "Hello 3", tok=self.frank_token)
-        event_2 = self.helper.send(room_id_2, "Hello 2", tok=self.frank_token)
-        event_1 = self.helper.send(room_id_1, "Hello 1", tok=self.frank_token)
-        self.get_success(
-            self.store.insert_receipt(
-                room_id_3,
-                ReceiptTypes.READ,
-                user_id=self.frank.to_string(),
-                event_ids=[event_3["event_id"]],
-                thread_id=None,
-                data={"ts": 100},
-            )
-        )
-        self.get_success(
-            self.store.insert_receipt(
-                room_id_2,
-                ReceiptTypes.READ,
-                user_id=self.frank.to_string(),
-                event_ids=[event_2["event_id"]],
-                thread_id=None,
-                data={"ts": 200},
-            )
-        )
-        self.get_success(
-            self.store.insert_receipt(
-                room_id_1,
-                ReceiptTypes.READ,
-                user_id=self.frank.to_string(),
-                event_ids=[event_1["event_id"]],
-                thread_id=None,
-                data={"ts": 300},
-            )
+        room_id_1, room_id_2, room_id_3 = self._setup_displayname_and_rooms(
+            initial_displayname
         )
 
         original_update_membership = self.hs.get_room_member_handler().update_membership
@@ -907,62 +857,8 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         """Test that rooms are updated in order of most recent read receipt."""
         initial_displayname = "Frank"
         updated_displayname = "Frank Jr."
-        self.get_success(
-            self.handler.set_displayname(
-                self.frank,
-                synapse.types.create_requester(self.frank),
-                initial_displayname,
-            )
-        )
 
-        # Create three rooms
-        room_id_1 = self.helper.create_room_as(
-            self.frank.to_string(), tok=self.frank_token
-        )
-        room_id_2 = self.helper.create_room_as(
-            self.frank.to_string(), tok=self.frank_token
-        )
-        room_id_3 = self.helper.create_room_as(
-            self.frank.to_string(), tok=self.frank_token
-        )
-
-        # Send an event in each room to create something to mark as read
-        event_1 = self.helper.send(room_id_1, "Hello 1", tok=self.frank_token)
-        event_2 = self.helper.send(room_id_2, "Hello 2", tok=self.frank_token)
-        event_3 = self.helper.send(room_id_3, "Hello 3", tok=self.frank_token)
-
-        # Set read receipts with different timestamps (simulate different read times)
-        # Room 3 is the most recent, then room 2, then room 1
-        self.get_success(
-            self.store.insert_receipt(
-                room_id_1,
-                ReceiptTypes.READ,
-                user_id=self.frank.to_string(),
-                event_ids=[event_1["event_id"]],
-                thread_id=None,
-                data={"ts": 100},
-            )
-        )
-        self.get_success(
-            self.store.insert_receipt(
-                room_id_2,
-                ReceiptTypes.READ,
-                user_id=self.frank.to_string(),
-                event_ids=[event_2["event_id"]],
-                thread_id=None,
-                data={"ts": 200},
-            )
-        )
-        self.get_success(
-            self.store.insert_receipt(
-                room_id_3,
-                ReceiptTypes.READ,
-                user_id=self.frank.to_string(),
-                event_ids=[event_3["event_id"]],
-                thread_id=None,
-                data={"ts": 300},
-            )
-        )
+        self._setup_displayname_and_rooms(initial_displayname)
 
         # Track the order in which rooms are updated
         room_update_order = []
@@ -979,15 +875,19 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             side_effect=track_update_membership,
         ):
             self.get_success(
-                self.handler.set_displayname(
-                    self.frank,
-                    synapse.types.create_requester(self.frank),
-                    updated_displayname,
+                self.handler.set_field(
+                    target_user=self.frank,
+                    requester=synapse.types.create_requester(self.frank),
+                    field_name=ProfileFields.DISPLAYNAME,
+                    new_value=updated_displayname,
                 )
             )
 
-        # Wait for background task to complete
-        self.get_success(self.clock.sleep(Duration(milliseconds=50)), by=1)
+        # Wait for background task to complete. `get_success` no longer advances the
+        # reactor itself, so drive the clock forward while it waits.
+        wait_d = ensureDeferred(self.clock.sleep(Duration(milliseconds=50)))
+        self.reactor.advance(Duration(milliseconds=50).as_secs())
+        self.get_success(wait_d)
 
         # Get receipts to understand the actual stream ordering
         user_receipts = self.get_success(
@@ -1007,11 +907,76 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         self.assertEqual(len(room_update_order), 3)
         self.assertEqual(room_update_order, rooms_by_stream_ordering)
 
+    def _setup_displayname_and_rooms(
+        self, initial_displayname: str
+    ) -> tuple[str, str, str]:
+        """Helper to set up initial displayname and create three rooms.
+        Returns tuples of (room_id_1, room_id_2, room_id_3) where room_id_1
+        is the room with the most recent read receipt, then room_id_2, then room_id_3."""
+        self.get_success(
+            self.handler.set_field(
+                target_user=self.frank,
+                requester=synapse.types.create_requester(self.frank),
+                field_name=ProfileFields.DISPLAYNAME,
+                new_value=initial_displayname,
+            )
+        )
+
+        # Create three rooms
+        room_id_1 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_id_2 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_id_3 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        # Set read receipts with different timestamps (simulate different read times)
+        # Room 1 should be most recent, then room 2, then room 3
+        event_3 = self.helper.send(room_id_3, "Hello 3", tok=self.frank_token)
+        event_2 = self.helper.send(room_id_2, "Hello 2", tok=self.frank_token)
+        event_1 = self.helper.send(room_id_1, "Hello 1", tok=self.frank_token)
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_3,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_3["event_id"]],
+                thread_id=None,
+                data={"ts": 100},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_2,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_2["event_id"]],
+                thread_id=None,
+                data={"ts": 200},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_1,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_1["event_id"]],
+                thread_id=None,
+                data={"ts": 300},
+            )
+        )
+        return room_id_1, room_id_2, room_id_3
+
     def test_room_update_ordering_with_no_receipts_fallback(self) -> None:
         """Test that rooms without read receipts fall back to alphabetical ordering."""
         self.get_success(
-            self.handler.set_displayname(
-                self.frank, synapse.types.create_requester(self.frank), "Frank"
+            self.handler.set_field(
+                target_user=self.frank,
+                requester=synapse.types.create_requester(self.frank),
+                field_name=ProfileFields.DISPLAYNAME,
+                new_value="Frank",
             )
         )
 
@@ -1044,15 +1009,19 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             side_effect=track_update_membership,
         ):
             self.get_success(
-                self.handler.set_displayname(
-                    self.frank,
-                    synapse.types.create_requester(self.frank),
-                    "Frank Updated",
+                self.handler.set_field(
+                    target_user=self.frank,
+                    requester=synapse.types.create_requester(self.frank),
+                    field_name=ProfileFields.DISPLAYNAME,
+                    new_value="Frank Updated",
                 )
             )
 
-        # Wait for background task to complete
-        self.get_success(self.clock.sleep(Duration(milliseconds=50)), by=1)
+        # Wait for background task to complete. `get_success` no longer advances the
+        # reactor itself, so drive the clock forward while it waits.
+        wait_d = ensureDeferred(self.clock.sleep(Duration(milliseconds=50)))
+        self.reactor.advance(Duration(milliseconds=50).as_secs())
+        self.get_success(wait_d)
 
         # Verify rooms were updated in alphabetical order
         self.assertEqual(len(room_update_order), 2)
@@ -1062,8 +1031,11 @@ class ProfileTestCase(unittest.HomeserverTestCase):
     def test_room_update_ordering_mixed_receipts_and_no_receipts(self) -> None:
         """Test ordering when some rooms have receipts and others don't."""
         self.get_success(
-            self.handler.set_displayname(
-                self.frank, synapse.types.create_requester(self.frank), "Frank"
+            self.handler.set_field(
+                target_user=self.frank,
+                requester=synapse.types.create_requester(self.frank),
+                field_name=ProfileFields.DISPLAYNAME,
+                new_value="Frank",
             )
         )
 
@@ -1113,15 +1085,19 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             side_effect=track_update_membership,
         ):
             self.get_success(
-                self.handler.set_displayname(
-                    self.frank,
-                    synapse.types.create_requester(self.frank),
-                    "Frank Updated",
+                self.handler.set_field(
+                    target_user=self.frank,
+                    requester=synapse.types.create_requester(self.frank),
+                    field_name=ProfileFields.DISPLAYNAME,
+                    new_value="Frank Updated",
                 )
             )
 
-        # Wait for background task to complete
-        self.get_success(self.clock.sleep(Duration(milliseconds=50)), by=1)
+        # Wait for background task to complete. `get_success` no longer advances the
+        # reactor itself, so drive the clock forward while it waits.
+        wait_d = ensureDeferred(self.clock.sleep(Duration(milliseconds=50)))
+        self.reactor.advance(Duration(milliseconds=50).as_secs())
+        self.get_success(wait_d)
 
         # Verify ordering: room with receipt first, then others alphabetically
         self.assertEqual(len(room_update_order), 3)

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -764,12 +764,46 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         room_id_2 = self.helper.create_room_as(
             self.frank.to_string(), tok=self.frank_token
         )
+        room_id_3 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
 
-        # Ensure `room_id_1` comes before `room_id_2` alphabetically
-        if room_id_1 > room_id_2:
-            room_id_1, room_id_2 = room_id_2, room_id_1
 
-        # Without read receipts, both rooms should be processed in alphabetical order
+        # Set read receipts with different timestamps (simulate different read times)
+        # Room 1 should be most recent, then room 2, then room 3
+        event_3 = self.helper.send(room_id_3, "Hello 3", tok=self.frank_token)
+        event_2 = self.helper.send(room_id_2, "Hello 2", tok=self.frank_token)
+        event_1 = self.helper.send(room_id_1, "Hello 1", tok=self.frank_token)
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_3,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_3["event_id"]],
+                thread_id=None,
+                data={"ts": 100},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_2,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_2["event_id"]],
+                thread_id=None,
+                data={"ts": 200},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_1,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_1["event_id"]],
+                thread_id=None,
+                data={"ts": 300},
+            )
+        )
 
         original_update_membership = self.hs.get_room_member_handler().update_membership
 
@@ -778,7 +812,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         async def potentially_slow_update_membership(
             *args: Any, **kwargs: Any
         ) -> tuple[str, int]:
-            if args[2] == room_id_2:
+            if args[2] == room_id_2 or args[2] == room_id_3:
                 await self.clock.sleep(Duration(milliseconds=10))
             if args[2] == room_id_1:
                 nonlocal room_1_updated
@@ -858,6 +892,15 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             self.assertEqual(
                 membership[state_tuple].content["displayname"], "Frank Jr."
             )
+            membership = self.get_success(
+                self.storage_controllers.state.get_current_state(
+                    room_id_3, StateFilter.from_types([state_tuple])
+                )
+            )
+            self.assertEqual(
+                membership[state_tuple].content["displayname"], "Frank Jr."
+            )
+
 
     def test_room_update_ordering_by_read_receipt(self) -> None:
         """Test that rooms are updated in order of most recent read receipt."""

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -827,10 +827,15 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                 )
             )
 
-            # Wait for the `TaskScheduler.SCHEDULE_INTERVAL`
+            # Wait for the `TaskScheduler.SCHEDULE_INTERVAL` so the task is relaunched
             self.reactor.advance(Duration(minutes=1).as_secs())
-            # Let's be sure we are over the delay introduced by slow_update_membership
-            self.reactor.advance(Duration(milliseconds=20).as_secs())
+
+            # The resumed task still has `room_id_2` and `room_id_3` to update, and
+            # `potentially_slow_update_membership` sleeps for each of them. A sleep
+            # scheduled *during* a `reactor.advance(...)` is queued past that advance's
+            # target time, so each one needs an advance of its own to fire.
+            for _ in (room_id_2, room_id_3):
+                self.reactor.advance(Duration(milliseconds=20).as_secs())
 
             # Updates should have been resumed from room 2 after the restart
             # so room 1 should not have been updated this time

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -30,6 +30,7 @@ from synapse.api.constants import (
     EventTypes,
     ProfileFields,
     ProfileUpdateAction,
+    ReceiptTypes,
 )
 from synapse.api.errors import AuthError, SynapseError
 from synapse.rest import admin
@@ -768,6 +769,8 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         if room_id_1 > room_id_2:
             room_id_1, room_id_2 = room_id_2, room_id_1
 
+        # Without read receipts, both rooms should be processed in alphabetical order
+
         original_update_membership = self.hs.get_room_member_handler().update_membership
 
         room_1_updated = False
@@ -855,6 +858,232 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             self.assertEqual(
                 membership[state_tuple].content["displayname"], "Frank Jr."
             )
+
+    def test_room_update_ordering_by_read_receipt(self) -> None:
+        """Test that rooms are updated in order of most recent read receipt."""
+        self.get_success(
+            self.handler.set_displayname(
+                self.frank, synapse.types.create_requester(self.frank), "Frank"
+            )
+        )
+
+        # Create three rooms
+        room_id_1 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_id_2 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_id_3 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+
+        # Send an event in each room to create something to mark as read
+        event_1 = self.helper.send(room_id_1, "Hello 1", tok=self.frank_token)
+        event_2 = self.helper.send(room_id_2, "Hello 2", tok=self.frank_token)
+        event_3 = self.helper.send(room_id_3, "Hello 3", tok=self.frank_token)
+
+        # Set read receipts with different timestamps (simulate different read times)
+        # Room 2 should be most recent, then room 3, then room 1
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_1,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_1["event_id"]],
+                thread_id=None,
+                data={"ts": 100},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_3,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_3["event_id"]],
+                thread_id=None,
+                data={"ts": 200},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_2,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_2["event_id"]],
+                thread_id=None,
+                data={"ts": 300},
+            )
+        )
+
+        # Track the order in which rooms are updated
+        room_update_order = []
+        original_update_membership = self.hs.get_room_member_handler().update_membership
+
+        async def track_update_membership(*args: Any, **kwargs: Any) -> tuple[str, int]:
+            room_id = args[2]
+            room_update_order.append(room_id)
+            return await original_update_membership(*args, **kwargs)
+
+        with patch.object(
+            self.hs.get_room_member_handler(),
+            "update_membership",
+            side_effect=track_update_membership,
+        ):
+            self.get_success(
+                self.handler.set_displayname(
+                    self.frank,
+                    synapse.types.create_requester(self.frank),
+                    "Frank Updated",
+                )
+            )
+
+        # Wait for background task to complete
+        self.get_success(self.clock.sleep(Duration(milliseconds=50)), by=1)
+
+        # Get receipts to understand the actual stream ordering
+        user_receipts = self.get_success(
+            self.store.get_receipts_for_user_with_orderings(
+                self.frank.to_string(),
+                [ReceiptTypes.READ, ReceiptTypes.READ_PRIVATE],
+            )
+        )
+
+        # Sort rooms by stream_ordering (descending) to get expected order
+        rooms_by_stream_ordering = sorted(
+            user_receipts.keys(),
+            key=lambda room_id: -user_receipts[room_id]["stream_ordering"],
+        )
+
+        # Verify rooms were updated in order of most recent read receipt (highest stream_ordering first)
+        self.assertEqual(len(room_update_order), 3)
+        self.assertEqual(room_update_order, rooms_by_stream_ordering)
+
+    def test_room_update_ordering_with_no_receipts_fallback(self) -> None:
+        """Test that rooms without read receipts fall back to alphabetical ordering."""
+        self.get_success(
+            self.handler.set_displayname(
+                self.frank, synapse.types.create_requester(self.frank), "Frank"
+            )
+        )
+
+        # Create two rooms - ensure we know their alphabetical order
+        room_id_a = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_id_b = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+
+        # Ensure room_id_a comes before room_id_b alphabetically
+        if room_id_a > room_id_b:
+            room_id_a, room_id_b = room_id_b, room_id_a
+
+        # Don't set any read receipts - should fall back to alphabetical
+
+        # Track the order in which rooms are updated
+        room_update_order = []
+        original_update_membership = self.hs.get_room_member_handler().update_membership
+
+        async def track_update_membership(*args: Any, **kwargs: Any) -> tuple[str, int]:
+            room_id = args[2]
+            room_update_order.append(room_id)
+            return await original_update_membership(*args, **kwargs)
+
+        with patch.object(
+            self.hs.get_room_member_handler(),
+            "update_membership",
+            side_effect=track_update_membership,
+        ):
+            self.get_success(
+                self.handler.set_displayname(
+                    self.frank,
+                    synapse.types.create_requester(self.frank),
+                    "Frank Updated",
+                )
+            )
+
+        # Wait for background task to complete
+        self.get_success(self.clock.sleep(Duration(milliseconds=50)), by=1)
+
+        # Verify rooms were updated in alphabetical order
+        self.assertEqual(len(room_update_order), 2)
+        self.assertEqual(room_update_order[0], room_id_a)  # Alphabetically first
+        self.assertEqual(room_update_order[1], room_id_b)  # Alphabetically second
+
+    def test_room_update_ordering_mixed_receipts_and_no_receipts(self) -> None:
+        """Test ordering when some rooms have receipts and others don't."""
+        self.get_success(
+            self.handler.set_displayname(
+                self.frank, synapse.types.create_requester(self.frank), "Frank"
+            )
+        )
+
+        # Create three rooms
+        room_with_receipt = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_without_receipt_1 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_without_receipt_2 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+
+        # Ensure we know the alphabetical order of rooms without receipts
+        if room_without_receipt_1 > room_without_receipt_2:
+            room_without_receipt_1, room_without_receipt_2 = (
+                room_without_receipt_2,
+                room_without_receipt_1,
+            )
+
+        # Send an event and set a read receipt for one room only
+        event = self.helper.send(room_with_receipt, "Hello", tok=self.frank_token)
+        self.get_success(
+            self.store.insert_receipt(
+                room_with_receipt,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event["event_id"]],
+                thread_id=None,
+                data={"ts": 100},
+            )
+        )
+
+        # Track the order in which rooms are updated
+        room_update_order = []
+        original_update_membership = self.hs.get_room_member_handler().update_membership
+
+        async def track_update_membership(*args: Any, **kwargs: Any) -> tuple[str, int]:
+            room_id = args[2]
+            room_update_order.append(room_id)
+            return await original_update_membership(*args, **kwargs)
+
+        with patch.object(
+            self.hs.get_room_member_handler(),
+            "update_membership",
+            side_effect=track_update_membership,
+        ):
+            self.get_success(
+                self.handler.set_displayname(
+                    self.frank,
+                    synapse.types.create_requester(self.frank),
+                    "Frank Updated",
+                )
+            )
+
+        # Wait for background task to complete
+        self.get_success(self.clock.sleep(Duration(milliseconds=50)), by=1)
+
+        # Verify ordering: room with receipt first, then others alphabetically
+        self.assertEqual(len(room_update_order), 3)
+        self.assertEqual(room_update_order[0], room_with_receipt)  # Has receipt - first
+        self.assertEqual(
+            room_update_order[1], room_without_receipt_1
+        )  # No receipt - alphabetically first
+        self.assertEqual(
+            room_update_order[2], room_without_receipt_2
+        )  # No receipt - alphabetically second
 
     @override_config({"enable_set_displayname": False})
     def test_set_my_name_if_disabled(self) -> None:

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -905,9 +905,13 @@ class ProfileTestCase(unittest.HomeserverTestCase):
 
     def test_room_update_ordering_by_read_receipt(self) -> None:
         """Test that rooms are updated in order of most recent read receipt."""
+        initial_displayname = "Frank"
+        updated_displayname = "Frank Jr."
         self.get_success(
             self.handler.set_displayname(
-                self.frank, synapse.types.create_requester(self.frank), "Frank"
+                self.frank,
+                synapse.types.create_requester(self.frank),
+                initial_displayname,
             )
         )
 
@@ -978,7 +982,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                 self.handler.set_displayname(
                     self.frank,
                     synapse.types.create_requester(self.frank),
-                    "Frank Updated",
+                    updated_displayname,
                 )
             )
 

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -26,7 +26,7 @@ from parameterized import parameterized
 from twisted.internet.testing import MemoryReactor
 
 import synapse.types
-from synapse.api.constants import EventTypes
+from synapse.api.constants import EventTypes, ReceiptTypes
 from synapse.api.errors import AuthError, SynapseError
 from synapse.rest import admin
 from synapse.rest.client import login, room
@@ -231,6 +231,8 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         if room_id_1 > room_id_2:
             room_id_1, room_id_2 = room_id_2, room_id_1
 
+        # Without read receipts, both rooms should be processed in alphabetical order
+
         original_update_membership = self.hs.get_room_member_handler().update_membership
 
         room_1_updated = False
@@ -313,6 +315,232 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             self.assertEqual(
                 membership[state_tuple].content["displayname"], "Frank Jr."
             )
+
+    def test_room_update_ordering_by_read_receipt(self) -> None:
+        """Test that rooms are updated in order of most recent read receipt."""
+        self.get_success(
+            self.handler.set_displayname(
+                self.frank, synapse.types.create_requester(self.frank), "Frank"
+            )
+        )
+
+        # Create three rooms
+        room_id_1 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_id_2 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_id_3 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+
+        # Send an event in each room to create something to mark as read
+        event_1 = self.helper.send(room_id_1, "Hello 1", tok=self.frank_token)
+        event_2 = self.helper.send(room_id_2, "Hello 2", tok=self.frank_token)
+        event_3 = self.helper.send(room_id_3, "Hello 3", tok=self.frank_token)
+
+        # Set read receipts with different timestamps (simulate different read times)
+        # Room 2 should be most recent, then room 3, then room 1
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_1,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_1["event_id"]],
+                thread_id=None,
+                data={"ts": 100},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_3,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_3["event_id"]],
+                thread_id=None,
+                data={"ts": 200},
+            )
+        )
+        self.get_success(
+            self.store.insert_receipt(
+                room_id_2,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event_2["event_id"]],
+                thread_id=None,
+                data={"ts": 300},
+            )
+        )
+
+        # Track the order in which rooms are updated
+        room_update_order = []
+        original_update_membership = self.hs.get_room_member_handler().update_membership
+
+        async def track_update_membership(*args: Any, **kwargs: Any) -> tuple[str, int]:
+            room_id = args[2]
+            room_update_order.append(room_id)
+            return await original_update_membership(*args, **kwargs)
+
+        with patch.object(
+            self.hs.get_room_member_handler(),
+            "update_membership",
+            side_effect=track_update_membership,
+        ):
+            self.get_success(
+                self.handler.set_displayname(
+                    self.frank,
+                    synapse.types.create_requester(self.frank),
+                    "Frank Updated",
+                )
+            )
+
+        # Wait for background task to complete
+        self.get_success(self.clock.sleep(Duration(milliseconds=50)), by=1)
+
+        # Get receipts to understand the actual stream ordering
+        user_receipts = self.get_success(
+            self.store.get_receipts_for_user_with_orderings(
+                self.frank.to_string(),
+                [ReceiptTypes.READ, ReceiptTypes.READ_PRIVATE],
+            )
+        )
+
+        # Sort rooms by stream_ordering (descending) to get expected order
+        rooms_by_stream_ordering = sorted(
+            user_receipts.keys(),
+            key=lambda room_id: -user_receipts[room_id]["stream_ordering"],
+        )
+
+        # Verify rooms were updated in order of most recent read receipt (highest stream_ordering first)
+        self.assertEqual(len(room_update_order), 3)
+        self.assertEqual(room_update_order, rooms_by_stream_ordering)
+
+    def test_room_update_ordering_with_no_receipts_fallback(self) -> None:
+        """Test that rooms without read receipts fall back to alphabetical ordering."""
+        self.get_success(
+            self.handler.set_displayname(
+                self.frank, synapse.types.create_requester(self.frank), "Frank"
+            )
+        )
+
+        # Create two rooms - ensure we know their alphabetical order
+        room_id_a = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_id_b = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+
+        # Ensure room_id_a comes before room_id_b alphabetically
+        if room_id_a > room_id_b:
+            room_id_a, room_id_b = room_id_b, room_id_a
+
+        # Don't set any read receipts - should fall back to alphabetical
+
+        # Track the order in which rooms are updated
+        room_update_order = []
+        original_update_membership = self.hs.get_room_member_handler().update_membership
+
+        async def track_update_membership(*args: Any, **kwargs: Any) -> tuple[str, int]:
+            room_id = args[2]
+            room_update_order.append(room_id)
+            return await original_update_membership(*args, **kwargs)
+
+        with patch.object(
+            self.hs.get_room_member_handler(),
+            "update_membership",
+            side_effect=track_update_membership,
+        ):
+            self.get_success(
+                self.handler.set_displayname(
+                    self.frank,
+                    synapse.types.create_requester(self.frank),
+                    "Frank Updated",
+                )
+            )
+
+        # Wait for background task to complete
+        self.get_success(self.clock.sleep(Duration(milliseconds=50)), by=1)
+
+        # Verify rooms were updated in alphabetical order
+        self.assertEqual(len(room_update_order), 2)
+        self.assertEqual(room_update_order[0], room_id_a)  # Alphabetically first
+        self.assertEqual(room_update_order[1], room_id_b)  # Alphabetically second
+
+    def test_room_update_ordering_mixed_receipts_and_no_receipts(self) -> None:
+        """Test ordering when some rooms have receipts and others don't."""
+        self.get_success(
+            self.handler.set_displayname(
+                self.frank, synapse.types.create_requester(self.frank), "Frank"
+            )
+        )
+
+        # Create three rooms
+        room_with_receipt = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_without_receipt_1 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+        room_without_receipt_2 = self.helper.create_room_as(
+            self.frank.to_string(), tok=self.frank_token
+        )
+
+        # Ensure we know the alphabetical order of rooms without receipts
+        if room_without_receipt_1 > room_without_receipt_2:
+            room_without_receipt_1, room_without_receipt_2 = (
+                room_without_receipt_2,
+                room_without_receipt_1,
+            )
+
+        # Send an event and set a read receipt for one room only
+        event = self.helper.send(room_with_receipt, "Hello", tok=self.frank_token)
+        self.get_success(
+            self.store.insert_receipt(
+                room_with_receipt,
+                ReceiptTypes.READ,
+                user_id=self.frank.to_string(),
+                event_ids=[event["event_id"]],
+                thread_id=None,
+                data={"ts": 100},
+            )
+        )
+
+        # Track the order in which rooms are updated
+        room_update_order = []
+        original_update_membership = self.hs.get_room_member_handler().update_membership
+
+        async def track_update_membership(*args: Any, **kwargs: Any) -> tuple[str, int]:
+            room_id = args[2]
+            room_update_order.append(room_id)
+            return await original_update_membership(*args, **kwargs)
+
+        with patch.object(
+            self.hs.get_room_member_handler(),
+            "update_membership",
+            side_effect=track_update_membership,
+        ):
+            self.get_success(
+                self.handler.set_displayname(
+                    self.frank,
+                    synapse.types.create_requester(self.frank),
+                    "Frank Updated",
+                )
+            )
+
+        # Wait for background task to complete
+        self.get_success(self.clock.sleep(Duration(milliseconds=50)), by=1)
+
+        # Verify ordering: room with receipt first, then others alphabetically
+        self.assertEqual(len(room_update_order), 3)
+        self.assertEqual(room_update_order[0], room_with_receipt)  # Has receipt - first
+        self.assertEqual(
+            room_update_order[1], room_without_receipt_1
+        )  # No receipt - alphabetically first
+        self.assertEqual(
+            room_update_order[2], room_without_receipt_2
+        )  # No receipt - alphabetically second
 
     def test_set_my_name_if_disabled(self) -> None:
         self.hs.config.registration.enable_set_displayname = False


### PR DESCRIPTION
# Problem to solve
Updating profile information, such as display name or avatar, requires updating state events in every room the user is part of. For large accounts, this can be a time-consuming operation. Historically, making an update led to a timeout and an ugly/confusing error to the user. 

https://github.com/element-hq/synapse/pull/17074 tried to fix this problem by returning immediately and then running the updates asynchronously in the background. The PR stalled due to time constraints, and the same problem was addressed and merged in https://github.com/element-hq/synapse/pull/19311

https://github.com/element-hq/synapse/pull/19311 fixed the timeout issue, but for large accounts, the experience is still jarring because rooms do not update immediately, so from the user's perspective, the update appears to have failed. 

One aspect of https://github.com/element-hq/synapse/pull/17074 that did not make it to https://github.com/element-hq/synapse/pull/19311 is to order the room update by likely importance to the user. 

This PR tries to address the importance issue by ordering the room list by read receipt rather than alphabetically. Since we're now processing rooms in the order of last read receipt, it will appear to be better because the rooms that the user looks at will be updated and hide the fact that we're still working on things in the background.

The important consideration is that once the room ordering is determined, it is never updated, even over a restart. This ensures all rooms are updated eventually. 

Long term we might try to fix this with https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/profile-changes/proposals/4218-profile-change-perf.md

Note, I had a first attempt to fix this in https://github.com/element-hq/synapse/pull/19311, which, in retrospect, was overly complicated and tried to maintain two orderings (stream ordering and alphabetical). 

Many thanks to @MatMaul for https://github.com/element-hq/synapse/pull/19311

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

This PR is Claude-assisted, though line by line, I am confident in its operation.
