### PR TITLE
Allow fully read markers to "go backwards"

### DIFF
--- a/changelog.d/19635.misc
+++ b/changelog.d/19635.misc
@@ -1,0 +1,1 @@
+Allow clients to set their user's `m.fully_read` marker back to older events.

--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -23,7 +23,6 @@ import logging
 from typing import TYPE_CHECKING
 
 from synapse.api.constants import ReceiptTypes
-from synapse.api.errors import SynapseError
 from synapse.util.async_helpers import Linearizer
 
 if TYPE_CHECKING:
@@ -55,25 +54,20 @@ class ReadMarkerHandler:
                 user_id, room_id, ReceiptTypes.FULLY_READ
             )
 
-            should_update = True
-            # Get event ordering, this also ensures we know about the event
-            event_ordering = await self.store.get_event_ordering(event_id, room_id)
+            # Ignore subsequent attempts to apply the same read marker.
+            if (
+                existing_read_marker is not None
+                and not isinstance(existing_read_marker.get("event_id"), str)
+                and event_id == existing_read_marker.get("event_id")
+            ):
+                return
 
-            if existing_read_marker:
-                try:
-                    old_event_ordering = await self.store.get_event_ordering(
-                        existing_read_marker["event_id"], room_id
-                    )
-                except SynapseError:
-                    # Old event no longer exists, assume new is ahead. This may
-                    # happen if the old event was removed due to retention.
-                    pass
-                else:
-                    # Only update if the new marker is ahead in the stream
-                    should_update = event_ordering > old_event_ordering
-
-            if should_update:
-                content = {"event_id": event_id}
-                await self.account_data_handler.add_account_data_to_room(
-                    user_id, room_id, ReceiptTypes.FULLY_READ, content
-                )
+            # Update the user's account data with the new read marker.
+            #
+            # Note: it's OK if this update refers to an *older* event than the
+            # previous read marker; a user may have accidentally marked some
+            # messages as read, and want to undo it.
+            content = {"event_id": event_id}
+            await self.account_data_handler.add_account_data_to_room(
+                user_id, room_id, ReceiptTypes.FULLY_READ, content
+            )


### PR DESCRIPTION
Allow `m.fully_read` markers to be updated to older events. Previously this was blocked if the update referred to an event that was older in terms of topological, then stream as a tie-breaker.

The spec does not forbid this behaviour, and a client developer would like to be able to do so to provide "undo" functionality for marking events as read.

This changed spawned from [a discussion](https://matrix.to/#/!nD4Jy1hp0We0VmIM9ubjqWLBX_uV8YlTBBPa3a_v2uk/$ygViA1BSCKBVPEwImy_7B6THCkgwUAAtZmlH8R2FH28?via=element.io&via=matrix.org&via=4d2.org) in #matrix-spec:matrix.org, where it was found that Synapse was the only homeserver to feature this block. Nobody could come up with a reason for it, and it has existed since the very early days of Synapse.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
