### PR TITLE
Add optional Cloudflare TURN credential fetching

### DIFF
--- a/.github/workflows/rebase-cf-turn.yml
+++ b/.github/workflows/rebase-cf-turn.yml
@@ -1,0 +1,175 @@
+name: Rebase CF-TURN branch onto develop
+
+on:
+  push:
+    branches:
+      - develop          # 每次你同步上游 push 到 develop 时触发
+  workflow_dispatch:     # 也支持手动触发
+    inputs:
+      dry_run:
+        description: "Dry run（只检查，不推送）"
+        type: boolean
+        default: false
+
+jobs:
+  rebase:
+    name: Rebase kakahu/cloudflare-turn-18472 → develop
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write      # 需要推送分支
+      issues: write        # 冲突时开 Issue
+
+    env:
+      PATCH_BRANCH: kakahu/cloudflare-turn-18472
+      BASE_BRANCH: develop
+
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch patch branch
+        run: git fetch origin "$PATCH_BRANCH"
+
+      - name: Check if rebase is needed
+        id: check
+        run: |
+          BASE_SHA=$(git rev-parse origin/$BASE_BRANCH)
+          PATCH_SHA=$(git rev-parse origin/$PATCH_BRANCH)
+          MERGE_BASE=$(git merge-base "$BASE_SHA" "$PATCH_SHA")
+
+          echo "base_sha=$BASE_SHA"         >> "$GITHUB_OUTPUT"
+          echo "patch_sha=$PATCH_SHA"        >> "$GITHUB_OUTPUT"
+          echo "merge_base=$MERGE_BASE"      >> "$GITHUB_OUTPUT"
+
+          if [ "$MERGE_BASE" = "$BASE_SHA" ]; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "✅ 补丁分支已是最新，无需 rebase"
+          else
+            BEHIND=$(git rev-list --count "$PATCH_SHA".."$BASE_SHA")
+            echo "needed=true"  >> "$GITHUB_OUTPUT"
+            echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
+            echo "📦 补丁分支落后 $BEHIND 个 commit，需要 rebase"
+          fi
+
+      - name: Perform rebase
+        if: steps.check.outputs.needed == 'true'
+        id: rebase
+        run: |
+          git checkout -b "$PATCH_BRANCH" "origin/$PATCH_BRANCH"
+
+          # 记录 rebase 前补丁 commit 数量
+          PATCH_COUNT=$(git rev-list --count "origin/$BASE_BRANCH"..HEAD)
+          echo "patch_count=$PATCH_COUNT" >> "$GITHUB_OUTPUT"
+
+          # 执行 rebase，失败时捕获冲突信息
+          if git rebase "origin/$BASE_BRANCH"; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "✅ Rebase 成功"
+          else
+            # 收集冲突文件列表
+            CONFLICTS=$(git diff --name-only --diff-filter=U | head -20 | tr '\n' ' ')
+            echo "status=conflict"      >> "$GITHUB_OUTPUT"
+            echo "conflicts=$CONFLICTS" >> "$GITHUB_OUTPUT"
+            git rebase --abort
+            echo "❌ Rebase 冲突：$CONFLICTS"
+            exit 1
+          fi
+
+      - name: Push rebased branch
+        if: >
+          steps.check.outputs.needed == 'true' &&
+          steps.rebase.outputs.status == 'success' &&
+          inputs.dry_run != 'true'
+        run: |
+          git push origin "$PATCH_BRANCH" --force-with-lease
+          echo "🚀 已推送 $PATCH_BRANCH"
+
+      - name: Dry run summary
+        if: inputs.dry_run == 'true' && steps.rebase.outputs.status == 'success'
+        run: |
+          echo "### Dry Run 结果" >> "$GITHUB_STEP_SUMMARY"
+          echo "- 补丁分支落后：${{ steps.check.outputs.behind }} 个 commit" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Rebase 测试：✅ 无冲突" >> "$GITHUB_STEP_SUMMARY"
+          echo "- 补丁数量：${{ steps.rebase.outputs.patch_count }} 个 commit" >> "$GITHUB_STEP_SUMMARY"
+          echo "- 实际推送：跳过（dry run 模式）" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Write success summary
+        if: steps.rebase.outputs.status == 'success' && inputs.dry_run != 'true'
+        run: |
+          NEW_SHA=$(git rev-parse HEAD)
+          echo "### ✅ Rebase 成功" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 项目 | 值 |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|----|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 基准分支 | \`$BASE_BRANCH\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 补丁分支 | \`$PATCH_BRANCH\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 落后 commit 数 | ${{ steps.check.outputs.behind }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 补丁 commit 数 | ${{ steps.rebase.outputs.patch_count }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 新 HEAD | \`${NEW_SHA:0:8}\` |" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open conflict issue
+        if: failure() && steps.rebase.outputs.status == 'conflict'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const behind   = '${{ steps.check.outputs.behind }}';
+            const conflicts = '${{ steps.rebase.outputs.conflicts }}';
+            const baseRef  = process.env.BASE_BRANCH;
+            const patchRef = process.env.PATCH_BRANCH;
+            const runUrl   = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // 检查是否已有同名未关闭 Issue，避免重复
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              state: 'open',
+              labels: 'patch-conflict',
+            });
+
+            if (issues.length > 0) {
+              // 已有 Issue，追加评论
+              await github.rest.issues.createComment({
+                owner:      context.repo.owner,
+                repo:       context.repo.repo,
+                issue_number: issues[0].number,
+                body: `## 🔄 新一轮冲突（${new Date().toISOString().slice(0,10)}）\n\n` +
+                      `- 基准分支落后：**${behind} 个 commit**\n` +
+                      `- 冲突文件：\`${conflicts}\`\n` +
+                      `- [查看本次 Action 日志](${runUrl})`,
+              });
+              console.log(`已追加评论到 Issue #${issues[0].number}`);
+            } else {
+              // 新建 Issue
+              await github.rest.issues.create({
+                owner:  context.repo.owner,
+                repo:   context.repo.repo,
+                title:  `⚠️ CF-TURN 补丁 rebase 冲突 — 需要手动处理`,
+                labels: ['patch-conflict'],
+                body:
+                  `## CF-TURN 补丁与上游 \`${baseRef}\` 发生冲突\n\n` +
+                  `本次自动 rebase 失败，需要你手动解决。\n\n` +
+                  `### 冲突详情\n` +
+                  `- **基准分支**：\`${baseRef}\`（上游 develop）\n` +
+                  `- **补丁分支**：\`${patchRef}\`\n` +
+                  `- **落后 commit 数**：${behind}\n` +
+                  `- **冲突文件**：\`${conflicts}\`\n\n` +
+                  `### 手动解决步骤\n` +
+                  `\`\`\`bash\n` +
+                  `git fetch origin\n` +
+                  `git checkout ${patchRef}\n` +
+                  `git rebase origin/${baseRef}\n` +
+                  `# 解决冲突后：\n` +
+                  `git add <冲突文件>\n` +
+                  `git rebase --continue\n` +
+                  `git push origin ${patchRef} --force-with-lease\n` +
+                  `\`\`\`\n\n` +
+                  `[查看 Action 日志](${runUrl})`,
+              });
+            }

