### PR TITLE
Remove unnecessary `self.pump` calls in some of our tests.

### DIFF
--- a/changelog.d/19676.misc
+++ b/changelog.d/19676.misc
@@ -1,0 +1,1 @@
+Remove unnecessary `self.pump` calls in some of our tests.

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -188,7 +188,6 @@ class KeyringTestCase(unittest.HomeserverTestCase):
 
         d2 = ensureDeferred(second_lookup())
 
-        self.pump()
         # the second request should be pending, but the fetcher should not yet have been
         # called
         self.assertEqual(second_lookup_state[0], 1)

--- a/tests/federation/test_complexity.py
+++ b/tests/federation/test_complexity.py
@@ -94,8 +94,6 @@ class RoomComplexityTests(unittest.FederatingHomeserverTestCase):
             {"membership": "join"},
         )
 
-        self.pump()
-
         # The request failed with a SynapseError saying the resource limit was
         # exceeded.
         f = self.get_failure(d, SynapseError)
@@ -124,8 +122,6 @@ class RoomComplexityTests(unittest.FederatingHomeserverTestCase):
             UserID.from_string(u1),
             {"membership": "join"},
         )
-
-        self.pump()
 
         # The request failed with a SynapseError saying the resource limit was
         # exceeded.
@@ -169,8 +165,6 @@ class RoomComplexityTests(unittest.FederatingHomeserverTestCase):
             UserID.from_string(u1),
             {"membership": "join"},
         )
-
-        self.pump()
 
         # The request failed with a SynapseError saying the resource limit was
         # exceeded.
@@ -221,8 +215,6 @@ class RoomComplexityAdminTests(unittest.FederatingHomeserverTestCase):
             {"membership": "join"},
         )
 
-        self.pump()
-
         # The request failed with a SynapseError saying the resource limit was
         # exceeded.
         f = self.get_failure(d, SynapseError)
@@ -250,8 +242,6 @@ class RoomComplexityAdminTests(unittest.FederatingHomeserverTestCase):
             UserID.from_string(u1),
             {"membership": "join"},
         )
-
-        self.pump()
 
         # The request success since the user is an admin
         self.get_success(d)

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -153,7 +153,6 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
         )
 
         self.helper.send(room, "wombats!", tok=u1_token)
-        self.pump()
 
         lsso_1 = self.get_success(
             self.hs.get_datastores().main.get_destination_last_successful_stream_ordering(

--- a/tests/http/test_matrixfederationclient.py
+++ b/tests/http/test_matrixfederationclient.py
@@ -847,6 +847,9 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
             self.hs.get_federation_http_client().get_json("remoteserv:8008", "foo/bar")
         )
 
+        # Needed under Postgres
+        self.pump()
+
         # Make sure that the request was proxied through the `federation_sender` worker
         mock_agent_on_federation_sender.request.assert_called_once_with(
             b"GET",
@@ -895,6 +898,9 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
         test_request_from_main_process_d = defer.ensureDeferred(
             self.hs.get_federation_http_client().get_json("remoteserv:8008", "foo/bar")
         )
+
+        # Needed under Postgres
+        self.pump(0.1)
 
         # Make sure that the request was proxied through the `federation_sender` worker
         mock_agent_on_federation_sender.request.assert_called_with(
@@ -969,6 +975,9 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
                 "remoteserv:8008", "foo/bar"
             )
         )
+
+        # Needed under Postgres
+        self.pump()
 
         # Make sure that the request was proxied through the `federation_sender` worker
         mock_agent_on_federation_sender.request.assert_called_once_with(
@@ -1060,6 +1069,9 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
         test_request_from_main_process_d = defer.ensureDeferred(
             self.hs.get_federation_http_client().get_json("remoteserv:8008", "foo/bar")
         )
+
+        # Needed under Postgres
+        self.pump(0.1)
 
         # Make sure that the request was *NOT* proxied through the `federation_sender`
         # worker

--- a/tests/http/test_matrixfederationclient.py
+++ b/tests/http/test_matrixfederationclient.py
@@ -133,8 +133,6 @@ class FederationClientTests(HomeserverTestCase):
             b"%s" % (len(res_json), res_json)
         )
 
-        self.pump()
-
         res = self.successResultOf(test_d)
 
         # check the response is as expected
@@ -710,8 +708,6 @@ class FederationClientTests(HomeserverTestCase):
             b"%s" % (len(return_value), return_value)
         )
 
