### PR TITLE
Allow 'article' and 'profile' opengraph fields on URL previews.

### DIFF
--- a/changelog.d/19659.feature
+++ b/changelog.d/19659.feature
@@ -1,0 +1,1 @@
+Passthrough 'article' and 'profile' opengraph metadata on url preview requests.

--- a/synapse/media/preview_html.py
+++ b/synapse/media/preview_html.py
@@ -278,17 +278,15 @@ def parse_html_to_open_graph(tree: "etree._Element") -> dict[str, str | None]:
     # "og:video:height" : "720",
     # "og:video:secure_url": "https://www.youtube.com/v/LXDBoHyjmtw?version=3",
 
-    og = _get_meta_tags(tree, "property", "og")
+    ogRoot = _get_meta_tags(tree, "property", "og")
 
-    # TODO: Search for properties specific to the different Open Graph types,
-    # such as article: meta tags, e.g.:
-    #
-    # "article:publisher" : "https://www.facebook.com/thethudonline" />
-    # "article:author" content="https://www.facebook.com/thethudonline" />
-    # "article:tag" content="baby" />
-    # "article:section" content="Breaking News" />
-    # "article:published_time" content="2016-03-31T19:58:24+00:00" />
-    # "article:modified_time" content="2016-04-01T18:31:53+00:00" />
+    # https://ogp.me/#type_article
+    ogArticle = _get_meta_tags(tree, "property", "article")
+    # https://ogp.me/#type_profile
+    ogProfile = _get_meta_tags(tree, "property", "profile")
+
+    # Merge as-is
+    og = ogRoot | ogArticle | ogProfile
 
     # Search for Twitter Card (twitter:) meta tags, e.g.:
     #

--- a/tests/media/test_html_preview.py
+++ b/tests/media/test_html_preview.py
@@ -433,6 +433,28 @@ class OpenGraphFromHtmlTestCase(unittest.TestCase):
             },
         )
 
+    def test_extended_opengraph(self) -> None:
+        """Ensure we pull in profile and article data from opengraph."""
+        html = b"""
+        <html>
+        <meta property="og:description" content="My description" />
+        <meta property="profile:username" content="myname">
+        <meta property="article:published_time" content="2026-04-07T10:07:37Z">
+        </html>
+        """
+        tree = decode_body(html, "http://example.com/test.html")
+        assert tree is not None
+        og = parse_html_to_open_graph(tree)
+        self.assertEqual(
+            og,
+            {
+                "og:title": None,
+                "og:description": "My description",
+                "profile:username": "myname",
+                "article:published_time": "2026-04-07T10:07:37Z",
+            },
+        )
+
     def test_nested_nodes(self) -> None:
         """A body with some nested nodes. Tests that we iterate over children
         in the right order (and don't reverse the order of the text)."""


### PR DESCRIPTION
### Pull Request Checklist

Expands our support for opengraph to allow article and profile sections from https://ogp.me/#no_vertical. This will enable us to render richer previews for articles and social media links.

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