--- a/.pr-body-cloudflare-turn.md
+++ b/.pr-body-cloudflare-turn.md
@@ -1,0 +1,135 @@
+## Summary
+
+This adds optional support for fetching short-lived TURN credentials from Cloudflare Realtime TURN via Synapse's existing `/_matrix/client/*/voip/turnServer` endpoint.
+
+Clients do not need any Cloudflare-specific changes: Synapse performs the Cloudflare API request server-side and returns the usual Matrix TURN response shape (`username`, `password`, `ttl`, `uris`).
+
+## Why
+
+Today Synapse supports:
+- shared-secret TURN credentials (`turn_shared_secret`)
+- static username/password TURN credentials (`turn_username` / `turn_password`)
+
+That works well for self-hosted TURN servers such as coturn or eturnal, but it does not cover providers like Cloudflare Realtime TURN, where Synapse needs to call an API to mint short-lived credentials.
+
+This is useful for deployments that want:
+- globally distributed TURN ingress without operating their own TURN fleet
+- a managed TURN service with short-lived credentials
+- lower operational overhead while keeping the existing Matrix client flow
+
+## What this PR changes
+
+### New configuration
+
+Adds optional Cloudflare-specific settings:
+- `turn_cloudflare_enabled`
+- `turn_cloudflare_key_id`
+- `turn_cloudflare_api_token`
+- `turn_cloudflare_api_token_path`
+- `turn_cloudflare_api_base_url`
+
+Adds optional broker-specific settings for federated deployments:
+- `turn_federation_deployment`
+- `turn_broker_url`
+- `turn_broker_api_token`
+- `turn_broker_api_token_path`
+
+Adds a `turn_mode` setting to explicitly select the TURN credential source:
+- `coturn` (default): use local CoTURN directly. Backward compatible — no behaviour change if unset.
+- `cf`: fetch credentials from Cloudflare Realtime TURN.
+- `broker`: fetch credentials from a federated TURN broker.
+
+### Request flow
+
+When `turn_mode: cf` is configured:
+1. Synapse receives `/_matrix/client/*/voip/turnServer`
+2. Synapse calls Cloudflare's TURN credential API server-side
+3. Synapse converts the Cloudflare response into the existing Matrix TURN response format
+4. Clients continue to consume the standard Matrix endpoint unchanged
+
+When `turn_mode: broker` is configured:
+1. Synapse receives `/_matrix/client/*/voip/turnServer`
+2. Synapse calls a configured TURN broker instead of calling Cloudflare directly
+3. The broker returns the same Matrix TURN response shape (`username`, `password`, `ttl`, `uris`)
+4. Clients continue to consume the standard Matrix endpoint unchanged
+
+When `turn_mode: coturn` (default) is configured:
+1. Synapse uses the existing `turn_uris` / `turn_shared_secret` or `turn_username` / `turn_password` flow as before.
+2. This is fully backward compatible.
+
+### Port 53 filtering
+
+Cloudflare documents that alternate port 53 TURN URLs may time out in browsers.
+This PR filters `turn:` / `turns:` URLs on port `53` before returning credentials to clients, while preserving the primary ports (`3478`, `80`, `443`, `5349`).
+
+## Security / operational notes
+
+- The Cloudflare API token can be loaded from `turn_cloudflare_api_token_path`, which is the recommended deployment mode.
+- The broker token can be loaded from `turn_broker_api_token_path`, which is the recommended deployment mode for broker deployments.
+- The implementation keeps both tokens on the server side; they are never exposed to Matrix clients.
+- `turn_user_lifetime` continues to control the returned TTL and is reused for Cloudflare or broker credential requests.
+
+## Documentation
+
+This PR updates:
+- TURN configuration reference
+- TURN how-to documentation
+
+The docs explicitly describe:
+- the server-side-only nature of the integration
+- recommended use of `turn_cloudflare_api_token_path`
+- filtering of Cloudflare's alternate port 53 TURN URLs
+
+## Tests
+
+Adds coverage for:
+- parsing Cloudflare TURN responses
+- validating broker TURN responses
+- filtering port 53 TURN URLs
+- rejecting mismatched multiple credential sets
+- successful Cloudflare-backed responses
+- successful broker-backed responses in federated mode
+- ignoring broker settings unless federated mode is explicitly enabled
+- config loading / secret file handling for the new options
+
+## Example config
+
+### Cloudflare TURN mode
+
+```yaml
+turn_mode: cf
+turn_cloudflare_enabled: true
+turn_cloudflare_key_id: YOUR_CLOUDFLARE_TURN_KEY_ID
+turn_cloudflare_api_token_path: /path/to/turn-cloudflare-api-token
+turn_user_lifetime: 1h
+```
+
+### Federation broker mode
+
+```yaml
+turn_mode: broker
+turn_federation_deployment: true
+turn_broker_url: https://turn-broker.example.com/credentials
+turn_broker_api_token_path: /path/to/turn-broker-api-token
+turn_user_lifetime: 1h
+```
+
+### Local CoTURN only (default, backward compatible)
+
+```yaml
+# turn_mode: coturn  (optional, this is the default)
+turn_uris:
+  - turn:coturn.example.com:3478?transport=udp
+turn_shared_secret: YOUR_SECRET
+turn_user_lifetime: 1h
+```
+
+## Reference TURN broker implementations
+
+Two reference implementations are provided:
+
+- **VPS / Docker**: <https://github.com/kakahu2015/synapse-turn-broker>
+  Python + Redis, self-hosted on a VPS behind Caddy/nginx.
+
+- **Cloudflare Workers**: <https://github.com/kakahu2015/synapse-turn-broker-worker>
+  JavaScript + Cloudflare KV, serverless deployment on Cloudflare edge. Zero server maintenance, free tier friendly.

--- a/changelog.d/18472.feature
+++ b/changelog.d/18472.feature
@@ -1,0 +1,1 @@
+Add optional Cloudflare TURN credential fetching for `/_matrix/client/*/voip/turnServer`, with automatic fallback to the existing TURN configuration.

--- a/changelog.d/18472.feature
+++ b/changelog.d/18472.feature
@@ -1,1 +1,1 @@
-Add optional Cloudflare TURN credential fetching for `/_matrix/client/*/voip/turnServer`, with automatic fallback to the existing TURN configuration.
+Add optional Cloudflare TURN credential fetching for `/_matrix/client/*/voip/turnServer`, plus an optional TURN broker mode for federated deployments, with automatic fallback to the existing TURN configuration.

--- a/docs/turn-howto.md
+++ b/docs/turn-howto.md
@@ -14,6 +14,12 @@ This documentation provides two TURN server configuration examples:
 * [coturn](setup/turn/coturn.md)
 * [eturnal](setup/turn/eturnal.md)
 
+Synapse can also fetch short-lived credentials from Cloudflare Realtime TURN.
+In that setup, Synapse requests temporary TURN credentials from Cloudflare on
+behalf of Matrix clients and returns them through the existing
+`/_matrix/client/*/voip/turnServer` endpoint, so clients do not need any
+Cloudflare-specific changes.
+
 ## Requirements
 
 For TURN relaying to work, the TURN service must be hosted on a server/endpoint with a public IP.
@@ -39,6 +45,24 @@ As an example, here is the relevant section of the config file for `matrix.org`.
     turn_shared_secret: "n0t4ctuAllymatr1Xd0TorgSshar3d5ecret4obvIousreAsons"
     turn_user_lifetime: 86400000
     turn_allow_guests: true
+
+If you are using Cloudflare Realtime TURN instead of a self-hosted TURN server,
+configure Synapse with:
+
+    turn_cloudflare_enabled: true
+    turn_cloudflare_key_id: YOUR_CLOUDFLARE_TURN_KEY_ID
+    turn_cloudflare_api_token_path: /path/to/turn-cloudflare-api-token
+    turn_user_lifetime: 1h
+
+Using `turn_cloudflare_api_token_path` is recommended over putting the API token
+inline in the homeserver configuration. If you already operate a self-hosted
+TURN server, you can keep the existing `turn_uris` / shared-secret settings in
+place. Synapse will try Cloudflare first and fall back to the existing TURN
+configuration if Cloudflare credential generation fails.
+
+Cloudflare may return alternate port 53 TURN URLs in addition to the primary
+ports. Synapse filters those `:53` TURN URLs before returning credentials to
+clients, since browsers often time out on that port.
 
 After updating the homeserver configuration, you must restart synapse:
 

--- a/docs/turn-howto.md
+++ b/docs/turn-howto.md
@@ -46,9 +46,22 @@ As an example, here is the relevant section of the config file for `matrix.org`.
     turn_user_lifetime: 86400000
     turn_allow_guests: true
 
+### TURN mode selection
+
+Synapse supports three TURN credential modes via the `turn_mode` config option:
+
+- **`coturn`** (default): Use local CoTURN directly. Fully backward compatible.
+- **`cf`**: Fetch credentials from Cloudflare Realtime TURN. Falls back to local
+  CoTURN if Cloudflare credential generation fails.
+- **`broker`**: Fetch credentials from a federated TURN broker. Falls back to
+  local CoTURN if the broker is unreachable.
+
+### Cloudflare TURN mode
+
 If you are using Cloudflare Realtime TURN instead of a self-hosted TURN server,
 configure Synapse with:
 
+    turn_mode: cf
     turn_cloudflare_enabled: true
     turn_cloudflare_key_id: YOUR_CLOUDFLARE_TURN_KEY_ID
     turn_cloudflare_api_token_path: /path/to/turn-cloudflare-api-token
@@ -60,21 +73,24 @@ TURN server, you can keep the existing `turn_uris` / shared-secret settings in
 place. Synapse will try Cloudflare first and fall back to the existing TURN
 configuration if Cloudflare credential generation fails.
 
+### Federation broker mode
+
 If you operate multiple federated homeservers and want them to fetch the same
 shared TURN credentials for a short time window, configure those homeservers to
 use a TURN broker instead of calling Cloudflare directly:
 
+    turn_mode: broker
     turn_federation_deployment: true
     turn_broker_url: https://turn-broker.example.com/credentials
     turn_broker_api_token_path: /path/to/turn-broker-api-token
     turn_user_lifetime: 1h
 
-When `turn_federation_deployment` is enabled, Synapse fetches TURN credentials
+When `turn_mode: broker` is enabled, Synapse fetches TURN credentials
 from `turn_broker_url` and authenticates using
-`turn_broker_api_token` / `turn_broker_api_token_path`. In this mode Synapse
-skips the direct Cloudflare request path for that homeserver. If
-`turn_broker_url` is set without enabling `turn_federation_deployment`, it is
-ignored.
+`turn_broker_api_token` / `turn_broker_api_token_path`. If the broker request
+fails, Synapse falls back to the existing local TURN configuration.
+
+If `turn_broker_url` is set without `turn_mode: broker`, it is ignored.
 
 Cloudflare may return alternate port 53 TURN URLs in addition to the primary
 ports. Synapse filters those `:53` TURN URLs before returning credentials to

