### PR TITLE
Handle newly left rooms with missing membership snapshots

### DIFF
--- a/synapse/handlers/sliding_sync/room_lists.py
+++ b/synapse/handlers/sliding_sync/room_lists.py
@@ -1197,18 +1197,17 @@ class SlidingSyncRoomLists:
             else:
                 rooms_for_user[room_id] = change_room_for_user
 
-        # Ensure we have entries for rooms that the user has been "state reset"
-        # out of. These are rooms appear in the `newly_left_rooms` map but
-        # aren't in the `rooms_for_user` map.
+        # Ensure we have entries for newly-left rooms that are missing from the current
+        # membership snapshot. This covers both true state resets and cases where the
+        # current membership snapshot disappeared after a real leave event.
         for room_id, newly_left_room_for_user in newly_left_room_map.items():
-            # If we already know about the room, it's not a state reset
+            # If we already know about the room, it's already represented in the current
+            # membership snapshot.
             if room_id in rooms_for_user:
                 continue
 
-            # This should be true if it's a state reset
+            # This should always be true for rooms in the newly-left map.
             assert newly_left_room_for_user.membership is Membership.LEAVE
-            assert newly_left_room_for_user.event_id is None
-            assert newly_left_room_for_user.sender is None
 
             rooms_for_user[room_id] = newly_left_room_for_user
 

--- a/synapse/handlers/sliding_sync/room_lists.py
+++ b/synapse/handlers/sliding_sync/room_lists.py
@@ -1169,18 +1169,17 @@ class SlidingSyncRoomLists:
             else:
                 rooms_for_user[room_id] = change_room_for_user
 
-        # Ensure we have entries for rooms that the user has been "state reset"
-        # out of. These are rooms appear in the `newly_left_rooms` map but
-        # aren't in the `rooms_for_user` map.
+        # Ensure we have entries for newly-left rooms that are missing from the current
+        # membership snapshot. This covers both true state resets and cases where the
+        # current membership snapshot disappeared after a real leave event.
         for room_id, newly_left_room_for_user in newly_left_room_map.items():
-            # If we already know about the room, it's not a state reset
+            # If we already know about the room, it's already represented in the current
+            # membership snapshot.
             if room_id in rooms_for_user:
                 continue
 
-            # This should be true if it's a state reset
+            # This should always be true for rooms in the newly-left map.
             assert newly_left_room_for_user.membership is Membership.LEAVE
-            assert newly_left_room_for_user.event_id is None
-            assert newly_left_room_for_user.sender is None
 
             rooms_for_user[room_id] = newly_left_room_for_user
 

--- a/tests/handlers/test_sliding_sync.py
+++ b/tests/handlers/test_sliding_sync.py
@@ -3465,6 +3465,58 @@ class FilterRoomsRelevantForSyncTestCase(HomeserverTestCase):
         self.assertTrue(room_id2 not in newly_joined)
         self.assertTrue(room_id2 in newly_left)
 
