### PR TITLE
Switch list quarantined media API to use max to_id instead of current

### DIFF
--- a/changelog.d/19677.feature
+++ b/changelog.d/19677.feature
@@ -1,0 +1,1 @@
+Add a ["Listing quarantined media changes" Admin API](https://element-hq.github.io/synapse/latest/admin_api/media_admin_api.html#listing-quarantined-media-changes) for retrieving a paginated record of when media became (un)quarantined.

--- a/synapse/rest/admin/media.py
+++ b/synapse/rest/admin/media.py
@@ -249,9 +249,9 @@ class ListQuarantineChanges(RestServlet):
 
         from_id = parse_integer(request, "from", default=0)
         limit = 100  # arbitrary; not enough to cause problems (hopefully)
-        to_id = await self.store.get_max_quarantined_media_stream_id()
 
-        if to_id < from_id:
+        max_id = await self.store.get_max_quarantined_media_stream_id()
+        if from_id > max_id:
             # The caller is trying to get future data, which isn't possible.
             raise SynapseError(
                 HTTPStatus.BAD_REQUEST,
@@ -275,6 +275,7 @@ class ListQuarantineChanges(RestServlet):
                 errcode=Codes.UNKNOWN,
             )
 
+        to_id = await self.store.get_current_quarantined_media_stream_id()
         changes = await self.store.get_quarantined_media_changes(
             from_id=from_id,
             to_id=to_id,

--- a/synapse/rest/admin/media.py
+++ b/synapse/rest/admin/media.py
@@ -249,7 +249,7 @@ class ListQuarantineChanges(RestServlet):
 
         from_id = parse_integer(request, "from", default=0)
         limit = 100  # arbitrary; not enough to cause problems (hopefully)
-        to_id = await self.store.get_current_quarantined_media_stream_id()
+        to_id = await self.store.get_max_quarantined_media_stream_id()
 
         if to_id < from_id:
             # The caller is trying to get future data, which isn't possible.

--- a/synapse/rest/admin/media.py
+++ b/synapse/rest/admin/media.py
@@ -254,7 +254,7 @@ class ListQuarantineChanges(RestServlet):
         if from_id > max_id:
             # The caller is trying to get future data, which we don't allow because
             # we know it's an invalid state that should never happen. We could
-            # wait until we reach the token but we might as well now waste our
+            # wait until we reach the token but we might as well not waste our
             # resources on that which is why `wait_for_quarantined_media_stream_id(...)`
             # has assertions around this.
             raise SynapseError(

--- a/synapse/rest/admin/media.py
+++ b/synapse/rest/admin/media.py
@@ -250,9 +250,13 @@ class ListQuarantineChanges(RestServlet):
         from_id = parse_integer(request, "from", default=0)
         limit = 100  # arbitrary; not enough to cause problems (hopefully)
 
-        max_id = await self.store.get_max_quarantined_media_stream_id()
+        max_id = await self.store.get_max_allocated_quarantined_media_stream_id()
         if from_id > max_id:
-            # The caller is trying to get future data, which isn't possible.
+            # The caller is trying to get future data, which we don't allow because
+            # we know it's an invalid state that should never happen. We could
+            # wait until we reach the token but we might as well now waste our
+            # resources on that which is why `wait_for_quarantined_media_stream_id(...)`
+            # has assertions around this.
             raise SynapseError(
                 HTTPStatus.BAD_REQUEST,
                 "The `from` token is considered invalid because it includes stream positions "

--- a/synapse/rest/admin/media.py
+++ b/synapse/rest/admin/media.py
@@ -250,6 +250,7 @@ class ListQuarantineChanges(RestServlet):
         from_id = parse_integer(request, "from", default=0)
         limit = 100  # arbitrary; not enough to cause problems (hopefully)
 
+        # Validate the `from` token
         max_id = await self.store.get_max_allocated_quarantined_media_stream_id()
         if from_id > max_id:
             # The caller is trying to get future data, which we don't allow because

--- a/synapse/rest/admin/media.py
+++ b/synapse/rest/admin/media.py
@@ -255,7 +255,11 @@ class ListQuarantineChanges(RestServlet):
             # The caller is trying to get future data, which isn't possible.
             raise SynapseError(
                 HTTPStatus.BAD_REQUEST,
-                "The `from` position is ahead of the currently persisted position.",
+                "The `from` token is considered invalid because it includes stream positions "
+                "greater than the furthest persisted position across all of the workers."
+                "This indicates either a Synapse programming error (as we should never hand out "
+                "invalid future tokens) or a fabricated `from` token. If you've modified the token, "
+                "you can try paginating from the beginning again.",
                 errcode=Codes.INVALID_PARAM,
             )
 

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1308,7 +1308,7 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
         Returns:
             int - the maximum stream ID
         """
-        return self._quarantined_media_changes_id_gen.get_max_allocated_token()
+        return await self._quarantined_media_changes_id_gen.get_max_allocated_token()
 
     async def wait_for_quarantined_media_stream_id(self, target_id: int) -> bool:
         """Waits until the quarantined media changes stream reaches the given stream ID.

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1310,8 +1310,8 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
         """
         return self._quarantined_media_changes_id_gen.get_current_token()
 
-    async def get_max_quarantined_media_stream_id(self) -> int:
-        """Gets the maximum position of the quarantined media changes stream.
+    async def get_max_allocated_quarantined_media_stream_id(self) -> int:
+        """Gets the maximum allocated position of the quarantined media changes stream.
 
         Returns:
             int - the maximum stream ID

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1302,6 +1302,14 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
 
         return local_media_ids
 
+    async def get_current_quarantined_media_stream_id(self) -> int:
+        """Gets the position of the quarantined media changes stream.
+
+        Returns:
+            int - the current stream ID
+        """
+        return self._quarantined_media_changes_id_gen.get_current_token()
+
     async def get_max_quarantined_media_stream_id(self) -> int:
         """Gets the maximum position of the quarantined media changes stream.
 

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1302,13 +1302,13 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
 
         return local_media_ids
 
-    async def get_current_quarantined_media_stream_id(self) -> int:
-        """Gets the position of the quarantined media changes stream.
+    async def get_max_quarantined_media_stream_id(self) -> int:
+        """Gets the maximum position of the quarantined media changes stream.
 
         Returns:
-            int - the current stream ID
+            int - the maximum stream ID
         """
-        return self._quarantined_media_changes_id_gen.get_current_token()
+        return self._quarantined_media_changes_id_gen.get_max_allocated_token()
 
     async def wait_for_quarantined_media_stream_id(self, target_id: int) -> bool:
         """Waits until the quarantined media changes stream reaches the given stream ID.


### PR DESCRIPTION
Following up on https://github.com/element-hq/synapse/pull/19558#discussion_r3054831510

Changelog for this PR is intended to overlap with the above PR.

`get_current_quarantined_media_stream_id` wasn't being used anywhere else, so we can replace it like we do in this PR.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