--- a/docs/turn-howto.md
+++ b/docs/turn-howto.md
@@ -60,6 +60,22 @@ TURN server, you can keep the existing `turn_uris` / shared-secret settings in
 place. Synapse will try Cloudflare first and fall back to the existing TURN
 configuration if Cloudflare credential generation fails.
 
+If you operate multiple federated homeservers and want them to fetch the same
+shared TURN credentials for a short time window, configure those homeservers to
+use a TURN broker instead of calling Cloudflare directly:
+
+    turn_federation_deployment: true
+    turn_broker_url: https://turn-broker.example.com/credentials
+    turn_broker_api_token_path: /path/to/turn-broker-api-token
+    turn_user_lifetime: 1h
+
+When `turn_federation_deployment` is enabled, Synapse fetches TURN credentials
+from `turn_broker_url` and authenticates using
+`turn_broker_api_token` / `turn_broker_api_token_path`. In this mode Synapse
+skips the direct Cloudflare request path for that homeserver. If
+`turn_broker_url` is set without enabling `turn_federation_deployment`, it is
+ignored.
+
 Cloudflare may return alternate port 53 TURN URLs in addition to the primary
 ports. Synapse filters those `:53` TURN URLs before returning credentials to
 clients, since browsers often time out on that port.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -2653,6 +2653,46 @@ Example configuration:
 turn_cloudflare_api_base_url: https://rtc.live.cloudflare.com/v1
 ```
 ---
+### `turn_federation_deployment`
+
+*(boolean)* Whether this homeserver is part of a federated deployment that should fetch TURN credentials from a shared TURN broker instead of calling Cloudflare directly. If false, `turn_broker_url` is ignored. Defaults to `false`.
+
+Example configuration:
+```yaml
+turn_federation_deployment: true
+```
+---
+### `turn_broker_url`
+
+*(string|null)* The URL of a TURN broker endpoint that returns Matrix-style TURN credentials (`username`, `password`, `ttl`, `uris`). This is only used when `turn_federation_deployment` is true. Defaults to `null`.
+
+Example configuration:
+```yaml
+turn_broker_url: https://turn-broker.example.com/credentials
+```
+---
+### `turn_broker_api_token`
+
+*(string|null)* The Bearer token used to authenticate requests to the TURN broker. This is only used when `turn_federation_deployment` is true. Defaults to `null`.
+
+Example configuration:
+```yaml
+turn_broker_api_token: YOUR_TURN_BROKER_API_TOKEN
+```
+---
+### `turn_broker_api_token_path`
+
+*(string|null)* An alternative to [`turn_broker_api_token`](#turn_broker_api_token): allows the TURN broker API token to be specified in an external file.
+
+The file should be a plain text file, containing only the token. Synapse reads the token from the given file once at startup.
+
+Defaults to `null`.
+
+Example configuration:
+```yaml
+turn_broker_api_token_path: /path/to/secrets/file
+```
+---
 ### `matrix_rtc`
 
 *(object)* Options related to MatrixRTC. Defaults to `{}`.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -2604,9 +2604,21 @@ Example configuration:
 turn_allow_guests: false
 ```
 ---
+### `turn_mode`
+
+*(string)* Selects the TURN credential source. Valid values:
+- `coturn` (default): use local CoTURN directly. Backward compatible.
+- `cf`: fetch credentials from Cloudflare Realtime TURN, falling back to local CoTURN on failure.
+- `broker`: fetch credentials from a federated TURN broker, falling back to local CoTURN on failure.
+
+Example configuration:
+```yaml
+turn_mode: cf
+```
+---
 ### `turn_cloudflare_enabled`
 
-*(boolean)* Whether to fetch dynamic TURN credentials from Cloudflare's TURN API before falling back to the locally configured TURN server. Defaults to `false`.
+*(boolean)* Whether to fetch dynamic TURN credentials from Cloudflare's TURN API. This must be set to `true` when `turn_mode` is `cf`. Defaults to `false`.
 
 Example configuration:
 ```yaml
@@ -2655,7 +2667,7 @@ turn_cloudflare_api_base_url: https://rtc.live.cloudflare.com/v1
 ---
 ### `turn_federation_deployment`
 
-*(boolean)* Whether this homeserver is part of a federated deployment that should fetch TURN credentials from a shared TURN broker instead of calling Cloudflare directly. If false, `turn_broker_url` is ignored. Defaults to `false`.
+*(boolean)* Whether this homeserver is part of a federated deployment that should fetch TURN credentials from a shared TURN broker. This must be set to `true` when `turn_mode` is `broker`. If false, `turn_broker_url` is ignored. Defaults to `false`.
 
 Example configuration:
 ```yaml

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -2604,6 +2604,55 @@ Example configuration:
 turn_allow_guests: false
 ```
 ---
+### `turn_cloudflare_enabled`
+
+*(boolean)* Whether to fetch dynamic TURN credentials from Cloudflare's TURN API before falling back to the locally configured TURN server. Defaults to `false`.
+
+Example configuration:
+```yaml
+turn_cloudflare_enabled: true
+```
+---
+### `turn_cloudflare_key_id`
+
+*(string|null)* The Cloudflare TURN key ID used to generate short-lived ICE server credentials. Defaults to `null`.
+
+Example configuration:
+```yaml
+turn_cloudflare_key_id: YOUR_CLOUDFLARE_TURN_KEY_ID
+```
+---
+### `turn_cloudflare_api_token`
+
+*(string|null)* The Cloudflare API token used to request short-lived TURN credentials. Defaults to `null`.
+
+Example configuration:
+```yaml
+turn_cloudflare_api_token: YOUR_CLOUDFLARE_API_TOKEN
+```
+---
+### `turn_cloudflare_api_token_path`
+
+*(string|null)* An alternative to [`turn_cloudflare_api_token`](#turn_cloudflare_api_token): allows the Cloudflare API token to be specified in an external file.
+
+The file should be a plain text file, containing only the API token. Synapse reads the token from the given file once at startup.
+
+Defaults to `null`.
+
+Example configuration:
+```yaml
+turn_cloudflare_api_token_path: /path/to/secrets/file
+```
+---
+### `turn_cloudflare_api_base_url`
+
+*(string)* The base URL for Cloudflare's TURN credential API. Defaults to `https://rtc.live.cloudflare.com/v1`.
+
+Example configuration:
+```yaml
+turn_cloudflare_api_base_url: https://rtc.live.cloudflare.com/v1
+```
+---
 ### `matrix_rtc`
 
 *(object)* Options related to MatrixRTC. Defaults to `{}`.

--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -2917,6 +2917,47 @@ properties:
     default: true
     examples:
       - false
