### PR TITLE
Run lint script to format Complement tests introduced in #19509

### DIFF
--- a/changelog.d/19636.misc
+++ b/changelog.d/19636.misc
@@ -1,0 +1,1 @@
+Run lint script to format Complement tests introduced in [#19509](https://github.com/element-hq/synapse/pull/19509).

--- a/complement/tests/internal/dockerutil/files.go
+++ b/complement/tests/internal/dockerutil/files.go
@@ -14,7 +14,13 @@ import (
 //
 // Internally, produces an uncompressed single-file tape archive (tar) that is sent to the docker
 // daemon to be unpacked into the container filesystem.
-func WriteFileIntoContainer(t *testing.T, docker *client.Client, containerID string, path string, data []byte) error {
+func WriteFileIntoContainer(
+	t *testing.T,
+	docker *client.Client,
+	containerID string,
+	path string,
+	data []byte,
+) error {
 	// Create a fake/virtual tar file in memory that we can copy to the container
 	// via https://stackoverflow.com/a/52131297/796832
 	var buf bytes.Buffer
@@ -25,7 +31,11 @@ func WriteFileIntoContainer(t *testing.T, docker *client.Client, containerID str
 		Size: int64(len(data)),
 	})
 	if err != nil {
-		return fmt.Errorf("WriteIntoContainer: failed to write tarball header for %s: %v", path, err)
+		return fmt.Errorf(
+			"WriteIntoContainer: failed to write tarball header for %s: %v",
+			path,
+			err,
+		)
 	}
 	_, err = tw.Write([]byte(data))
 	if err != nil {
@@ -34,7 +44,11 @@ func WriteFileIntoContainer(t *testing.T, docker *client.Client, containerID str
 
 	err = tw.Close()
 	if err != nil {
-		return fmt.Errorf("WriteIntoContainer: failed to close tarball writer for %s: %w", path, err)
+		return fmt.Errorf(
+			"WriteIntoContainer: failed to close tarball writer for %s: %w",
+			path,
+			err,
+		)
 	}
 
 	// Put our new fake file in the container volume

--- a/complement/tests/oidc_test.go
+++ b/complement/tests/oidc_test.go
@@ -93,7 +93,10 @@ func TestOIDCProviderUnavailable(t *testing.T) {
 		// by the user's browser in order to start the login flow.
 		queryParams := url.Values{}
 		queryParams.Add("redirectUrl", "http://redirect.invalid/redirect")
-		res := unauthedClient.Do(t, "GET", []string{"_matrix", "client", "v3", "login", "sso", "redirect", "oidc-test_provider"},
+		res := unauthedClient.Do(
+			t,
+			"GET",
+			[]string{"_matrix", "client", "v3", "login", "sso", "redirect", "oidc-test_provider"},
 			client.WithQueries(queryParams),
 		)
 


### PR DESCRIPTION
Run `poetry run ./scripts-dev/lint.sh` which exposed some formatted Complement tests that were introduced in https://github.com/element-hq/synapse/pull/19509

There is no CI for this so it's easy to miss.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
