### PR TITLE
docs/config: make it explicit that auto_join_rooms can be used for invite-only rooms

### DIFF
--- a/changelog.d/19660.doc
+++ b/changelog.d/19660.doc
@@ -1,0 +1,1 @@
+Update `auto_join_rooms` config documentation to cover requirements for auto-joining invite-only rooms.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -2866,6 +2866,8 @@ enable_3pid_changes: false
 
 By default, any room aliases included in this list will be created as a publicly joinable room when the first user registers for the homeserver. If the room already exists, make certain it is a publicly joinable room, i.e. the join rule of the room must be set to `public`. You can find more options relating to auto-joining rooms below.
 
+Invite-only rooms can also be auto-joined when setting `auto_join_mxid_localpart` to a user who's part of the invite-only rooms.
+
 As Spaces are just rooms under the hood, Space aliases may also be used.
 
 Defaults to `[]`.

--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -3223,6 +3223,10 @@ properties:
       options relating to auto-joining rooms below.
 
 
+      Invite-only rooms can also be auto-joined when setting `auto_join_mxid_localpart`
+      to a user who's part of the invite-only rooms.
+
+
       As Spaces are just rooms under the hood, Space aliases may also be used.
     items:
       type: string


### PR DESCRIPTION
Right now it looks like this option only works for publicly joinable rooms which is wrong thanks to `auto_join_mxid_localpart`. Point to that option to make it explicit you can also auto-invite people to invite-only rooms.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should (is this needed for a one-liner in the docs?):
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