+    def test_newly_left_room_still_shows_up_when_current_membership_is_gone(self) -> None:
+        """
+        Test that a room still shows up as `newly_left` when the user left during the
+        token range but the current membership snapshot was later removed.
+
+        The room can be reconstructed via a state-reset-style entry in this case, so
+        the important regression is that we still include it without asserting.
+        """
+        user1_id = self.register_user("user1", "pass")
+        user1_tok = self.login(user1_id, "pass")
+
+        before_leave_token = self.event_sources.get_current_token()
+
+        room_id = self.helper.create_room_as(user1_id, tok=user1_tok)
+        self.helper.leave(room_id, user1_id, tok=user1_tok)
+
+        after_leave_token = self.event_sources.get_current_token()
+
+        self.get_success(
+            self.store.db_pool.simple_delete(
+                table="current_state_events",
+                keyvalues={
+                    "room_id": room_id,
+                    "type": EventTypes.Member,
+                    "state_key": user1_id,
+                },
+                desc="remove_current_membership_state_after_leave",
+            )
+        )
+        self.get_success(
+            self.store.db_pool.simple_delete(
+                table="local_current_membership",
+                keyvalues={
+                    "room_id": room_id,
+                    "user_id": user1_id,
+                },
+                desc="remove_local_current_membership_after_leave",
+            )
+        )
+        self.store._get_rooms_for_local_user_where_membership_is_inner.invalidate_all()
+
+        room_id_results, newly_joined, newly_left = self._get_sync_room_ids_for_user(
+            UserID.from_string(user1_id),
+            from_token=before_leave_token,
+            to_token=after_leave_token,
+        )
+
+        self.assertIncludes(room_id_results.keys(), {room_id}, exact=True)
+        self.assertEqual(room_id_results[room_id].membership, Membership.LEAVE)
+        self.assertTrue(room_id not in newly_joined)
+        self.assertTrue(room_id in newly_left)
+
     def test_get_kicked_room(self) -> None:
         """
         Test that a room that the user was kicked from still shows up. When the user


### PR DESCRIPTION
# Handle newly left rooms with missing membership snapshots

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

## Summary

This fixes a Sliding Sync crash when a room is newly left in the requested token range, but the user's current membership snapshot for that room has already been removed.

In practice this was returning HTTP 500 from `/_matrix/client/unstable/org.matrix.simplified_msc3575/sync` and leaving Element X clients stuck retrying the same failing sync until local state was reset by fully logging out and fully logging back in.

## Repro

1. Receive a message from a mautrix bridge bot user which becomes admin.
2. Leave the room.
3. Perform another incremental Sliding Sync, which in Element X is to just wait briefly.

or

1. Admin leaves a room
2. Issue `DELETE` request on the `/_synapse/admin/v2/rooms/$room_id` endpoint with a `block=True` `purge=True` and a `new_room_user_id` and `room_name set`
3. Every Element X user left in the room after admin leaves experiences the issue on next Sliding Sync.

## Root cause

The relevant traceback in synapse logs points to `get_room_membership_for_user_at_to_token` in `synapse/handlers/sliding_sync/room_lists.py`:

<details>
<summary>Synapse logs</summary>

```
Apr 03 09:48:04 localhost matrix-synapse-reverse-proxy-companion[172308]: 123.45.6.78 - - [03/Apr/2026:16:48:04 +0000] "GET /_matrix/client/v3/sync?filter=%7B%22room%22%3A%7B%22state%22%3A%7B%22lazy_load_members%22%3Atrue%7D%7D%7D&since=s2638061_70869282_2458_4400835_4030251_6051930_620209_3932481_0_16_2_1&timeout=30000&use_state_after=true HTTP/1.1"200 1759 "-" "matrix-rust-sdk" "172.28.0.1" "matrix.example.net" "generic_workers_upstream" "192.168.01.01:18111" "200" "23.922" "23.922"
Apr 03 09:48:04 localhost matrix-synapse-reverse-proxy-companion[172308]: 123.45.6.78 - - [03/Apr/2026:16:48:04 +0000] "GET /_matrix/client/v3/sync?since=s2638061_70869282_2458_4400835_4030251_6051930_620209_3932481_0_16_2_1&timeout=30000 HTTP/1.1"200 1857 "-" "Python/3.12 aiohttp/3.12.15" "172.29.0.28" "matrix-traefik" "generic_workers_upstream" "192.168.01.01:18111" "200" "24.743" "24.744"
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]: 2026-04-03 16:48:05,286 - synapse.http.server - 147 - ERROR - POST-423060 - Failed handle request via 'SlidingSyncRestServlet': <XForwardedForRequest at 0x7f48832b6710 method='POST' uri='/_matrix/client/unstable/org.matrix.simplified_msc3575/sync?pos=71392%2Fs2638059_70869278_2458_4400835_4030251_6051930_620209_3932481_0_16_2_1&timeout=0' clientproto='HTTP/1.1' site='18111'>
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]: Traceback (most recent call last):
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:   File "/usr/local/lib/python3.13/site-packages/synapse/http/server.py", line 335, in _async_render_wrapper
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     callback_return = await self._async_render(request)
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:   File "/usr/local/lib/python3.13/site-packages/synapse/http/server.py", line 576, in _async_render
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     callback_return = await raw_callback_return
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:   File "/usr/local/lib/python3.13/site-packages/synapse/rest/client/sync.py", line 846, in on_POST
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     ) = await self.sliding_sync_handler.wait_for_sync_for_user(
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     ...<4 lines>...
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     )
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     ^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:   File "/usr/local/lib/python3.13/site-packages/synapse/handlers/sliding_sync/__init__.py", line 175, in wait_for_sync_for_user
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     result = await self.current_sync_for_user(
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     ...<3 lines>...
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     )
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     ^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:   File "/usr/local/lib/python3.13/site-packages/synapse/logging/opentracing.py", line 949, in _wrapper
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     return await func(*args, **kwargs)
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:   File "/usr/local/lib/python3.13/site-packages/synapse/handlers/sliding_sync/__init__.py", line 253, in current_sync_for_user
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     interested_rooms = await self.room_lists.compute_interested_rooms(
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     ...<4 lines>...
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     )
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     ^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:   File "/usr/local/lib/python3.13/site-packages/synapse/handlers/sliding_sync/room_lists.py", line 234, in compute_interested_rooms
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     return await self._compute_interested_rooms_fallback(
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     ...<4 lines>...
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     )
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     ^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:   File "/usr/local/lib/python3.13/site-packages/synapse/handlers/sliding_sync/room_lists.py", line 654, in _compute_interested_rooms_fallback
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     ) = await self.get_room_membership_for_user_at_to_token(
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:         sync_config.user, to_token, from_token
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     )
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     ^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:   File "/usr/local/lib/python3.13/site-packages/synapse/logging/opentracing.py", line 949, in _wrapper
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     return await func(*args, **kwargs)
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:   File "/usr/local/lib/python3.13/site-packages/synapse/handlers/sliding_sync/room_lists.py", line 1182, in get_room_membership_for_user_at_to_token
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:     assert newly_left_room_for_user.event_id is None
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]: AssertionError
Apr 03 09:48:05 localhost matrix-synapse-worker-generic-0[176950]: 2026-04-03 16:48:05,289 - synapse.access.http.18111 - 643 - INFO - POST-423060 - .654.321 - 18111 - {@user:example.net} Processed request: 0.010sec/0.001sec ru=(0.004sec, 0.001sec) db=(0.001sec/0.003sec/3) 55B 500 "POST /_matrix/client/unstable/org.matrix.simplified_msc3575/sync?pos=71392%2Fs2638059_70869278_2458_4400835_4030251_6051930_620209_3932481_0_16_2_1&timeout=0 HTTP/1.1" "Element X/26.03.2 (Device Model; Android 15; device_os-userdebug 15 BP1A.250505.005 eng.root dev-keys; Sdk 21e813880)" [0 dbevts]
Apr 03 09:48:05 localhost matrix-synapse-reverse-proxy-companion[172308]: 123.45.6.78 - - [03/Apr/2026:16:48:05 +0000] "POST /_matrix/client/unstable/org.matrix.simplified_msc3575/sync?pos=71392%2Fs2638059_70869278_2458_4400835_4030251_6051930_620209_3932481_0_16_2_1&timeout=0 HTTP/1.1"500 66 "-" "Element X/26.03.2 (Device Model; Android 15; device_os-userdebug 15 BP1A.250505.005 eng.root dev-keys; Sdk 21e813880)" ".654.321" "matrix.example.net" "generic_workers_upstream" "192.168.01.01:18111" "500" "0.013" "0.013"
Apr 03 09:48:05 localhost matrix-synapse[171953]: 2026-04-03 16:48:05,602 - synapse.http.server - 131 - INFO - GET-174198 - <XForwardedForRequest at 0x7fc86ad487d0 method='GET' uri='/_matrix/client/v3/rooms/!AbcdEFGhijKlMnoPq:example.net/messages?dir=b&limit=20' clientproto='HTTP/1.1' site='8008'> SynapseError: 403 - User @user:example.net not in room !AbcdEFGhijKlMnoPq:example.net, and room previews are disabled
Apr 03 09:48:05 localhost matrix-synapse[171953]: 2026-04-03 16:48:05,604 - synapse.http.server - 131 - INFO - GET-174200 - <XForwardedForRequest at 0x7fc86ad49310 method='GET' uri='/_matrix/client/v3/rooms/!N-UrXTBJFH4I-ab123kjiucdlsesejffsi0a0-wIsA/messages?dir=b&limit=20' clientproto='HTTP/1.1' site='8008'> SynapseError: 403 - User @user:example.net not in room !N-UrXTBJFH4I-ab123kjiucdlsesejffsi0a0-wIsA, and room previews are disabled
```

</details>

That fallback path correctly notices that a room is newly left in the token range and missing from the current membership snapshot, but it then assumes this can only be a pure state-reset case and asserts:

- `membership is LEAVE`
- `event_id is None`
- `sender is None`

That assumption is too strict. In the reported case, the current membership snapshot had been cleaned up, but there was still a real leave event in the requested range, so `event_id` was present and the assertion turned a valid sync response into a 500.

## Fix

- Keep the invariant that the fallback entry must be a leave.
- Stop asserting that `event_id` and `sender` are `None`.
- Update the comments to reflect that this path covers both state resets and rooms whose current membership snapshot disappeared after a real leave.
- Add a regression test for a normal leave followed by removal of the current membership rows before the next incremental sync.

## Testing

- Added a handler-level regression test in `tests/handlers/test_sliding_sync.py`.
- Ran `python -m py_compile synapse/handlers/sliding_sync/room_lists.py tests/handlers/test_sliding_sync.py`.

Unfortunately, haven't been able to test this in production yet due to complexity, and I don't have a build setup.

## Client impact

This is the root-cause fix. Client side mitigations though just in case:

https://github.com/element-hq/element-x-android/pull/6532
https://github.com/element-hq/element-x-ios/pull/5354