### PR TITLE
Support deleting media from non-local storage providers

### DIFF
--- a/changelog.d/19665.feature
+++ b/changelog.d/19665.feature
@@ -1,0 +1,1 @@
+Add support for deleting media from non-local providers. Contributed by @nexy7574.

--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -1542,11 +1542,11 @@ class MediaRepository:
             # TODO: Should we delete from the backup store
 
             async with self.remote_media_linearizer.queue(key):
-                full_path = self.filepaths.remote_media_filepath(origin, file_id)
+                file_info = FileInfo(origin, file_id)
                 try:
-                    os.remove(full_path)
+                    await self.media_storage.remove_file(file_info)
                 except OSError as e:
-                    logger.warning("Failed to remove file: %r", full_path)
+                    logger.warning("Failed to remove file: %r", file_info)
                     if e.errno == errno.ENOENT:
                         pass
                     else:
@@ -1622,12 +1622,12 @@ class MediaRepository:
         """
         removed_media = []
         for media_id in media_ids:
+            file_info = FileInfo(None, media_id)
             logger.info("Deleting media with ID '%s'", media_id)
-            full_path = self.filepaths.local_media_filepath(media_id)
             try:
-                os.remove(full_path)
+                await self.media_storage.remove_file(file_info)
             except OSError as e:
-                logger.warning("Failed to remove file: %r: %s", full_path, e)
+                logger.warning("Failed to remove file: %r: %s", file_info, e)
                 if e.errno == errno.ENOENT:
                     pass
                 else:

--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -1539,10 +1539,26 @@ class MediaRepository:
 
             logger.info("Deleting: %r", key)
 
-            # TODO: Should we delete from the backup store
-
             async with self.remote_media_linearizer.queue(key):
                 file_info = FileInfo(origin, file_id)
+                thumbnails = await self.store.get_remote_media_thumbnails(origin, media_id)
+                thumbnails_ok = True
+                for thumbnail_info in thumbnails:
+                    try:
+                        file = FileInfo(origin, file_id, thumbnail=thumbnail_info)
+                        await self.media_storage.remove_file(file)
+                    except OSError as e:
+                        logger.warning("Failed to remove file: %r", file_info)
+                        if thumbnails_ok:
+                            thumbnails_ok = e.errno == errno.ENOENT
+                if not thumbnails_ok:
+                    # Leave the parent intact to avoid dangling thumbnails
+                    continue
+                # remove the (now empty) dir if it existed at all
+                thumbnail_dir = self.filepaths.remote_media_thumbnail_dir(
+                    origin, file_id
+                )
+                shutil.rmtree(thumbnail_dir, ignore_errors=True)
                 try:
                     await self.media_storage.remove_file(file_info)
                 except OSError as e:
@@ -1551,11 +1567,6 @@ class MediaRepository:
                         pass
                     else:
                         continue
-
-                thumbnail_dir = self.filepaths.remote_media_thumbnail_dir(
-                    origin, file_id
-                )
-                shutil.rmtree(thumbnail_dir, ignore_errors=True)
 
                 await self.store.delete_remote_media(origin, media_id)
                 deleted += 1

--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -1544,11 +1544,11 @@ class MediaRepository:
                 thumbnails = await self.store.get_remote_media_thumbnails(origin, media_id)
                 thumbnails_ok = True
                 for thumbnail_info in thumbnails:
+                    file = FileInfo(origin, file_id, thumbnail=thumbnail_info)
                     try:
-                        file = FileInfo(origin, file_id, thumbnail=thumbnail_info)
                         await self.media_storage.remove_file(file)
                     except OSError as e:
-                        logger.warning("Failed to remove file: %r", file_info)
+                        logger.warning("Failed to remove file: %r", file)
                         if thumbnails_ok:
                             thumbnails_ok = e.errno == errno.ENOENT
                 if not thumbnails_ok:
@@ -1634,6 +1634,21 @@ class MediaRepository:
         removed_media = []
         for media_id in media_ids:
             file_info = FileInfo(None, media_id)
+            thumbnails = await self.store.get_local_media_thumbnails(media_id)
+            thumbnails_ok = True
+            for thumbnail in thumbnails:
+                file = FileInfo(None, media_id, thumbnail=thumbnail)
+                try:
+                    await self.media_storage.remove_file(file)
+                except OSError as e:
+                    logger.warning("Failed to remove file: %r", file)
+                    if thumbnails_ok:
+                        thumbnails_ok = e.errno == errno.ENOENT
+            if not thumbnails_ok:
+                # Don't leave dangling thumbnails
+                continue
+            thumbnail_dir = self.filepaths.local_media_thumbnail_dir(media_id)
+            shutil.rmtree(thumbnail_dir, ignore_errors=True)
             logger.info("Deleting media with ID '%s'", media_id)
             try:
                 await self.media_storage.remove_file(file_info)
@@ -1643,9 +1658,6 @@ class MediaRepository:
                     pass
                 else:
                     continue
-
-            thumbnail_dir = self.filepaths.local_media_thumbnail_dir(media_id)
-            shutil.rmtree(thumbnail_dir, ignore_errors=True)
 
             await self.store.delete_remote_media(self.server_name, media_id)
 

--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -1541,7 +1541,9 @@ class MediaRepository:
 
             async with self.remote_media_linearizer.queue(key):
                 file_info = FileInfo(origin, file_id)
-                thumbnails = await self.store.get_remote_media_thumbnails(origin, media_id)
+                thumbnails = await self.store.get_remote_media_thumbnails(
+                    origin, media_id
+                )
                 thumbnails_ok = True
                 for thumbnail_info in thumbnails:
                     file = FileInfo(origin, file_id, thumbnail=thumbnail_info)

--- a/synapse/media/media_storage.py
+++ b/synapse/media/media_storage.py
@@ -463,6 +463,16 @@ class MediaStorage:
             )
         return self.filepaths.local_media_filepath_rel(file_info.file_id)
 
+    async def remove_file(self, file_info: FileInfo) -> None:
+        """Removes the file described by file_info from the configured storage providers.
+
+        Args:
+            file_info: Metadata about the media file
+        """
+        paths = self._file_info_to_path(file_info)
+        for provider in filter(None, [self.local_provider, *self.storage_providers]):
+            await provider.delete(paths, file_info)
+
 
 @trace
 def _write_file_synchronously(source: IO, dest: IO) -> None:

--- a/synapse/media/media_storage.py
+++ b/synapse/media/media_storage.py
@@ -469,9 +469,9 @@ class MediaStorage:
         Args:
             file_info: Metadata about the media file
         """
