### PR TITLE
Fix Docker image link typo in worker docs

### DIFF
--- a/changelog.d/19645.doc
+++ b/changelog.d/19645.doc
@@ -1,0 +1,1 @@
+Fix Docker image link typo in worker docs.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -60,10 +60,10 @@ virtualenv, these can be installed with:
 pip install "matrix-synapse[redis]"
 ```
 
-Note that these dependencies are included when synapse is installed with `pip
-install matrix-synapse[all]`. They are also included in the debian packages from
-`packages.matrix.org` and in the docker images at
-https://hub.docker.com/r/ectorim/synapse/.
+Note that these dependencies are included when Synapse is installed with `pip install
+matrix-synapse[all]`. They are also included in the [Debian
+packages](setup/installation.md#debianubuntu) and in the [Docker
+images](setup/installation.md#docker-images-and-ansible-playbooks).
 
 To make effective use of the workers, you will need to configure an HTTP
 reverse-proxy such as nginx or haproxy, which will direct incoming requests to


### PR DESCRIPTION
Fix Docker image link typo in worker docs

Fix https://github.com/element-hq/synapse/issues/19521

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
