### PR TITLE
Increase timeout for policy server requests

### DIFF
--- a/changelog.d/19629.bugfix
+++ b/changelog.d/19629.bugfix
@@ -1,0 +1,1 @@
+Increase timeout for policy server requests to avoid repeated requests for checking media.

--- a/synapse/handlers/room_policy.py
+++ b/synapse/handlers/room_policy.py
@@ -228,7 +228,7 @@ class RoomPolicyHandler:
             signature = await self._federation_client.ask_policy_server_to_sign_event(
                 policy_server.server_name,
                 event,
-                timeout=15000,
+                timeout=30000,
             )
             # TODO: We can *probably* remove this when we remove unstable MSC4284 support.
             # The server *should* be returning either a signature or an error, but there could

--- a/synapse/handlers/room_policy.py
+++ b/synapse/handlers/room_policy.py
@@ -228,7 +228,7 @@ class RoomPolicyHandler:
             signature = await self._federation_client.ask_policy_server_to_sign_event(
                 policy_server.server_name,
                 event,
-                timeout=3000,
+                timeout=15000,
             )
             # TODO: We can *probably* remove this when we remove unstable MSC4284 support.
             # The server *should* be returning either a signature or an error, but there could


### PR DESCRIPTION
This is to accommodate media scanning and checking. Currently, a 3s timeout means we make 2-5 requests before a media item is successfully scanned. 

Number chosen based on vibes and light real world testing.

Fixes https://github.com/matrix-org/policyserv/issues/108

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
