### PR TITLE
Document workaround for SQLite `sqlite_master` permissions error in the contributing docs

### DIFF
--- a/changelog.d/19615.doc
+++ b/changelog.d/19615.doc
@@ -1,1 +1,1 @@
-Include workaround for running tests under MacOS.
+Include a workaround for running the unit tests with SQLite under recent versions of MacOS.

--- a/changelog.d/19615.doc
+++ b/changelog.d/19615.doc
@@ -1,0 +1,1 @@
+Include workaround for running tests under MacOS.

--- a/docs/development/contributing_guide.md
+++ b/docs/development/contributing_guide.md
@@ -309,6 +309,22 @@ works without further arguments).
 Your Postgres account needs to be able to create databases; see the postgres
 docs for [`ALTER ROLE`](https://www.postgresql.org/docs/current/sql-alterrole.html).
 
+### Running the tests on MacOS
+
+To run the unit tests on MacOS you will need to swap out the default MacOS
+python interpreter with the homebrew version. This is due to the default using a
+locked down version of Python and sqlite3.
+
+```
+  poetry env remove --all
+  poetry env use /opt/homebrew/bin/python3.13
+  poetry install
+  poetry run trial tests.handlers.test_profile
+
+```
+
+This example uses python 3.13, but choose whichever version you want.
+
 ## Run the integration tests ([Sytest](https://github.com/matrix-org/sytest)).
 
 The integration tests are a more comprehensive suite of tests. They

--- a/docs/development/contributing_guide.md
+++ b/docs/development/contributing_guide.md
@@ -311,16 +311,15 @@ docs for [`ALTER ROLE`](https://www.postgresql.org/docs/current/sql-alterrole.ht
 
 ### Running the tests on MacOS
 
-To run the unit tests on MacOS you will need to swap out the default MacOS
+To run the unit tests with SQLite on MacOS you will need to swap out the default MacOS
 python interpreter with the homebrew version. This is due to the default using a
-locked down version of Python and sqlite3.
+locked down version of Python and sqlite3. After installing python from homebrew:
 
 ```
   poetry env remove --all
   poetry env use /opt/homebrew/bin/python3.13
   poetry install
-  poetry run trial tests.handlers.test_profile
-
+  poetry run trial tests
 ```
 
 This example uses python 3.13, but choose whichever version you want.


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