+  turn_cloudflare_enabled:
+    type: boolean
+    description: >-
+      Whether to fetch dynamic TURN credentials from Cloudflare's TURN API
+      before falling back to the locally configured TURN server.
+    default: false
+    examples:
+      - true
+  turn_cloudflare_key_id:
+    type: ["string", "null"]
+    description: >-
+      The Cloudflare TURN key ID used to generate short-lived ICE server
+      credentials.
+    default: null
+    examples:
+      - YOUR_CLOUDFLARE_TURN_KEY_ID
+  turn_cloudflare_api_token:
+    type: ["string", "null"]
+    description: >-
+      The Cloudflare API token used to request short-lived TURN credentials.
+    default: null
+    examples:
+      - YOUR_CLOUDFLARE_API_TOKEN
+  turn_cloudflare_api_token_path:
+    type: ["string", "null"]
+    description: >-
+      An alternative to [`turn_cloudflare_api_token`](#turn_cloudflare_api_token):
+      allows the Cloudflare API token to be specified in an external file.
+
+
+      The file should be a plain text file, containing only the API token.
+      Synapse reads the token from the given file once at startup.
+    default: null
+    examples:
+      - /path/to/secrets/file
+  turn_cloudflare_api_base_url:
+    type: string
+    description: The base URL for Cloudflare's TURN credential API.
+    default: https://rtc.live.cloudflare.com/v1
+    examples:
+      - https://rtc.live.cloudflare.com/v1
   matrix_rtc:
     type: object 
     description: >-

--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -2958,6 +2958,44 @@ properties:
     default: https://rtc.live.cloudflare.com/v1
     examples:
       - https://rtc.live.cloudflare.com/v1
+  turn_federation_deployment:
+    type: boolean
+    description: >-
+      Whether this homeserver is part of a federated deployment that should
+      fetch TURN credentials from a shared TURN broker instead of calling
+      Cloudflare directly. If false, `turn_broker_url` is ignored.
+    default: false
+    examples:
+      - true
+  turn_broker_url:
+    type: ["string", "null"]
+    description: >-
+      The URL of a TURN broker endpoint that returns Matrix-style TURN
+      credentials (`username`, `password`, `ttl`, `uris`). This is only used
+      when `turn_federation_deployment` is true.
+    default: null
+    examples:
+      - https://turn-broker.example.com/credentials
+  turn_broker_api_token:
+    type: ["string", "null"]
+    description: >-
+      The Bearer token used to authenticate requests to the TURN broker.
+      This is only used when `turn_federation_deployment` is true.
+    default: null
+    examples:
+      - YOUR_TURN_BROKER_API_TOKEN
+  turn_broker_api_token_path:
+    type: ["string", "null"]
+    description: >-
+      An alternative to [`turn_broker_api_token`](#turn_broker_api_token):
+      allows the TURN broker API token to be specified in an external file.
+
+
+      The file should be a plain text file, containing only the token.
+      Synapse reads the token from the given file once at startup.
+    default: null
+    examples:
+      - /path/to/secrets/file
   matrix_rtc:
     type: object 
     description: >-

--- a/synapse/config/voip.py
+++ b/synapse/config/voip.py
@@ -30,6 +30,12 @@ You have configured both `turn_shared_secret` and `turn_shared_secret_path`.
 These are mutually incompatible.
 """
 
+CONFLICTING_CLOUDFLARE_API_TOKEN_OPTS_ERROR = """\
+You have configured both `turn_cloudflare_api_token` and
+`turn_cloudflare_api_token_path`.
+These are mutually incompatible.
+"""
+
 
 class VoipConfig(Config):
     section = "voip"
@@ -57,3 +63,41 @@ class VoipConfig(Config):
             config.get("turn_user_lifetime", "1h")
         )
         self.turn_allow_guests = config.get("turn_allow_guests", True)
+
+        self.turn_cloudflare_enabled = config.get("turn_cloudflare_enabled", False)
+        self.turn_cloudflare_key_id = config.get("turn_cloudflare_key_id")
+        self.turn_cloudflare_api_token = config.get("turn_cloudflare_api_token")
+        if self.turn_cloudflare_api_token and not allow_secrets_in_config:
+            raise ConfigError(
+                "Config options that expect an in-line secret as value are disabled",
+                ("turn_cloudflare_api_token",),
+            )
+
+        turn_cloudflare_api_token_path = config.get("turn_cloudflare_api_token_path")
+        if turn_cloudflare_api_token_path:
+            if self.turn_cloudflare_api_token:
+                raise ConfigError(CONFLICTING_CLOUDFLARE_API_TOKEN_OPTS_ERROR)
+
+            self.turn_cloudflare_api_token = read_file(
+                turn_cloudflare_api_token_path,
+                ("turn_cloudflare_api_token_path",),
+            ).strip()
+
+        self.turn_cloudflare_api_base_url = config.get(
+            "turn_cloudflare_api_base_url", "https://rtc.live.cloudflare.com/v1"
+        ).rstrip("/")
+
+        if self.turn_cloudflare_enabled and not self.turn_cloudflare_key_id:
+            raise ConfigError(
+                "`turn_cloudflare_key_id` is required when "
+                "`turn_cloudflare_enabled` is true",
+                ("turn_cloudflare_key_id",),
+            )
+
+        if self.turn_cloudflare_enabled and not self.turn_cloudflare_api_token:
+            raise ConfigError(
+                "One of `turn_cloudflare_api_token` or "
+                "`turn_cloudflare_api_token_path` is required when "
+                "`turn_cloudflare_enabled` is true",
+                ("turn_cloudflare_api_token",),
+            )

--- a/synapse/config/voip.py
+++ b/synapse/config/voip.py
@@ -96,6 +96,7 @@ class VoipConfig(Config):
         self.turn_federation_deployment = config.get(
             "turn_federation_deployment", False
         )
+        self.turn_mode = config.get("turn_mode", "coturn")
         self.turn_broker_url = config.get("turn_broker_url")
         self.turn_broker_api_token = config.get("turn_broker_api_token")
         if self.turn_broker_api_token and not allow_secrets_in_config:

--- a/synapse/config/voip.py
+++ b/synapse/config/voip.py
@@ -36,6 +36,12 @@ You have configured both `turn_cloudflare_api_token` and
 These are mutually incompatible.
 """
 
+CONFLICTING_TURN_BROKER_API_TOKEN_OPTS_ERROR = """\
+You have configured both `turn_broker_api_token` and
+`turn_broker_api_token_path`.
+These are mutually incompatible.
+"""
+
 
 class VoipConfig(Config):
     section = "voip"
@@ -87,6 +93,27 @@ class VoipConfig(Config):
             "turn_cloudflare_api_base_url", "https://rtc.live.cloudflare.com/v1"
         ).rstrip("/")
 
+        self.turn_federation_deployment = config.get(
+            "turn_federation_deployment", False
+        )
+        self.turn_broker_url = config.get("turn_broker_url")
+        self.turn_broker_api_token = config.get("turn_broker_api_token")
+        if self.turn_broker_api_token and not allow_secrets_in_config:
+            raise ConfigError(
+                "Config options that expect an in-line secret as value are disabled",
+                ("turn_broker_api_token",),
+            )
+
+        turn_broker_api_token_path = config.get("turn_broker_api_token_path")
+        if turn_broker_api_token_path:
+            if self.turn_broker_api_token:
+                raise ConfigError(CONFLICTING_TURN_BROKER_API_TOKEN_OPTS_ERROR)
+
+            self.turn_broker_api_token = read_file(
+                turn_broker_api_token_path,
+                ("turn_broker_api_token_path",),
+            ).strip()
+
         if self.turn_cloudflare_enabled and not self.turn_cloudflare_key_id:
             raise ConfigError(
                 "`turn_cloudflare_key_id` is required when "
@@ -100,4 +127,18 @@ class VoipConfig(Config):
                 "`turn_cloudflare_api_token_path` is required when "
                 "`turn_cloudflare_enabled` is true",
                 ("turn_cloudflare_api_token",),
+            )
+
+        if self.turn_federation_deployment and not self.turn_broker_url:
+            raise ConfigError(
+                "`turn_broker_url` is required when "
+                "`turn_federation_deployment` is true",
+                ("turn_broker_url",),
+            )
+
+        if self.turn_federation_deployment and not self.turn_broker_api_token:
+            raise ConfigError(
+                "One of `turn_broker_api_token` or `turn_broker_api_token_path` "
+                "is required when `turn_federation_deployment` is true",
+                ("turn_broker_api_token",),
             )

--- a/synapse/rest/client/voip.py
+++ b/synapse/rest/client/voip.py
@@ -22,8 +22,11 @@
 import base64
 import hashlib
 import hmac
+import logging
 from typing import TYPE_CHECKING
+from urllib.parse import quote
 
+from synapse.http.client import SimpleHttpClient
 from synapse.http.server import HttpServer
 from synapse.http.servlet import RestServlet
 from synapse.http.site import SynapseRequest
@@ -34,6 +37,67 @@ if TYPE_CHECKING:
     from synapse.server import HomeServer
 
 
+logger = logging.getLogger(__name__)
+
+
+def _parse_cloudflare_turn_response(response: JsonDict, ttl: int) -> JsonDict:
+    """Convert Cloudflare TURN API credentials into the Matrix VoIP response shape."""
+
+    ice_servers = response.get("iceServers")
+    if not isinstance(ice_servers, list):
+        raise ValueError("Cloudflare TURN response did not include an iceServers list")
+
+    turn_uris: list[str] = []
+    username: str | None = None
+    password: str | None = None
+
+    for ice_server in ice_servers:
+        if not isinstance(ice_server, dict):
+            continue
+
+        urls = ice_server.get("urls")
+        if isinstance(urls, str):
+            candidate_urls = [urls]
+        elif isinstance(urls, list):
+            candidate_urls = [url for url in urls if isinstance(url, str)]
+        else:
+            continue
+
+        candidate_turn_uris = [
+            url
+            for url in candidate_urls
+            if url.startswith(("turn:", "turns:"))
+            and ":53" not in url.split("?", 1)[0]
+        ]
+        if not candidate_turn_uris:
+            continue
+
+        ice_username = ice_server.get("username")
+        ice_password = ice_server.get("credential")
+        if not isinstance(ice_username, str) or not isinstance(ice_password, str):
+            continue
+
+        if username is None:
+            username = ice_username
+            password = ice_password
+        elif username != ice_username or password != ice_password:
+            raise ValueError("Cloudflare TURN response contained multiple credentials")
+
+        for uri in candidate_turn_uris:
+            if uri not in turn_uris:
+                turn_uris.append(uri)
+
+    if username is None or password is None or not turn_uris:
+        raise ValueError("Cloudflare TURN response did not include TURN credentials")
+
+    return {
+        "username": username,
+        "password": password,
+        "ttl": ttl,
+        "uris": turn_uris,
+    }
+
+
 class VoipRestServlet(RestServlet):
     PATTERNS = client_patterns("/voip/turnServer$", v1=True)
     CATEGORY = "Client API requests"
@@ -42,6 +106,31 @@ class VoipRestServlet(RestServlet):
         super().__init__()
         self.hs = hs
         self.auth = hs.get_auth()
+        self.http_client: SimpleHttpClient = hs.get_proxied_http_client()
+
+    async def _get_cloudflare_turn_credentials(self, ttl: int) -> JsonDict | None:
+        if not self.hs.config.voip.turn_cloudflare_enabled:
+            return None
+
+        key_id = self.hs.config.voip.turn_cloudflare_key_id
+        api_token = self.hs.config.voip.turn_cloudflare_api_token
+        if not key_id or not api_token:
+            return None
+
+        uri = (
+            f"{self.hs.config.voip.turn_cloudflare_api_base_url}/turn/keys/"
+            f"{quote(key_id, safe='')}/credentials/generate-ice-servers"
+        )
+        response = await self.http_client.post_json_get_json(
+            uri,
+            {"ttl": ttl},
+            headers={b"Authorization": [f"Bearer {api_token}".encode("ascii")]},
+        )
+
+        if not isinstance(response, dict):
+            raise ValueError("Cloudflare TURN API returned a non-object response")
+
+        return _parse_cloudflare_turn_response(response, ttl)
 
     async def on_GET(self, request: SynapseRequest) -> tuple[int, JsonDict]:
         requester = await self.auth.get_user_by_req(
@@ -53,6 +142,21 @@ class VoipRestServlet(RestServlet):
         turnUsername = self.hs.config.voip.turn_username
         turnPassword = self.hs.config.voip.turn_password
         userLifetime = self.hs.config.voip.turn_user_lifetime
+
+        if self.hs.config.voip.turn_cloudflare_enabled:
+            try:
+                cloudflare_response = await self._get_cloudflare_turn_credentials(
+                    userLifetime // 1000
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to fetch Cloudflare TURN credentials; falling back to "
+                    "the configured TURN server",
+                    exc_info=True,
+                )
+            else:
+                if cloudflare_response is not None:
+                    return 200, cloudflare_response
 
         if turnUris and turnSecret and userLifetime:
             expiry = (self.hs.get_clock().time_msec() + userLifetime) / 1000

--- a/synapse/rest/client/voip.py
+++ b/synapse/rest/client/voip.py
@@ -199,7 +199,9 @@ class VoipRestServlet(RestServlet):
         turnPassword = self.hs.config.voip.turn_password
         userLifetime = self.hs.config.voip.turn_user_lifetime
 
-        if self.hs.config.voip.turn_federation_deployment:
+        turn_mode = self.hs.config.voip.turn_mode
+
+        if turn_mode == "broker":
             try:
                 broker_response = await self._get_turn_broker_credentials(
                     userLifetime // 1000
@@ -207,26 +209,26 @@ class VoipRestServlet(RestServlet):
             except Exception:
                 logger.warning(
                     "Failed to fetch TURN credentials from the configured broker; "
-                    "falling back to the configured TURN server",
+                    "falling back to local CoTURN",
                     exc_info=True,
                 )
             else:
                 if broker_response is not None:
                     return 200, broker_response
-        elif self.hs.config.voip.turn_cloudflare_enabled:
+        elif turn_mode == "cf":
             try:
-                cloudflare_response = await self._get_cloudflare_turn_credentials(
+                cf_response = await self._get_cloudflare_turn_credentials(
                     userLifetime // 1000
                 )
             except Exception:
                 logger.warning(
-                    "Failed to fetch Cloudflare TURN credentials; falling back to "
-                    "the configured TURN server",
+                    "Failed to fetch Cloudflare TURN credentials; "
+                    "falling back to local CoTURN",
                     exc_info=True,
                 )
             else:
-                if cloudflare_response is not None:
-                    return 200, cloudflare_response
+                if cf_response is not None:
+                    return 200, cf_response
 
         if turnUris and turnSecret and userLifetime:
             expiry = (self.hs.get_clock().time_msec() + userLifetime) / 1000

--- a/synapse/rest/client/voip.py
+++ b/synapse/rest/client/voip.py
@@ -40,6 +40,38 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _validate_turn_credentials_response(
+    response: JsonDict, requested_ttl: int | None = None
+) -> JsonDict:
+    """Validate a Matrix TURN credentials response shape."""
+
+    username = response.get("username")
+    password = response.get("password")
+    ttl = response.get("ttl")
+    uris = response.get("uris")
+
+    if not isinstance(username, str) or not isinstance(password, str):
+        raise ValueError("TURN credentials response did not include credentials")
+
+    if not isinstance(ttl, int) or ttl <= 0:
+        raise ValueError("TURN credentials response did not include a valid ttl")
+
+    if requested_ttl is not None and ttl > requested_ttl:
+        raise ValueError("TURN credentials response ttl exceeded the requested ttl")
+
+    if not isinstance(uris, list) or not uris or not all(
+        isinstance(uri, str) and uri.startswith(("turn:", "turns:")) for uri in uris
+    ):
+        raise ValueError("TURN credentials response did not include TURN URIs")
+
+    return {
+        "username": username,
+        "password": password,
+        "ttl": ttl,
+        "uris": uris,
+    }
+
+
 def _parse_cloudflare_turn_response(response: JsonDict, ttl: int) -> JsonDict:
     """Convert Cloudflare TURN API credentials into the Matrix VoIP response shape."""
 
@@ -108,6 +140,30 @@ class VoipRestServlet(RestServlet):
         self.auth = hs.get_auth()
         self.http_client: SimpleHttpClient = hs.get_proxied_http_client()
 
+    async def _get_turn_broker_credentials(self, ttl: int) -> JsonDict | None:
+        if not self.hs.config.voip.turn_federation_deployment:
+            return None
+
+        broker_url = self.hs.config.voip.turn_broker_url
+        if not broker_url:
+            return None
+
+        api_token = self.hs.config.voip.turn_broker_api_token
+        headers = None
+        if api_token:
+            headers = {b"Authorization": [f"Bearer {api_token}".encode("ascii")]}
+
+        response = await self.http_client.post_json_get_json(
+            broker_url,
+            {"ttl": ttl},
+            headers=headers,
+        )
+
+        if not isinstance(response, dict):
+            raise ValueError("TURN broker returned a non-object response")
+
+        return _validate_turn_credentials_response(response, ttl)
+
     async def _get_cloudflare_turn_credentials(self, ttl: int) -> JsonDict | None:
         if not self.hs.config.voip.turn_cloudflare_enabled:
             return None
@@ -143,7 +199,21 @@ class VoipRestServlet(RestServlet):
         turnPassword = self.hs.config.voip.turn_password
         userLifetime = self.hs.config.voip.turn_user_lifetime
 
-        if self.hs.config.voip.turn_cloudflare_enabled:
+        if self.hs.config.voip.turn_federation_deployment:
+            try:
+                broker_response = await self._get_turn_broker_credentials(
+                    userLifetime // 1000
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to fetch TURN credentials from the configured broker; "
+                    "falling back to the configured TURN server",
+                    exc_info=True,
+                )
+            else:
+                if broker_response is not None:
+                    return 200, broker_response
+        elif self.hs.config.voip.turn_cloudflare_enabled:
             try:
                 cloudflare_response = await self._get_cloudflare_turn_credentials(
                     userLifetime // 1000

--- a/synapse/rest/client/voip.py
+++ b/synapse/rest/client/voip.py
@@ -24,7 +24,7 @@ import hashlib
 import hmac
 import logging
 from typing import TYPE_CHECKING
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 from synapse.http.client import SimpleHttpClient
 from synapse.http.server import HttpServer
@@ -99,7 +99,7 @@ def _parse_cloudflare_turn_response(response: JsonDict, ttl: int) -> JsonDict:
             url
             for url in candidate_urls
             if url.startswith(("turn:", "turns:"))
-            and ":53" not in url.split("?", 1)[0]
+            and urlparse(url).port != 53
         ]
         if not candidate_turn_uris:
             continue
@@ -141,6 +141,14 @@ class VoipRestServlet(RestServlet):
         self.http_client: SimpleHttpClient = hs.get_proxied_http_client()
 
     async def _get_turn_broker_credentials(self, ttl: int) -> JsonDict | None:
+        """Fetch TURN credentials from a federated TURN broker.
+
+        The broker ensures all homeservers in a federation receive the same
+        TURN credentials, so ICE candidate pairs can match across servers
+        during cross-domain calls.
+
+        Returns None if federation deployment mode is not enabled.
+        """
         if not self.hs.config.voip.turn_federation_deployment:
             return None
 
@@ -165,6 +173,14 @@ class VoipRestServlet(RestServlet):
         return _validate_turn_credentials_response(response, ttl)
 
     async def _get_cloudflare_turn_credentials(self, ttl: int) -> JsonDict | None:
+        """Fetch short-lived TURN credentials from Cloudflare's TURN API.
+
+        Synapse calls the Cloudflare API server-side and converts the response
+        into the standard Matrix TURN format. The API token is never exposed
+        to clients.
+
+        Returns None if Cloudflare TURN is not enabled.
+        """
         if not self.hs.config.voip.turn_cloudflare_enabled:
             return None
 

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -144,6 +144,7 @@ class ConfigLoadingFileTestCase(ConfigFileTestCase):
         [
             "turn_shared_secret_path: /does/not/exist",
             "turn_cloudflare_api_token_path: /does/not/exist",
+            "turn_broker_api_token_path: /does/not/exist",
             "registration_shared_secret_path: /does/not/exist",
             "macaroon_secret_key_path: /does/not/exist",
             "recaptcha_private_key_path: /does/not/exist",
@@ -172,6 +173,10 @@ class ConfigLoadingFileTestCase(ConfigFileTestCase):
             (
                 "turn_cloudflare_api_token_path: {}",
                 lambda c: c.voip.turn_cloudflare_api_token.encode("utf-8"),
+            ),
+            (
+                "turn_broker_api_token_path: {}",
+                lambda c: c.voip.turn_broker_api_token.encode("utf-8"),
             ),
             (
                 "registration_shared_secret_path: {}",
@@ -232,6 +237,7 @@ class ConfigLoadingFileTestCase(ConfigFileTestCase):
         [
             "turn_shared_secret: 53C237",
             "turn_cloudflare_api_token: 53C237",
+            "turn_broker_api_token: 53C237",
             "registration_shared_secret: 53C237",
             "macaroon_secret_key: 53C237",
             "recaptcha_private_key: 53C237",
@@ -305,6 +311,7 @@ class ConfigLoadingFileTestCase(ConfigFileTestCase):
                     "",
                     f"turn_shared_secret_path: {secret_file.name}",
                     f"turn_cloudflare_api_token_path: {secret_file.name}",
+                    f"turn_broker_api_token_path: {secret_file.name}",
                     f"registration_shared_secret_path: {secret_file.name}",
                     f"macaroon_secret_key_path: {secret_file.name}",
                     f"recaptcha_private_key_path: {secret_file.name}",
@@ -349,3 +356,36 @@ class ConfigLoadingFileTestCase(ConfigFileTestCase):
 
         with self.assertRaises(ConfigError):
             HomeServerConfig.load_config("", ["-c", self.config_file])
+
+    def test_turn_broker_requires_federation_deployment_configuration(self) -> None:
+        self.generate_config()
+        self.add_lines_to_config(["", "turn_federation_deployment: true"])
+
+        with self.assertRaises(ConfigError):
+            HomeServerConfig.load_config("", ["-c", self.config_file])
+
+    def test_turn_broker_requires_api_token_configuration(self) -> None:
+        self.generate_config()
+        self.add_lines_to_config(
+            [
+                "",
+                "turn_federation_deployment: true",
+                "turn_broker_url: https://turn-broker.example.com/credentials",
+            ]
+        )
+
+        with self.assertRaises(ConfigError):
+            HomeServerConfig.load_config("", ["-c", self.config_file])
+
+    def test_turn_broker_url_is_accepted_without_federation_deployment(self) -> None:
+        self.generate_config()
+        self.add_lines_to_config(
+            ["", "turn_broker_url: https://turn-broker.example.com/credentials"]
+        )
+
+        config = HomeServerConfig.load_config("", ["-c", self.config_file])
+        self.assertFalse(config.voip.turn_federation_deployment)
+        self.assertEqual(
+            config.voip.turn_broker_url,
+            "https://turn-broker.example.com/credentials",
+        )

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -143,6 +143,7 @@ class ConfigLoadingFileTestCase(ConfigFileTestCase):
     @parameterized.expand(
         [
             "turn_shared_secret_path: /does/not/exist",
+            "turn_cloudflare_api_token_path: /does/not/exist",
             "registration_shared_secret_path: /does/not/exist",
             "macaroon_secret_key_path: /does/not/exist",
             "recaptcha_private_key_path: /does/not/exist",
@@ -167,6 +168,10 @@ class ConfigLoadingFileTestCase(ConfigFileTestCase):
             (
                 "turn_shared_secret_path: {}",
                 lambda c: c.voip.turn_shared_secret.encode("utf-8"),
+            ),
+            (
+                "turn_cloudflare_api_token_path: {}",
+                lambda c: c.voip.turn_cloudflare_api_token.encode("utf-8"),
             ),
             (
                 "registration_shared_secret_path: {}",
@@ -226,6 +231,7 @@ class ConfigLoadingFileTestCase(ConfigFileTestCase):
     @parameterized.expand(
         [
             "turn_shared_secret: 53C237",
+            "turn_cloudflare_api_token: 53C237",
             "registration_shared_secret: 53C237",
             "macaroon_secret_key: 53C237",
             "recaptcha_private_key: 53C237",
@@ -298,6 +304,7 @@ class ConfigLoadingFileTestCase(ConfigFileTestCase):
                 [
                     "",
                     f"turn_shared_secret_path: {secret_file.name}",
+                    f"turn_cloudflare_api_token_path: {secret_file.name}",
                     f"registration_shared_secret_path: {secret_file.name}",
                     f"macaroon_secret_key_path: {secret_file.name}",
                     f"recaptcha_private_key_path: {secret_file.name}",
@@ -320,3 +327,25 @@ class ConfigLoadingFileTestCase(ConfigFileTestCase):
             HomeServerConfig.load_config(
                 "", ["-c", self.config_file, "--no-secrets-in-config"]
             )
+
+    @parameterized.expand(
+        [
+            ("turn_cloudflare_enabled: true",),
+            (
+                "turn_cloudflare_enabled: true\n"
+                "turn_cloudflare_api_token_path: /tmp/example-token",
+            ),
+            (
+                "turn_cloudflare_enabled: true\n"
+                "turn_cloudflare_key_id: example-key-id",
+            ),
+        ]
+    )
+    def test_cloudflare_turn_requires_complete_configuration(
+        self, config_str: str
+    ) -> None:
+        self.generate_config()
+        self.add_lines_to_config(["", config_str])
+
+        with self.assertRaises(ConfigError):
+            HomeServerConfig.load_config("", ["-c", self.config_file])

--- a/tests/rest/client/test_voip.py
+++ b/tests/rest/client/test_voip.py
@@ -1,0 +1,190 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 New Vector, Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+
+from unittest.mock import AsyncMock, patch
+
+from twisted.internet.testing import MemoryReactor
+
+import synapse.rest.admin
+from synapse.rest.client import login, voip
+from synapse.server import HomeServer
+from synapse.util.clock import Clock
+
+from tests import unittest
+from tests.unittest import override_config
+
+
+class ParseCloudflareTurnResponseTestCase(unittest.TestCase):
+    def test_parses_cloudflare_turn_credentials(self) -> None:
+        response = voip._parse_cloudflare_turn_response(
+            {
+                "iceServers": [
+                    {"urls": ["stun:stun.cloudflare.com:3478"]},
+                    {
+                        "urls": [
+                            "turn:turn.cloudflare.com:3478?transport=udp",
+                            "turns:turn.cloudflare.com:443?transport=tcp",
+                        ],
+                        "username": "user",
+                        "credential": "pass",
+                    },
+                ]
+            },
+            ttl=3600,
+        )
+
+        self.assertEqual(
+            response,
+            {
+                "username": "user",
+                "password": "pass",
+                "ttl": 3600,
+                "uris": [
+                    "turn:turn.cloudflare.com:3478?transport=udp",
+                    "turns:turn.cloudflare.com:443?transport=tcp",
+                ],
+            },
+        )
+
+    def test_filters_cloudflare_port_53_turn_urls(self) -> None:
+        response = voip._parse_cloudflare_turn_response(
+            {
+                "iceServers": [
+                    {
+                        "urls": [
+                            "turn:turn.cloudflare.com:53?transport=udp",
+                            "turn:turn.cloudflare.com:3478?transport=udp",
+                            "turns:turn.cloudflare.com:443?transport=tcp",
+                        ],
+                        "username": "user",
+                        "credential": "pass",
+                    },
+                ]
+            },
+            ttl=3600,
+        )
+
+        self.assertEqual(
+            response["uris"],
+            [
+                "turn:turn.cloudflare.com:3478?transport=udp",
+                "turns:turn.cloudflare.com:443?transport=tcp",
+            ],
+        )
+
+    def test_rejects_multiple_cloudflare_turn_credentials(self) -> None:
+        with self.assertRaises(ValueError):
+            voip._parse_cloudflare_turn_response(
+                {
+                    "iceServers": [
+                        {
+                            "urls": ["turn:turn.cloudflare.com:3478?transport=udp"],
+                            "username": "user-a",
+                            "credential": "pass-a",
+                        },
+                        {
+                            "urls": ["turns:turn.cloudflare.com:443?transport=tcp"],
+                            "username": "user-b",
+                            "credential": "pass-b",
+                        },
+                    ]
+                },
+                ttl=3600,
+            )
+
+
+class VoipTestCase(unittest.HomeserverTestCase):
+    servlets = [
+        synapse.rest.admin.register_servlets_for_client_rest_resource,
+        login.register_servlets,
+        voip.register_servlets,
+    ]
+
+    def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
+        return self.setup_test_homeserver()
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.localpart = "user"
+        self.password = "pass"
+        self.register_user(self.localpart, self.password)
+        self.access_token = self.login(self.localpart, self.password)
+
+    @override_config(
+        {
+            "turn_cloudflare_enabled": True,
+            "turn_cloudflare_key_id": "cf-key-id",
+            "turn_cloudflare_api_token": "cf-api-token",
+            "turn_user_lifetime": "1h",
+        }
+    )
+    def test_cloudflare_turn_credentials_are_returned(self) -> None:
+        with patch.object(
+            voip.VoipRestServlet,
+            "_get_cloudflare_turn_credentials",
+            new=AsyncMock(
+                return_value={
+                    "username": "user",
+                    "password": "pass",
+                    "ttl": 3600,
+                    "uris": ["turn:turn.cloudflare.com:3478?transport=udp"],
+                }
+            ),
+        ) as mock_fetch:
+            channel = self.make_request(
+                "GET", "/voip/turnServer", access_token=self.access_token
+            )
+
+        self.assertEqual(channel.code, 200)
+        self.assertEqual(
+            channel.json_body,
+            {
+                "username": "user",
+                "password": "pass",
+                "ttl": 3600,
+                "uris": ["turn:turn.cloudflare.com:3478?transport=udp"],
+            },
+        )
+        self.assertEqual(mock_fetch.await_count, 1)
+
+    @override_config(
+        {
+            "turn_cloudflare_enabled": True,
+            "turn_cloudflare_key_id": "cf-key-id",
+            "turn_cloudflare_api_token": "cf-api-token",
+            "turn_uris": ["turn:turn.example.com:3478?transport=udp"],
+            "turn_username": "fallback-user",
+            "turn_password": "fallback-pass",
+            "turn_user_lifetime": "1h",
+        }
+    )
+    def test_cloudflare_failure_falls_back_to_existing_turn_config(self) -> None:
+        with patch.object(
+            voip.VoipRestServlet,
+            "_get_cloudflare_turn_credentials",
+            new=AsyncMock(side_effect=ValueError("boom")),
+        ):
+            channel = self.make_request(
+                "GET", "/voip/turnServer", access_token=self.access_token
+            )
+
+        self.assertEqual(channel.code, 200)
+        self.assertEqual(
+            channel.json_body,
+            {
+                "username": "fallback-user",
+                "password": "fallback-pass",
+                "ttl": 3600,
+                "uris": ["turn:turn.example.com:3478?transport=udp"],
+            },
+        )

--- a/tests/rest/client/test_voip.py
+++ b/tests/rest/client/test_voip.py
@@ -143,6 +143,7 @@ class VoipTestCase(unittest.HomeserverTestCase):
 
     @override_config(
         {
+            "turn_mode": "cf",
             "turn_cloudflare_enabled": True,
             "turn_cloudflare_key_id": "cf-key-id",
             "turn_cloudflare_api_token": "cf-api-token",
@@ -180,6 +181,7 @@ class VoipTestCase(unittest.HomeserverTestCase):
 
     @override_config(
         {
+            "turn_mode": "broker",
             "turn_federation_deployment": True,
             "turn_broker_url": "https://turn-broker.example.com/credentials",
             "turn_broker_api_token": "broker-token",
@@ -235,6 +237,7 @@ class VoipTestCase(unittest.HomeserverTestCase):
 
     @override_config(
         {
+            "turn_mode": "cf",
             "turn_broker_url": "https://turn-broker.example.com/credentials",
             "turn_broker_api_token": "broker-token",
             "turn_cloudflare_enabled": True,
@@ -289,6 +292,8 @@ class VoipTestCase(unittest.HomeserverTestCase):
 
     @override_config(
         {
+            "turn_cloudflare_enabled": True,
+            "turn_mode": "cf",
             "turn_cloudflare_enabled": True,
             "turn_cloudflare_key_id": "cf-key-id",
             "turn_cloudflare_api_token": "cf-api-token",

--- a/tests/rest/client/test_voip.py
+++ b/tests/rest/client/test_voip.py
@@ -26,7 +26,10 @@ from tests.unittest import override_config
 
 
 class ParseCloudflareTurnResponseTestCase(unittest.TestCase):
+    """Tests for TURN credential response parsing and validation."""
+
     def test_validates_turn_broker_credentials(self) -> None:
+        """Ensure valid Matrix TURN credentials pass validation."""
         response = voip._validate_turn_credentials_response(
             {
                 "username": "user",
@@ -48,6 +51,7 @@ class ParseCloudflareTurnResponseTestCase(unittest.TestCase):
         )
 
     def test_parses_cloudflare_turn_credentials(self) -> None:
+        """Ensure Cloudflare iceServers response is correctly converted to Matrix format."""
         response = voip._parse_cloudflare_turn_response(
             {
                 "iceServers": [
@@ -79,6 +83,7 @@ class ParseCloudflareTurnResponseTestCase(unittest.TestCase):
         )
 
     def test_filters_cloudflare_port_53_turn_urls(self) -> None:
+        """Ensure alternate port 53 TURN URLs are filtered out while preserving other ports."""
         response = voip._parse_cloudflare_turn_response(
             {
                 "iceServers": [
@@ -104,7 +109,37 @@ class ParseCloudflareTurnResponseTestCase(unittest.TestCase):
             ],
         )
 
+    def test_preserves_port_5349_turn_urls(self) -> None:
+        """Ensure port 5349 (TURNS) is not accidentally filtered by port 53 check."""
+        response = voip._parse_cloudflare_turn_response(
+            {
+                "iceServers": [
+                    {
+                        "urls": [
+                            "turn:turn.cloudflare.com:53?transport=udp",
+                            "turn:turn.cloudflare.com:3478?transport=udp",
+                            "turns:turn.cloudflare.com:5349?transport=tcp",
+                            "turns:turn.cloudflare.com:443?transport=tcp",
+                        ],
+                        "username": "user",
+                        "credential": "pass",
+                    },
+                ]
+            },
+            ttl=3600,
+        )
+
+        self.assertEqual(
+            response["uris"],
+            [
+                "turn:turn.cloudflare.com:3478?transport=udp",
+                "turns:turn.cloudflare.com:5349?transport=tcp",
+                "turns:turn.cloudflare.com:443?transport=tcp",
+            ],
+        )
+
     def test_rejects_multiple_cloudflare_turn_credentials(self) -> None:
+        """Ensure responses with multiple distinct credential sets are rejected."""
         with self.assertRaises(ValueError):
             voip._parse_cloudflare_turn_response(
                 {
@@ -126,6 +161,8 @@ class ParseCloudflareTurnResponseTestCase(unittest.TestCase):
 
 
 class VoipTestCase(unittest.HomeserverTestCase):
+    """Integration tests for the VoIP TURN endpoint with different credential modes."""
+
     servlets = [
         synapse.rest.admin.register_servlets_for_client_rest_resource,
         login.register_servlets,
@@ -151,6 +188,7 @@ class VoipTestCase(unittest.HomeserverTestCase):
         }
     )
     def test_cloudflare_turn_credentials_are_returned(self) -> None:
+        """Ensure Cloudflare credentials are returned when turn_mode is 'cf'."""
         with patch.object(
             voip.VoipRestServlet,
             "_get_cloudflare_turn_credentials",
@@ -192,6 +230,7 @@ class VoipTestCase(unittest.HomeserverTestCase):
         }
     )
     def test_federation_deployment_prefers_turn_broker(self) -> None:
+        """Ensure broker credentials are preferred over Cloudflare in federation mode."""
         with patch.object(
             voip.VoipRestServlet,
             "_get_turn_broker_credentials",
@@ -247,6 +286,7 @@ class VoipTestCase(unittest.HomeserverTestCase):
         }
     )
     def test_turn_broker_url_is_ignored_without_federation_deployment(self) -> None:
+        """Ensure broker settings are ignored when turn_federation_deployment is false."""
         with patch.object(
             voip.VoipRestServlet,
             "_get_turn_broker_credentials",
@@ -292,7 +332,6 @@ class VoipTestCase(unittest.HomeserverTestCase):
 
     @override_config(
         {
-            "turn_cloudflare_enabled": True,
             "turn_mode": "cf",
             "turn_cloudflare_enabled": True,
             "turn_cloudflare_key_id": "cf-key-id",
@@ -304,6 +343,7 @@ class VoipTestCase(unittest.HomeserverTestCase):
         }
     )
     def test_cloudflare_failure_falls_back_to_existing_turn_config(self) -> None:
+        """Ensure local TURN config is used as fallback when Cloudflare fetch fails."""
         with patch.object(
             voip.VoipRestServlet,
             "_get_cloudflare_turn_credentials",

--- a/tests/rest/client/test_voip.py
+++ b/tests/rest/client/test_voip.py
@@ -26,6 +26,27 @@ from tests.unittest import override_config
 
 
 class ParseCloudflareTurnResponseTestCase(unittest.TestCase):
+    def test_validates_turn_broker_credentials(self) -> None:
+        response = voip._validate_turn_credentials_response(
+            {
+                "username": "user",
+                "password": "pass",
+                "ttl": 3600,
+                "uris": ["turn:turn.example.com:3478?transport=udp"],
+            },
+            requested_ttl=3600,
+        )
+
+        self.assertEqual(
+            response,
+            {
+                "username": "user",
+                "password": "pass",
+                "ttl": 3600,
+                "uris": ["turn:turn.example.com:3478?transport=udp"],
+            },
+        )
+
     def test_parses_cloudflare_turn_credentials(self) -> None:
         response = voip._parse_cloudflare_turn_response(
             {
@@ -156,6 +177,115 @@ class VoipTestCase(unittest.HomeserverTestCase):
             },
         )
         self.assertEqual(mock_fetch.await_count, 1)
+
+    @override_config(
+        {
+            "turn_federation_deployment": True,
+            "turn_broker_url": "https://turn-broker.example.com/credentials",
+            "turn_broker_api_token": "broker-token",
+            "turn_cloudflare_enabled": True,
+            "turn_cloudflare_key_id": "cf-key-id",
+            "turn_cloudflare_api_token": "cf-api-token",
+            "turn_user_lifetime": "1h",
+        }
+    )
+    def test_federation_deployment_prefers_turn_broker(self) -> None:
+        with patch.object(
+            voip.VoipRestServlet,
+            "_get_turn_broker_credentials",
+            new=AsyncMock(
+                return_value={
+                    "username": "broker-user",
+                    "password": "broker-pass",
+                    "ttl": 3600,
+                    "uris": ["turn:broker.example.com:3478?transport=udp"],
+                }
+            ),
+        ) as mock_broker:
+            with patch.object(
+                voip.VoipRestServlet,
+                "_get_cloudflare_turn_credentials",
+                new=AsyncMock(
+                    return_value={
+                        "username": "cf-user",
+                        "password": "cf-pass",
+                        "ttl": 3600,
+                        "uris": [
+                            "turn:turn.cloudflare.com:3478?transport=udp"
+                        ],
+                    }
+                ),
+            ) as mock_cloudflare:
+                channel = self.make_request(
+                    "GET", "/voip/turnServer", access_token=self.access_token
+                )
+
+        self.assertEqual(channel.code, 200)
+        self.assertEqual(
+            channel.json_body,
+            {
+                "username": "broker-user",
+                "password": "broker-pass",
+                "ttl": 3600,
+                "uris": ["turn:broker.example.com:3478?transport=udp"],
+            },
+        )
+        self.assertEqual(mock_broker.await_count, 1)
+        self.assertEqual(mock_cloudflare.await_count, 0)
+
+    @override_config(
+        {
+            "turn_broker_url": "https://turn-broker.example.com/credentials",
+            "turn_broker_api_token": "broker-token",
+            "turn_cloudflare_enabled": True,
+            "turn_cloudflare_key_id": "cf-key-id",
+            "turn_cloudflare_api_token": "cf-api-token",
+            "turn_user_lifetime": "1h",
+        }
+    )
+    def test_turn_broker_url_is_ignored_without_federation_deployment(self) -> None:
+        with patch.object(
+            voip.VoipRestServlet,
+            "_get_turn_broker_credentials",
+            new=AsyncMock(
+                return_value={
+                    "username": "broker-user",
+                    "password": "broker-pass",
+                    "ttl": 3600,
+                    "uris": ["turn:broker.example.com:3478?transport=udp"],
+                }
+            ),
+        ) as mock_broker:
+            with patch.object(
+                voip.VoipRestServlet,
+                "_get_cloudflare_turn_credentials",
+                new=AsyncMock(
+                    return_value={
+                        "username": "cf-user",
+                        "password": "cf-pass",
+                        "ttl": 3600,
+                        "uris": [
+                            "turn:turn.cloudflare.com:3478?transport=udp"
+                        ],
+                    }
+                ),
+            ) as mock_cloudflare:
+                channel = self.make_request(
+                    "GET", "/voip/turnServer", access_token=self.access_token
+                )
+
+        self.assertEqual(channel.code, 200)
+        self.assertEqual(
+            channel.json_body,
+            {
+                "username": "cf-user",
+                "password": "cf-pass",
+                "ttl": 3600,
+                "uris": ["turn:turn.cloudflare.com:3478?transport=udp"],
+            },
+        )
+        self.assertEqual(mock_broker.await_count, 0)
+        self.assertEqual(mock_cloudflare.await_count, 1)
 
     @override_config(
         {


### PR DESCRIPTION
## Summary

This adds optional support for fetching short-lived TURN credentials from Cloudflare Realtime TURN via Synapse's existing `/_matrix/client/*/voip/turnServer` endpoint.

Clients do not need any Cloudflare-specific changes: Synapse performs the Cloudflare API request server-side and returns the usual Matrix TURN response shape (`username`, `password`, `ttl`, `uris`).

## Why

Today Synapse supports:
- shared-secret TURN credentials (`turn_shared_secret`)
- static username/password TURN credentials (`turn_username` / `turn_password`)

That works well for self-hosted TURN servers such as coturn or eturnal, but it does not cover providers like Cloudflare Realtime TURN, where Synapse needs to call an API to mint short-lived credentials.

This is useful for deployments that want:
- globally distributed TURN ingress without operating their own TURN fleet
- a managed TURN service with short-lived credentials
- lower operational overhead while keeping the existing Matrix client flow

## What this PR changes

### New configuration

Adds optional Cloudflare-specific settings:
- `turn_cloudflare_enabled`
- `turn_cloudflare_key_id`
- `turn_cloudflare_api_token`
- `turn_cloudflare_api_token_path`
- `turn_cloudflare_api_base_url`

Adds optional broker-specific settings for federated deployments:
- `turn_federation_deployment`
- `turn_broker_url`
- `turn_broker_api_token`
- `turn_broker_api_token_path`

Adds a `turn_mode` setting to explicitly select the TURN credential source:
- `coturn` (default): use local CoTURN directly. Backward compatible — no behaviour change if unset.
- `cf`: fetch credentials from Cloudflare Realtime TURN.
- `broker`: fetch credentials from a federated TURN broker.

### Request flow

When `turn_mode: cf` is configured:
1. Synapse receives `/_matrix/client/*/voip/turnServer`
2. Synapse calls Cloudflare's TURN credential API server-side
3. Synapse converts the Cloudflare response into the existing Matrix TURN response format
4. Clients continue to consume the standard Matrix endpoint unchanged

When `turn_mode: broker` is configured:
1. Synapse receives `/_matrix/client/*/voip/turnServer`
2. Synapse calls a configured TURN broker instead of calling Cloudflare directly
3. The broker returns the same Matrix TURN response shape (`username`, `password`, `ttl`, `uris`)
4. Clients continue to consume the standard Matrix endpoint unchanged

When `turn_mode: coturn` (default) is configured:
1. Synapse uses the existing `turn_uris` / `turn_shared_secret` or `turn_username` / `turn_password` flow as before.
2. This is fully backward compatible.

### Port 53 filtering

Cloudflare documents that alternate port 53 TURN URLs may time out in browsers.
This PR filters `turn:` / `turns:` URLs on port `53` before returning credentials to clients, while preserving the primary ports (`3478`, `80`, `443`, `5349`).

## Security / operational notes

- The Cloudflare API token can be loaded from `turn_cloudflare_api_token_path`, which is the recommended deployment mode.
- The broker token can be loaded from `turn_broker_api_token_path`, which is the recommended deployment mode for broker deployments.
- The implementation keeps both tokens on the server side; they are never exposed to Matrix clients.
- `turn_user_lifetime` continues to control the returned TTL and is reused for Cloudflare or broker credential requests.

## Documentation

This PR updates:
- TURN configuration reference
- TURN how-to documentation

The docs explicitly describe:
- the server-side-only nature of the integration
- recommended use of `turn_cloudflare_api_token_path`
- filtering of Cloudflare's alternate port 53 TURN URLs

## Tests

Adds coverage for:
- parsing Cloudflare TURN responses
- validating broker TURN responses
- filtering port 53 TURN URLs
- rejecting mismatched multiple credential sets
- successful Cloudflare-backed responses
- successful broker-backed responses in federated mode
- ignoring broker settings unless federated mode is explicitly enabled
- config loading / secret file handling for the new options

## Example config

### Cloudflare TURN mode

```yaml
turn_mode: cf
turn_cloudflare_enabled: true
turn_cloudflare_key_id: YOUR_CLOUDFLARE_TURN_KEY_ID
turn_cloudflare_api_token_path: /path/to/turn-cloudflare-api-token
turn_user_lifetime: 1h
```

### Federation broker mode

```yaml
turn_mode: broker
turn_federation_deployment: true
turn_broker_url: https://turn-broker.example.com/credentials
turn_broker_api_token_path: /path/to/turn-broker-api-token
turn_user_lifetime: 1h
```

### Local CoTURN only (default, backward compatible)

```yaml
# turn_mode: coturn  (optional, this is the default)
turn_uris:
  - turn:coturn.example.com:3478?transport=udp
turn_shared_secret: YOUR_SECRET
turn_user_lifetime: 1h
```

## Reference TURN broker implementations

Two reference implementations are provided:

- **VPS / Docker**: <https://github.com/kakahu2015/synapse-turn-broker>
  Python + Redis, self-hosted on a VPS behind Caddy/nginx.

- **Cloudflare Workers**: <https://github.com/kakahu2015/synapse-turn-broker-worker>
  JavaScript + Cloudflare KV, serverless deployment on Cloudflare edge. Zero server maintenance, free tier friendly.