-        self.pump()
-
         f = self.failureResultOf(test_d)
         self.assertIsInstance(f.value, RequestSendFailed)
 
@@ -750,8 +746,6 @@ class FederationClientTests(HomeserverTestCase):
         protocol.dataReceived(
             b"HTTP/1.1 200 OK\r\nServer: Fake\r\nContent-Type: application/json\r\n\r\n"
         )
-
-        self.pump()
 
         # should still be waiting
         self.assertNoResult(test_d)
@@ -853,9 +847,6 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
             self.hs.get_federation_http_client().get_json("remoteserv:8008", "foo/bar")
         )
 
-        # Pump the reactor so our deferred goes through the motions
-        self.pump()
-
         # Make sure that the request was proxied through the `federation_sender` worker
         mock_agent_on_federation_sender.request.assert_called_once_with(
             b"GET",
@@ -904,11 +895,6 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
         test_request_from_main_process_d = defer.ensureDeferred(
             self.hs.get_federation_http_client().get_json("remoteserv:8008", "foo/bar")
         )
-
-        # Pump the reactor so our deferred goes through the motions. We pump with 10
-        # seconds (0.1 * 100) so the `MatrixFederationHttpClient` runs out of retries
-        # and finally passes along the error response.
-        self.pump(0.1)
 
         # Make sure that the request was proxied through the `federation_sender` worker
         mock_agent_on_federation_sender.request.assert_called_with(
@@ -983,9 +969,6 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
                 "remoteserv:8008", "foo/bar"
             )
         )
