### PR TITLE
Bail out if `admin_unsafely_bypass_quarantine` was used by a non-admin

### DIFF
--- a/changelog.d/19639.bugfix
+++ b/changelog.d/19639.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.145 where a non-admin could bypass admin checks for downloading remote quarantined media. This relied on the media already being previously present on the homeserver.

--- a/synapse/rest/client/media.py
+++ b/synapse/rest/client/media.py
@@ -253,6 +253,7 @@ class DownloadResource(RestServlet):
                     ),
                     send_cors=True,
                 )
+                return
 
         set_cors_headers(request)
         set_corp_headers(request)

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -18,6 +18,7 @@
 # [This file includes modifications made by New Vector Limited]
 #
 #
+from __future__ import annotations
 
 import urllib.parse
 from typing import Any, cast

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -20,10 +20,12 @@
 #
 
 import urllib.parse
-from typing import cast
+from typing import Any, cast
+from unittest.mock import Mock
 
 from parameterized import parameterized
 
+from twisted.internet.defer import Deferred
 from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
@@ -69,6 +71,24 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
         resources = super().create_resource_dict()
         resources["/_matrix/media"] = self.hs.get_media_repository_resource()
         return resources
+
+    def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
+        self.fetches: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+        # A remote fetch of media that was not intentional.
+        # Used to check that remote media fetches do NOT happen.
+        def unexpected_remote_fetch(*args: Any, **kwargs: Any) -> Deferred[Any]:
+            self.fetches.append((args, kwargs))
+            return Deferred()
+
+        client = Mock()
+        client.federation_get_file = unexpected_remote_fetch
+        client.get_file = unexpected_remote_fetch
+
+        return self.setup_test_homeserver(
+            clock=clock,
+            federation_http_client=client,
+        )
 
     def _ensure_quarantined(
         self,
@@ -175,6 +195,28 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
                 % server_name_and_media_id
             ),
         )
+
+    def test_non_admin_bypass_does_not_fetch_remote_media(self) -> None:
+        self.register_user("nonadmin", "pass", admin=False)
+        non_admin_user_tok = self.login("nonadmin", "pass")
+
+        channel = self.make_request(
+            "GET",
+            "/_matrix/client/v1/media/download/example.com/remote_media"
+            "?admin_unsafely_bypass_quarantine=true",
+            shorthand=False,
+            access_token=non_admin_user_tok,
+            await_result=False,
+        )
+        self.pump()
+
+        self.assertEqual(400, channel.code, msg=channel.json_body)
+        self.assertEqual(
+            channel.json_body["error"],
+            "Must be a server admin to bypass quarantine",
+        )
+        # Check that a remote fetch attempt did not occur.
+        self.assertEqual(self.fetches, [])
 
     @parameterized.expand(
         [


### PR DESCRIPTION
Previously the code would send an error back to the client, but would continue executing and fetch the remote media anyhow.

This isn't too much of an issue, as remote media must already be cached locally in order to quarantine it in the first place.

Introduced in https://github.com/element-hq/synapse/pull/19275

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