-        paths = self._file_info_to_path(file_info)
+        path = self._file_info_to_path(file_info)
         for provider in filter(None, [self.local_provider, *self.storage_providers]):
-            await provider.delete(paths, file_info)
+            await provider.delete(path, file_info)
 
 
 @trace

--- a/synapse/media/storage_provider.py
+++ b/synapse/media/storage_provider.py
@@ -215,6 +215,7 @@ class FileStorageProviderBackend(StorageProvider):
 
     @trace_with_opname("FileStorageProviderBackend.delete")
     async def delete(self, path: str, file_info: FileInfo) -> None:
+        # Convert to an absolute path.
         fn = os.path.join(self.base_directory, path)
         if os.path.isfile(fn):
             os_remove: Callable[[str], None] = os.remove

--- a/synapse/media/storage_provider.py
+++ b/synapse/media/storage_provider.py
@@ -66,7 +66,6 @@ class StorageProvider(metaclass=abc.ABCMeta):
             Returns a Responder if the provider has the file, otherwise returns None.
         """
 
-    @abc.abstractmethod
     async def delete(self, path: str, file_info: FileInfo) -> None:
         """Delete the file described by file_info.
 
@@ -74,6 +73,7 @@ class StorageProvider(metaclass=abc.ABCMeta):
             path: Relative path of file in local cache
             file_info: The metadata of the file.
         """
+        return None
 
 
 class StorageProviderWrapper(StorageProvider):

--- a/synapse/media/storage_provider.py
+++ b/synapse/media/storage_provider.py
@@ -148,7 +148,7 @@ class StorageProviderWrapper(StorageProvider):
         if file_info.url_cache:
             return None
 
-        await maybe_awaitable(self.backend.delete(path, file_info))
+        return await maybe_awaitable(self.backend.delete(path, file_info))
 
 
 class FileStorageProviderBackend(StorageProvider):

--- a/synapse/media/storage_provider.py
+++ b/synapse/media/storage_provider.py
@@ -66,6 +66,15 @@ class StorageProvider(metaclass=abc.ABCMeta):
             Returns a Responder if the provider has the file, otherwise returns None.
         """
 
