### PR TITLE
Document context for why increase timeout for policy server requests

### DIFF
--- a/changelog.d/19633.bugfix
+++ b/changelog.d/19633.bugfix
@@ -1,0 +1,1 @@
+Increase timeout for policy server requests to avoid repeated requests for checking media.

--- a/changelog.d/19633.bugfix
+++ b/changelog.d/19633.bugfix
@@ -1,1 +1,0 @@
-Increase timeout for policy server requests to avoid repeated requests for checking media.

--- a/changelog.d/19633.misc
+++ b/changelog.d/19633.misc
@@ -1,0 +1,1 @@
+Document context for why increase timeout for policy server requests.

--- a/synapse/handlers/room_policy.py
+++ b/synapse/handlers/room_policy.py
@@ -223,11 +223,16 @@ class RoomPolicyHandler:
             return
 
         # Ask the policy server to sign this event.
-        # We set a smallish timeout here as we don't want to block event sending too long.
         try:
             signature = await self._federation_client.ask_policy_server_to_sign_event(
                 policy_server.server_name,
                 event,
+                # We set a smallish timeout here as we don't want to block event sending
+                # too long.
+                #
+                # We were previously seeing regular timeouts with media
+                # scanning/checking when the timeout was set to 3s. 30s was chosen based
+                # on vibes and light real world testing.
                 timeout=30000,
             )
             # TODO: We can *probably* remove this when we remove unstable MSC4284 support.


### PR DESCRIPTION
Document context for why increase timeout for policy server requests

See https://github.com/element-hq/synapse/pull/19629#discussion_r3011377886

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