-
-        # Pump the reactor so our deferred goes through the motions
-        self.pump()
 
         # Make sure that the request was proxied through the `federation_sender` worker
         mock_agent_on_federation_sender.request.assert_called_once_with(
@@ -1077,11 +1060,6 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
         test_request_from_main_process_d = defer.ensureDeferred(
             self.hs.get_federation_http_client().get_json("remoteserv:8008", "foo/bar")
         )
-
-        # Pump the reactor so our deferred goes through the motions. We pump with 10
-        # seconds (0.1 * 100) so the `MatrixFederationHttpClient` runs out of retries
-        # and finally passes along the error response.
-        self.pump(0.1)
 
         # Make sure that the request was *NOT* proxied through the `federation_sender`
         # worker

--- a/tests/http/test_simple_client.py
+++ b/tests/http/test_simple_client.py
@@ -46,15 +46,12 @@ class SimpleHttpClientTests(HomeserverTestCase):
         If the DNS lookup returns an error, it will bubble up.
         """
         d = defer.ensureDeferred(self.cl.get_json("http://testserv2:8008/foo/bar"))
-        self.pump()
 
         f = self.failureResultOf(d)
         self.assertIsInstance(f.value, DNSLookupError)
 
     def test_client_connection_refused(self) -> None:
         d = defer.ensureDeferred(self.cl.get_json("http://testserv:8008/foo/bar"))
-
-        self.pump()
 
         # Nothing happened yet
         self.assertNoResult(d)
@@ -78,8 +75,6 @@ class SimpleHttpClientTests(HomeserverTestCase):
         ConnectingCancelledError or TimeoutError.
         """
         d = defer.ensureDeferred(self.cl.get_json("http://testserv:8008/foo/bar"))
-
-        self.pump()
 
         # Nothing happened yet
         self.assertNoResult(d)
@@ -105,8 +100,6 @@ class SimpleHttpClientTests(HomeserverTestCase):
         timed out, it'll give a ResponseNeverReceived.
         """
         d = defer.ensureDeferred(self.cl.get_json("http://testserv:8008/foo/bar"))
-
-        self.pump()
 
         # Nothing happened yet
         self.assertNoResult(d)

--- a/tests/media/test_media_storage.py
+++ b/tests/media/test_media_storage.py
@@ -845,8 +845,6 @@ class MediaRepoTests(unittest.HomeserverTestCase):
             HttpResponseException(404, "NOT FOUND", unknown_endpoint)
         )
 
-        self.pump()
-
         # There should now be another request to the r0 URL.
         self.assertEqual(len(self.fetches), 2)
         self.assertEqual(self.fetches[1][1], "example.com")

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -159,9 +159,6 @@ class HTTPPusherTests(HomeserverTestCase):
         self.assertEqual(len(pushers), 1)
         last_stream_ordering = pushers[0].last_stream_ordering
 
-        # Advance time a bit, so the pusher will register something has happened
-        self.pump()
-
         # It hasn't succeeded yet, so the stream ordering shouldn't have moved
         pushers = list(
             self.get_success(
@@ -182,7 +179,6 @@ class HTTPPusherTests(HomeserverTestCase):
 
         # Make the push succeed
         self.push_attempts[0][0].callback({})
-        self.pump()
 
         # The stream ordering has increased
         pushers = list(
@@ -205,7 +201,6 @@ class HTTPPusherTests(HomeserverTestCase):
 
         # Make the second push succeed
         self.push_attempts[1][0].callback({})
-        self.pump()
 
         # The stream ordering has increased, again
         pushers = list(
@@ -284,12 +279,8 @@ class HTTPPusherTests(HomeserverTestCase):
             tok=other_access_token,
         )
 
-        # Advance time a bit, so the pusher will register something has happened
-        self.pump()
-
         # Make the push succeed
         self.push_attempts[0][0].callback({})
-        self.pump()
 
         # Check our push made it with high priority
         self.assertEqual(len(self.push_attempts), 1)
@@ -308,7 +299,6 @@ class HTTPPusherTests(HomeserverTestCase):
 
         # Check no push notifications are sent regarding the membership changes
         # (that would confuse the test)
-        self.pump()
         self.assertEqual(len(self.push_attempts), 1)
 
         # Send another encrypted event
@@ -330,8 +320,6 @@ class HTTPPusherTests(HomeserverTestCase):
             tok=other_access_token,
         )
 
-        # Advance time a bit, so the pusher will register something has happened
-        self.pump()
         self.assertEqual(len(self.push_attempts), 2)
         self.assertEqual(
             self.push_attempts[1][1], "http://example.com/_matrix/push/v1/notify"
@@ -385,12 +373,8 @@ class HTTPPusherTests(HomeserverTestCase):
         # Send a message
         self.helper.send(room, body="Hi!", tok=other_access_token)
 
-        # Advance time a bit, so the pusher will register something has happened
-        self.pump()
-
         # Make the push succeed
         self.push_attempts[0][0].callback({})
-        self.pump()
 
         # Check our push made it with high priority — this is a one-to-one room
         self.assertEqual(len(self.push_attempts), 1)
@@ -406,14 +390,11 @@ class HTTPPusherTests(HomeserverTestCase):
 
         # Check no push notifications are sent regarding the membership changes
         # (that would confuse the test)
-        self.pump()
         self.assertEqual(len(self.push_attempts), 1)
 
         # Send another event
         self.helper.send(room, body="Welcome!", tok=other_access_token)
 
-        # Advance time a bit, so the pusher will register something has happened
-        self.pump()
         self.assertEqual(len(self.push_attempts), 2)
         self.assertEqual(
             self.push_attempts[1][1], "http://example.com/_matrix/push/v1/notify"
@@ -472,12 +453,8 @@ class HTTPPusherTests(HomeserverTestCase):
         # Send a message
         self.helper.send(room, body="Oh, user, hello!", tok=other_access_token)
 
-        # Advance time a bit, so the pusher will register something has happened
-        self.pump()
-
         # Make the push succeed
         self.push_attempts[0][0].callback({})
-        self.pump()
 
         # Check our push made it with high priority
         self.assertEqual(len(self.push_attempts), 1)
@@ -489,8 +466,6 @@ class HTTPPusherTests(HomeserverTestCase):
         # Send another event, this time with no mention
         self.helper.send(room, body="Are you there?", tok=other_access_token)
 
-        # Advance time a bit, so the pusher will register something has happened
-        self.pump()
         self.assertEqual(len(self.push_attempts), 2)
         self.assertEqual(
             self.push_attempts[1][1], "http://example.com/_matrix/push/v1/notify"
@@ -554,12 +529,8 @@ class HTTPPusherTests(HomeserverTestCase):
             tok=other_access_token,
         )
 
-        # Advance time a bit, so the pusher will register something has happened
-        self.pump()
-
         # Make the push succeed
         self.push_attempts[0][0].callback({})
-        self.pump()
 
         # Check our push made it with high priority
         self.assertEqual(len(self.push_attempts), 1)
@@ -573,8 +544,6 @@ class HTTPPusherTests(HomeserverTestCase):
             room, body="@room the spider is gone", tok=yet_another_access_token
         )
 
-        # Advance time a bit, so the pusher will register something has happened
-        self.pump()
         self.assertEqual(len(self.push_attempts), 2)
         self.assertEqual(
             self.push_attempts[1][1], "http://example.com/_matrix/push/v1/notify"
@@ -703,7 +672,6 @@ class HTTPPusherTests(HomeserverTestCase):
         self.helper.send(room_id, body="HELLO???", tok=other_access_token)
 
     def _advance_time_and_make_push_succeed(self, expected_push_attempts: int) -> None:
-        self.pump()
         self.push_attempts[expected_push_attempts - 1][0].callback({})
 
     def _check_push_attempt(
@@ -1084,7 +1052,6 @@ class HTTPPusherTests(HomeserverTestCase):
                 index += 1
 
             self.reactor.advance(1)
-            self.pump()
 
         self.assertEqual(len(self.push_attempts), 11)
 
@@ -1150,7 +1117,6 @@ class HTTPPusherTests(HomeserverTestCase):
         self.helper.send(room, body="Hi!", tok=other_access_token)
 
         # Advance time a bit, so the pusher will register something has happened
-        self.pump()
 
         # One push was attempted to be sent
         self.assertEqual(len(self.push_attempts), 1)
@@ -1218,17 +1184,14 @@ class HTTPPusherTests(HomeserverTestCase):
             self.push_attempts[0][2]["notification"]["content"]["body"], "Message 1"
         )
         self.push_attempts[0][0].callback({})
-        self.pump()
 
         # Send another message, this time it fails
         self.helper.send(room, body="Message 2", tok=other_access_token)
         self.assertEqual(len(self.push_attempts), 2)
         self.push_attempts[1][0].errback(Exception("couldn't connect"))
-        self.pump()
 
         # Sending yet another message doesn't trigger a push immediately
         self.helper.send(room, body="Message 3", tok=other_access_token)
-        self.pump()
         self.assertEqual(len(self.push_attempts), 2)
 
         # .. but waiting for a bit will cause more pushes

--- a/tests/replication/test_multi_media_repo.py
+++ b/tests/replication/test_multi_media_repo.py
@@ -98,6 +98,9 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
             await_result=False,
         )
 
+        # Needed under Postgres
+        self.pump()
+
         clients = self.reactor.tcpClients
         self.assertGreaterEqual(len(clients), 1)
         (host, port, client_factory, _timeout, _bindAddress) = clients.pop()
@@ -160,6 +163,9 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request.write(b"Hello!")
         request.finish()
 
+        # Needed under Postgres
+        self.pump(0.1)
+
         self.assertEqual(channel.code, 200)
         self.assertEqual(channel.result["body"], b"Hello!")
 
@@ -184,6 +190,9 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request1.write(b"Hello!")
         request1.finish()
 
+        # Needed under Postgres
+        self.pump(0.1)
+
         self.assertEqual(channel1.code, 200, channel1.result["body"])
         self.assertEqual(channel1.result["body"], b"Hello!")
 
@@ -192,6 +201,9 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request2.responseHeaders.setRawHeaders(b"Content-Type", [b"text/plain"])
         request2.write(b"Hello!")
         request2.finish()
+
+        # Needed under Postgres
+        self.pump(0.1)
 
         self.assertEqual(channel2.code, 200, channel2.result["body"])
         self.assertEqual(channel2.result["body"], b"Hello!")
@@ -226,6 +238,9 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request1.write(b"Hello!")
         request1.finish()
 
+        # Needed under Postgres
+        self.pump(0.1)
+
         # With local storage disabled and no storage providers,
         # we expect a 404 error
         self.assertEqual(channel1.code, 404, channel1.result["body"])
@@ -235,6 +250,9 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request2.responseHeaders.setRawHeaders(b"Content-Type", [b"text/plain"])
         request2.write(b"Hello!")
         request2.finish()
+
+        # Needed under Postgres
+        self.pump(0.1)
 
         # Same for the second request
         self.assertEqual(channel2.code, 404, channel2.result["body"])
@@ -262,6 +280,9 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request1.write(SMALL_PNG)
         request1.finish()
 
+        # Needed under Postgres
+        self.pump(0.1)
+
         self.assertEqual(channel1.code, 200, channel1.result["body"])
         self.assertEqual(channel1.result["body"], SMALL_PNG)
 
@@ -269,6 +290,9 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request2.responseHeaders.setRawHeaders(b"Content-Type", [b"image/png"])
         request2.write(SMALL_PNG)
         request2.finish()
+
+        # Needed under Postgres
+        self.pump(0.1)
 
         self.assertEqual(channel2.code, 200, channel2.result["body"])
         self.assertEqual(channel2.result["body"], SMALL_PNG)
@@ -345,6 +369,9 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
             await_result=False,
         )
 
+        # Needed under Postgres
+        self.pump()
+
         clients = self.reactor.tcpClients
         self.assertGreaterEqual(len(clients), 1)
         (host, port, client_factory, _timeout, _bindAddress) = clients.pop()
@@ -409,6 +436,9 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request.write(self.file_data)
         request.finish()
 
+        # Needed under Postgres
+        self.pump(0.1)
+
         self.assertEqual(channel.code, 200)
         self.assertEqual(channel.result["body"], b"file_to_stream")
 
@@ -435,6 +465,9 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request1.write(self.file_data)
         request1.finish()
 
+        # Needed under Postgres
+        self.pump(0.1)
+
         self.assertEqual(channel1.code, 200, channel1.result["body"])
         self.assertEqual(channel1.result["body"], b"file_to_stream")
 
@@ -446,6 +479,9 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         )
         request2.write(self.file_data)
         request2.finish()
+
+        # Needed under Postgres
+        self.pump(0.1)
 
         self.assertEqual(channel2.code, 200, channel2.result["body"])
         self.assertEqual(channel2.result["body"], b"file_to_stream")
@@ -479,6 +515,9 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request1.write(self.file_data)
         request1.finish()
 
+        # Needed under Postgres
+        self.pump(0.1)
+
         # With local storage disabled and no storage providers,
         # we expect a 404 error
         self.assertEqual(channel1.code, 404, channel1.result["body"])
@@ -491,6 +530,9 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         )
         request2.write(self.file_data)
         request2.finish()
+
+        # Needed under Postgres
+        self.pump(0.1)
 
         self.assertEqual(channel2.code, 404, channel2.result["body"])
 
@@ -522,6 +564,9 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request1.write(b"\r\n--6067d4698f8d40a0a794ea7d7379d53a--\r\n\r\n")
         request1.finish()
 
+        # Needed under Postgres
+        self.pump(0.1)
+
         self.assertEqual(channel1.code, 200, channel1.result["body"])
         self.assertEqual(channel1.result["body"], SMALL_PNG)
 
@@ -534,6 +579,9 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request2.write(SMALL_PNG)
         request2.write(b"\r\n--6067d4698f8d40a0a794ea7d7379d53a--\r\n\r\n")
         request2.finish()
+
+        # Needed under Postgres
+        self.pump(0.1)
 
         self.assertEqual(channel2.code, 200, channel2.result["body"])
         self.assertEqual(channel2.result["body"], SMALL_PNG)

--- a/tests/replication/test_multi_media_repo.py
+++ b/tests/replication/test_multi_media_repo.py
@@ -97,7 +97,6 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
             access_token=self.access_token,
             await_result=False,
         )
-        self.pump()
 
         clients = self.reactor.tcpClients
         self.assertGreaterEqual(len(clients), 1)
@@ -161,8 +160,6 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request.write(b"Hello!")
         request.finish()
 
-        self.pump(0.1)
-
         self.assertEqual(channel.code, 200)
         self.assertEqual(channel.result["body"], b"Hello!")
 
@@ -187,8 +184,6 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request1.write(b"Hello!")
         request1.finish()
 
-        self.pump(0.1)
-
         self.assertEqual(channel1.code, 200, channel1.result["body"])
         self.assertEqual(channel1.result["body"], b"Hello!")
 
@@ -197,8 +192,6 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request2.responseHeaders.setRawHeaders(b"Content-Type", [b"text/plain"])
         request2.write(b"Hello!")
         request2.finish()
-
-        self.pump(0.1)
 
         self.assertEqual(channel2.code, 200, channel2.result["body"])
         self.assertEqual(channel2.result["body"], b"Hello!")
@@ -233,8 +226,6 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request1.write(b"Hello!")
         request1.finish()
 
-        self.pump(0.1)
-
         # With local storage disabled and no storage providers,
         # we expect a 404 error
         self.assertEqual(channel1.code, 404, channel1.result["body"])
@@ -244,8 +235,6 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request2.responseHeaders.setRawHeaders(b"Content-Type", [b"text/plain"])
         request2.write(b"Hello!")
         request2.finish()
-
-        self.pump(0.1)
 
         # Same for the second request
         self.assertEqual(channel2.code, 404, channel2.result["body"])
@@ -273,8 +262,6 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request1.write(SMALL_PNG)
         request1.finish()
 
-        self.pump(0.1)
-
         self.assertEqual(channel1.code, 200, channel1.result["body"])
         self.assertEqual(channel1.result["body"], SMALL_PNG)
 
@@ -282,8 +269,6 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request2.responseHeaders.setRawHeaders(b"Content-Type", [b"image/png"])
         request2.write(SMALL_PNG)
         request2.finish()
-
-        self.pump(0.1)
 
         self.assertEqual(channel2.code, 200, channel2.result["body"])
         self.assertEqual(channel2.result["body"], SMALL_PNG)
@@ -359,7 +344,6 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
             access_token=self.access_token,
             await_result=False,
         )
-        self.pump()
 
         clients = self.reactor.tcpClients
         self.assertGreaterEqual(len(clients), 1)
@@ -425,8 +409,6 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request.write(self.file_data)
         request.finish()
 
-        self.pump(0.1)
-
         self.assertEqual(channel.code, 200)
         self.assertEqual(channel.result["body"], b"file_to_stream")
 
@@ -453,8 +435,6 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request1.write(self.file_data)
         request1.finish()
 
-        self.pump(0.1)
-
         self.assertEqual(channel1.code, 200, channel1.result["body"])
         self.assertEqual(channel1.result["body"], b"file_to_stream")
 
@@ -466,8 +446,6 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         )
         request2.write(self.file_data)
         request2.finish()
-
-        self.pump(0.1)
 
         self.assertEqual(channel2.code, 200, channel2.result["body"])
         self.assertEqual(channel2.result["body"], b"file_to_stream")
@@ -501,7 +479,6 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request1.write(self.file_data)
         request1.finish()
 
-        self.pump(0.1)
         # With local storage disabled and no storage providers,
         # we expect a 404 error
         self.assertEqual(channel1.code, 404, channel1.result["body"])
@@ -514,8 +491,6 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         )
         request2.write(self.file_data)
         request2.finish()
-
-        self.pump(0.1)
 
         self.assertEqual(channel2.code, 404, channel2.result["body"])
 
@@ -547,8 +522,6 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request1.write(b"\r\n--6067d4698f8d40a0a794ea7d7379d53a--\r\n\r\n")
         request1.finish()
 
-        self.pump(0.1)
-
         self.assertEqual(channel1.code, 200, channel1.result["body"])
         self.assertEqual(channel1.result["body"], SMALL_PNG)
 
@@ -561,8 +534,6 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         request2.write(SMALL_PNG)
         request2.write(b"\r\n--6067d4698f8d40a0a794ea7d7379d53a--\r\n\r\n")
         request2.finish()
-
-        self.pump(0.1)
 
         self.assertEqual(channel2.code, 200, channel2.result["body"])
         self.assertEqual(channel2.result["body"], SMALL_PNG)

--- a/tests/rest/client/test_filter.py
+++ b/tests/rest/client/test_filter.py
@@ -57,7 +57,6 @@ class FilterTestCase(unittest.HomeserverTestCase):
                 user_id=UserID.from_string(FilterTestCase.user_id), filter_id=0
             )
         )
-        self.pump()
         self.assertEqual(filter, self.EXAMPLE_FILTER)
 
     def test_add_filter_for_other_user(self) -> None:

--- a/tests/storage/databases/main/test_lock.py
+++ b/tests/storage/databases/main/test_lock.py
@@ -66,16 +66,11 @@ class LockTestCase(unittest.HomeserverTestCase):
         task2 = defer.ensureDeferred(task())
         task3 = defer.ensureDeferred(task())
 
-        # Give the reactor a kick so that the database transaction returns.
-        self.pump()
-
         release_lock.callback(None)
 
         # Run the tasks to completion.
         self.get_success(task1)
-        self.pump()
         self.get_success(task2)
-        self.pump()
         self.get_success(task3)
 
         # At most one task should have held the lock at a time.

--- a/tests/storage/databases/main/test_metrics.py
+++ b/tests/storage/databases/main/test_metrics.py
@@ -55,7 +55,6 @@ class ExtremStatisticsTestCase(HomeserverTestCase):
         # Let it run for a while, then pull out the statistics from the
         # Prometheus client registry
         self.reactor.advance(60 * 60 * 1000)
-        self.pump(1)
 
         items = list(
             filter(

--- a/tests/storage/test_client_ips.py
+++ b/tests/storage/test_client_ips.py
@@ -101,7 +101,6 @@ class ClientIpStoreTestCase(unittest.HomeserverTestCase):
             )
         )
         self.reactor.advance(200)
-        self.pump(0)
 
         result = cast(
             list[tuple[str, str, str, str | None, int]],
@@ -132,7 +131,6 @@ class ClientIpStoreTestCase(unittest.HomeserverTestCase):
             )
         )
         self.reactor.advance(10)
-        self.pump(0)
 
         result = cast(
             list[tuple[str, str, str, str | None, int]],

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -100,8 +100,6 @@ class RoomMemberStoreTestCase(unittest.HomeserverTestCase):
         self.inject_room_member(self.room, self.u_bob, Membership.JOIN)
         self.inject_room_member(self.room, self.u_charlie.to_string(), Membership.JOIN)
 
-        self.pump()
-
         self.assertTrue("_known_servers_count" not in self.store.__dict__.keys())
 
     @unittest.override_config(
@@ -113,8 +111,6 @@ class RoomMemberStoreTestCase(unittest.HomeserverTestCase):
         """
         # Initialises to 1 -- itself
         self.assertEqual(self.store._known_servers_count, 1)
-
-        self.pump()
 
         # No rooms have been joined, so technically the SQL returns 0, but it
         # will still say it knows about itself.


### PR DESCRIPTION
Spawning from some discussion on https://github.com/element-hq/synapse/pull/19602

There are a good handful of `self.pump` calls that are not necessary for the test to complete.

This PR removes the ones that a basic dirty search & replace script found.

After this, I have a `self.advance` helper I intend to PR up that is a wrapper for `self.reactor.advance`
with assertions that there is actually progress to be made.