+    @abc.abstractmethod
+    async def delete(self, path: str, file_info: FileInfo) -> None:
+        """Delete the file described by file_info.
+
+        Args:
+            path: Relative path of file in local cache
+            file_info: The metadata of the file.
+        """
+
 
 class StorageProviderWrapper(StorageProvider):
     """Wraps a storage provider and provides various config options
@@ -133,6 +142,14 @@ class StorageProviderWrapper(StorageProvider):
         # against improper implementations.
         return await maybe_awaitable(self.backend.fetch(path, file_info))
 
+    @trace_with_opname("StorageProviderWrapper.delete")
+    async def delete(self, path: str, file_info: FileInfo) -> None:
+        # see: fetch
+        if file_info.url_cache:
+            return None
+
+        await maybe_awaitable(self.backend.delete(path, file_info))
+
 
 class FileStorageProviderBackend(StorageProvider):
     """A storage provider that stores files in a directory on a filesystem.
@@ -195,3 +212,14 @@ class FileStorageProviderBackend(StorageProvider):
         just pull that out.
         """
         return Config.ensure_directory(config["directory"])
+
+    @trace_with_opname("FileStorageProviderBackend.delete")
+    async def delete(self, path: str, file_info: FileInfo) -> None:
+        fn = os.path.join(self.base_directory, path)
+        if os.path.isfile(fn):
+            os_remove: Callable[[str], None] = os.remove
+            await defer_to_thread(
+                self.reactor,
+                os_remove,
+                fn,
+            )

--- a/synapse/media/storage_provider.py
+++ b/synapse/media/storage_provider.py
@@ -23,7 +23,7 @@ import abc
 import logging
 import os
 import shutil
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from synapse.config._base import Config
 from synapse.logging.context import defer_to_thread, run_in_background
@@ -179,11 +179,10 @@ class FileStorageProviderBackend(StorageProvider):
         os.makedirs(dirname, exist_ok=True)
 
         # mypy needs help inferring the type of the second parameter, which is generic
-        shutil_copyfile: Callable[[str, str], str] = shutil.copyfile
         with start_active_span("shutil_copyfile"):
             await defer_to_thread(
                 self.reactor,
-                shutil_copyfile,
+                shutil.copyfile,
                 primary_fname,
                 backup_fname,
             )
@@ -218,9 +217,8 @@ class FileStorageProviderBackend(StorageProvider):
         # Convert to an absolute path.
         fn = os.path.join(self.base_directory, path)
         if os.path.isfile(fn):
-            os_remove: Callable[[str], None] = os.remove
             await defer_to_thread(
                 self.reactor,
-                os_remove,
+                os.remove,
                 fn,
             )

--- a/synapse/media/storage_provider.py
+++ b/synapse/media/storage_provider.py
@@ -145,7 +145,7 @@ class StorageProviderWrapper(StorageProvider):
     @trace_with_opname("StorageProviderWrapper.delete")
     async def delete(self, path: str, file_info: FileInfo) -> None:
         # see: fetch
-        if file_info.url_cache:
+        if file_info.url_cache or getattr(self.backend, "delete", None) is None:
             return None
 
         return await maybe_awaitable(self.backend.delete(path, file_info))


### PR DESCRIPTION
Adds a new method, `delete` to the `StorageProvider` abstract base class. Also implements it for `FileStorageProviderBackend`. Downstream this is used in https://github.com/matrix-org/synapse-s3-storage-provider/pull/153

This change will allow external storage providers, such as synapse-s3-storage-provider, to delete media from their stores when media is removed. Previously, only media in the local provider would be removed, which means that deployments that stored their media on S3 would end up with dangling files, wasting storage.

Discussed in [`#synapse-dev:matrix.org`](https://matrix.to/#/!i5D5LLct_DYG-4hQprLzrxdbZ580U9UB6AEgFnk6rZQ/$kmKrkyROQ2PZiwVLPAa8Bg02RSpIJQLV18G7_LbvTTo?via=element.io&via=matrix.org&via=beeper.com)

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
