### PR TITLE
Small simplifications to the events class

### DIFF
--- a/changelog.d/19680.misc
+++ b/changelog.d/19680.misc
@@ -1,0 +1,1 @@
+Small simplifications to the events class.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -358,7 +358,7 @@ def check_state_dependent_auth_rules(
     # a user is allowed to issue invites.  Fixes
     # https://github.com/vector-im/vector-web/issues/1208 hopefully
     if event.type == EventTypes.ThirdPartyInvite:
-        user_level = get_user_power_level(event.user_id, auth_dict)
+        user_level = get_user_power_level(event.sender, auth_dict)
         invite_level = get_named_level(auth_dict, "invite", 0)
 
         if user_level < invite_level:
@@ -409,8 +409,8 @@ def _check_size_limits(event: "EventBase") -> None:
 
     # Codepoint size check: Synapse always enforced these limits, so apply
     # them strictly.
-    if len(event.user_id) > 255:
-        raise EventSizeError("'user_id' too large", unpersistable=True)
+    if len(event.sender) > 255:
+        raise EventSizeError("'sender' too large", unpersistable=True)
     if len(event.room_id) > 255:
         raise EventSizeError("'room_id' too large", unpersistable=True)
     if event.is_state() and len(event.state_key) > 255:
@@ -423,8 +423,8 @@ def _check_size_limits(event: "EventBase") -> None:
     strict_byte_limits = event.room_version.strict_event_byte_limits_room_versions
 
     # Byte size check: if these fail, then be lenient to avoid breaking rooms.
-    if len(event.user_id.encode("utf-8")) > 255:
-        raise EventSizeError("'user_id' too large", unpersistable=strict_byte_limits)
+    if len(event.sender.encode("utf-8")) > 255:
+        raise EventSizeError("'sender' too large", unpersistable=strict_byte_limits)
     if len(event.room_id.encode("utf-8")) > 255:
         raise EventSizeError("'room_id' too large", unpersistable=strict_byte_limits)
     if event.is_state() and len(event.state_key.encode("utf-8")) > 255:
@@ -544,7 +544,7 @@ def _is_membership_change_allowed(
             raise AuthError(403, "This room has been marked as unfederatable.")
 
     # get info about the caller
-    key = (EventTypes.Member, event.user_id)
+    key = (EventTypes.Member, event.sender)
     caller = auth_events.get(key)
 
     caller_in_room = caller and caller.membership == Membership.JOIN
@@ -569,7 +569,7 @@ def _is_membership_change_allowed(
     else:
         join_rule = JoinRules.INVITE
 
-    user_level = get_user_power_level(event.user_id, auth_events)
+    user_level = get_user_power_level(event.sender, auth_events)
     target_level = get_user_power_level(target_user_id, auth_events)
 
     invite_level = get_named_level(auth_events, "invite", 0)
@@ -587,7 +587,7 @@ def _is_membership_change_allowed(
             "membership": membership,
             "join_rule": join_rule,
             "target_user_id": target_user_id,
-            "event.user_id": event.user_id,
+            "event.sender": event.sender,
         },
     )
 
@@ -607,14 +607,14 @@ def _is_membership_change_allowed(
         if (
             (caller_invited or caller_knocked)
             and Membership.LEAVE == membership
-            and target_user_id == event.user_id
+            and target_user_id == event.sender
         ):
             return
 
         if not caller_in_room:  # caller isn't joined
             raise UnstableSpecAuthError(
                 403,
-                "%s not in room %s." % (event.user_id, event.room_id),
+                "%s not in room %s." % (event.sender, event.room_id),
                 errcode=Codes.NOT_JOINED,
             )
 
@@ -645,7 +645,7 @@ def _is_membership_change_allowed(
         # * They are already joined (it's a NOOP).
         # * The room is public.
         # * The room is restricted and the user meets the allows rules.
-        if event.user_id != target_user_id:
+        if event.sender != target_user_id:
             raise AuthError(403, "Cannot force another user to join.")
         elif target_banned:
             raise AuthError(403, "You are banned from this room")
@@ -705,7 +705,7 @@ def _is_membership_change_allowed(
                 "You cannot unban user %s." % (target_user_id,),
                 errcode=Codes.INSUFFICIENT_POWER,
             )
-        elif target_user_id != event.user_id:
+        elif target_user_id != event.sender:
             kick_level = get_named_level(auth_events, "kick", 50)
 
             if user_level < kick_level or user_level <= target_level:
@@ -733,7 +733,7 @@ def _is_membership_change_allowed(
             or join_rule != JoinRules.KNOCK_RESTRICTED
         ):
             raise AuthError(403, "You don't have permission to knock")
-        elif target_user_id != event.user_id:
+        elif target_user_id != event.sender:
             raise AuthError(403, "You cannot knock for other users")
         elif target_in_room:
             raise UnstableSpecAuthError(
@@ -752,10 +752,10 @@ def _is_membership_change_allowed(
 def _check_event_sender_in_room(
     event: "EventBase", auth_events: StateMap["EventBase"]
 ) -> None:
-    key = (EventTypes.Member, event.user_id)
+    key = (EventTypes.Member, event.sender)
     member_event = auth_events.get(key)
 
-    _check_joined_room(member_event, event.user_id, event.room_id)
+    _check_joined_room(member_event, event.sender, event.room_id)
 
 
 def _check_joined_room(
@@ -809,7 +809,7 @@ def _can_send_event(event: "EventBase", auth_events: StateMap["EventBase"]) -> b
     power_levels_event = get_power_level_event(auth_events)
 
     send_level = get_send_level(event.type, state_key, power_levels_event)
-    user_level = get_user_power_level(event.user_id, auth_events)
+    user_level = get_user_power_level(event.sender, auth_events)
 
     if user_level < send_level:
         raise UnstableSpecAuthError(
@@ -822,7 +822,7 @@ def _can_send_event(event: "EventBase", auth_events: StateMap["EventBase"]) -> b
     if (
         state_key is not None
         and state_key.startswith("@")
-        and state_key != event.user_id
+        and state_key != event.sender
     ):
         if event.room_version.msc3757_enabled:
             try:
@@ -841,7 +841,7 @@ def _can_send_event(event: "EventBase", auth_events: StateMap["EventBase"]) -> b
                 )
             if (
                 # sender is owner of the state key
-                state_key_user_id == event.user_id
+                state_key_user_id == event.sender
                 # sender has higher PL than the owner of the state key
                 or user_level > get_user_power_level(state_key_user_id, auth_events)
             ):
@@ -868,7 +868,7 @@ def check_redaction(
         AuthError if the event sender is definitely not allowed to redact
         the target event.
     """
-    user_level = get_user_power_level(event.user_id, auth_events)
+    user_level = get_user_power_level(event.sender, auth_events)
 
     redact_level = get_named_level(auth_events, "redact", 50)
 
@@ -966,7 +966,7 @@ def _check_power_levels(
     if not current_state:
         return
 
-    user_level = get_user_power_level(event.user_id, auth_events)
+    user_level = get_user_power_level(event.sender, auth_events)
 
     # Check other levels:
     levels_to_check: list[tuple[str, str | None]] = [
@@ -1020,7 +1020,7 @@ def _check_power_levels(
             if new_level == old_level:
                 continue
 
-        if dir == "users" and level_to_check != event.user_id:
+        if dir == "users" and level_to_check != event.sender:
             if old_level == user_level:
                 raise AuthError(
                     403,
@@ -1137,7 +1137,7 @@ def _verify_third_party_invite(
     if invite_event.sender != event.sender:
         return False
 
-    if event.user_id != invite_event.user_id:
+    if event.sender != invite_event.sender:
         return False
 
     if signed["mxid"] != event.state_key:

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -288,9 +288,6 @@ class EventBase(metaclass=abc.ABCMeta):
 
         return template_json
 
-    def __getitem__(self, field: str) -> Any | None:
-        return self._dict[field]
-
     def __contains__(self, field: str) -> bool:
         return field in self._dict
 

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -221,7 +221,6 @@ class EventBase(metaclass=abc.ABCMeta):
     # get_state_key() (and a check for None).
     state_key: DictProperty[str] = DictProperty("state_key")
     type: DictProperty[str] = DictProperty("type")
-    user_id: DictProperty[str] = DictProperty("sender")
 
     @property
     def event_id(self) -> str:

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1190,7 +1190,7 @@ class FederationHandler:
         # We should assert some things.
         # FIXME: Do this in a nicer way
         assert event.type == EventTypes.Member
-        assert event.user_id == user_id
+        assert event.sender == user_id
         assert event.state_key == user_id
         assert event.room_id == room_id
         return origin, event, room_version

--- a/synapse/handlers/initial_sync.py
+++ b/synapse/handlers/initial_sync.py
@@ -456,9 +456,7 @@ class InitialSyncHandler:
             if not self.hs.config.server.presence_enabled:
                 return []
 
-            states = await presence_handler.get_states(
-                [m.user_id for m in room_members]
-            )
+            states = await presence_handler.get_states([m.sender for m in room_members])
 
             return [
                 {

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -895,7 +895,7 @@ class EventCreationHandler:
         if not prev_event:
             return None
 
-        if prev_event and event.user_id == prev_event.user_id:
+        if prev_event and event.sender == prev_event.sender:
             prev_content = encode_canonical_json(prev_event.content)
             next_content = encode_canonical_json(event.content)
             if prev_content == next_content:
@@ -1541,7 +1541,7 @@ class EventCreationHandler:
                 EventTypes.Message,
                 EventTypes.Encrypted,
             ]:
-                await self.store.set_room_participation(event.user_id, event.room_id)
+                await self.store.set_room_participation(event.sender, event.room_id)
 
             if event.internal_metadata.is_out_of_band_membership():
                 # the only sort of out-of-band-membership events we expect to see here are
@@ -2098,7 +2098,7 @@ class EventCreationHandler:
                             "Could not find event %s" % (event.redacts,)
                         )
 
-                    if event.user_id != original_event.user_id:
+                    if event.sender != original_event.sender:
                         raise AuthError(
                             403, "You don't have permission to redact events"
                         )

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -501,7 +501,7 @@ class HttpPusher(Pusher):
                 "event_id": event.event_id,
                 "room_id": event.room_id,
                 "type": event.type,
-                "sender": event.user_id,
+                "sender": event.sender,
                 "prio": priority,
             }
             if not self.disable_badge_count:

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -3028,7 +3028,7 @@ class PersistEventsStore:
                     event.event_id,
                     event.internal_metadata.stream_ordering,
                     event.state_key,
-                    event.user_id,
+                    event.sender,
                     event.room_id,
                     event.membership,
                     non_null_str_or_none(event.content.get("displayname")),

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -568,8 +568,8 @@ class ApplicationServicesHandlerSendEventsTestCase(unittest.HomeserverTestCase):
             # notify us because the interesting user is joined to the room where the
             # message was sent.
             self.assertEqual(service, interested_appservice)
-            self.assertEqual(events[0]["type"], "m.room.message")
-            self.assertEqual(events[0]["sender"], alice)
+            self.assertEqual(events[0].type, "m.room.message")
+            self.assertEqual(events[0].sender, alice)
         else:
             self.send_mock.assert_not_called()
 
@@ -628,8 +628,8 @@ class ApplicationServicesHandlerSendEventsTestCase(unittest.HomeserverTestCase):
         # Events sent from an interesting local user should also be picked up as
         # interesting to the appservice.
         self.assertEqual(service, interested_appservice)
-        self.assertEqual(events[0]["type"], "m.room.message")
-        self.assertEqual(events[0]["sender"], alice)
+        self.assertEqual(events[0].type, "m.room.message")
+        self.assertEqual(events[0].sender, alice)
 
     def test_sending_read_receipt_batches_to_application_services(self) -> None:
         """Tests that a large batch of read receipts are sent correctly to

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -19,7 +19,7 @@
 #
 #
 import logging
-from typing import Collection, cast
+from typing import Collection
 from unittest import TestCase
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -140,7 +140,7 @@ class FederationTestCase(unittest.FederatingHomeserverTestCase):
                 "content": {},
                 "room_id": room_id,
                 "sender": "@yetanotheruser:" + OTHER_SERVER,
-                "depth": cast(int, join_event["depth"]) + 1,
+                "depth": join_event.depth + 1,
                 "prev_events": [join_event.event_id],
                 "auth_events": [],
                 "origin_server_ts": self.clock.time_msec(),
@@ -192,7 +192,7 @@ class FederationTestCase(unittest.FederatingHomeserverTestCase):
                 "content": {},
                 "room_id": room_id,
                 "sender": "@yetanotheruser:" + OTHER_SERVER,
-                "depth": cast(int, join_event["depth"]) + 1,
+                "depth": join_event.depth + 1,
                 "prev_events": [join_event.event_id],
                 "auth_events": [],
                 "origin_server_ts": self.clock.time_msec(),

--- a/tests/storage/test_redaction.py
+++ b/tests/storage/test_redaction.py
@@ -152,7 +152,7 @@ class RedactionTestCase(unittest.HomeserverTestCase):
         self.assertObjectHasAttributes(
             {
                 "type": EventTypes.Message,
-                "user_id": self.u_alice.to_string(),
+                "sender": self.u_alice.to_string(),
                 "content": {"body": "t", "msgtype": "message"},
             },
             event,
@@ -173,7 +173,7 @@ class RedactionTestCase(unittest.HomeserverTestCase):
         self.assertObjectHasAttributes(
             {
                 "type": EventTypes.Message,
-                "user_id": self.u_alice.to_string(),
+                "sender": self.u_alice.to_string(),
                 "content": {},
             },
             event,
@@ -191,7 +191,7 @@ class RedactionTestCase(unittest.HomeserverTestCase):
         self.assertObjectHasAttributes(
             {
                 "type": EventTypes.Member,
-                "user_id": self.u_bob.to_string(),
+                "sender": self.u_bob.to_string(),
                 "content": {"membership": Membership.JOIN, "blue": "red"},
             },
             event,
@@ -212,7 +212,7 @@ class RedactionTestCase(unittest.HomeserverTestCase):
         self.assertObjectHasAttributes(
             {
                 "type": EventTypes.Member,
-                "user_id": self.u_bob.to_string(),
+                "sender": self.u_bob.to_string(),
                 "content": {"membership": Membership.JOIN},
             },
             event,
@@ -328,7 +328,7 @@ class RedactionTestCase(unittest.HomeserverTestCase):
         self.assertObjectHasAttributes(
             {
                 "type": EventTypes.Message,
-                "user_id": self.u_alice.to_string(),
+                "sender": self.u_alice.to_string(),
                 "content": {"body": "t", "msgtype": "message"},
             },
             event,
@@ -347,7 +347,7 @@ class RedactionTestCase(unittest.HomeserverTestCase):
         self.assertObjectHasAttributes(
             {
                 "type": EventTypes.Message,
-                "user_id": self.u_alice.to_string(),
+                "sender": self.u_alice.to_string(),
                 "content": {},
             },
             event,


### PR DESCRIPTION
This is to make it easier to port to Rust, as well as making things conceptually simpler.

Two changes:
1. Remove the `__getitem__` interface on events
2. Remove `.user_id` as an alias of `.sender`.