### PR TITLE
Fix docstring for `limit` argument in `_maybe_backfill_inner(...)`

### DIFF
--- a/changelog.d/19630.misc
+++ b/changelog.d/19630.misc
@@ -1,0 +1,1 @@
+Fix docstring for `limit` argument in `_maybe_backfill_inner(...)`.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -242,7 +242,9 @@ class FederationHandler:
         Args:
             room_id: The room to backfill in.
             current_depth: The depth to check at for any upcoming backfill points.
-            limit: The max number of events to request from the remote federated server.
+            limit: The number of events that the pagination request will
+                return. This is used as part of the heuristic to decide if we
+                should back paginate.
             processing_start_time: The time when `maybe_backfill` started processing.
                 Only used for timing. If `None`, no timing observation will be made.
 


### PR DESCRIPTION
Fix docstring for `limit` argument in `_maybe_backfill_inner(...)`.

Incorrectly labeled in https://github.com/matrix-org/synapse/pull/13535.

`maybe_backfill` already accurately describes `limit` (introduced in https://github.com/matrix-org/synapse/pull/8349)

Spotted in https://github.com/element-hq/synapse/pull/19611#discussion_r3011259710


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
