### PR TITLE
Add `room_type` filter on `/_synapse/admin/v1/rooms` API

### DIFF
--- a/changelog.d/19707.feature
+++ b/changelog.d/19707.feature
@@ -1,0 +1,1 @@
+Add room type filter on admin room list API. Contributed by @velikopter.

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -40,6 +40,8 @@ The following query parameters are available:
   the query. When the flag is absent (the default), **both** public and non-public rooms are included in the search results.
 * `empty_rooms` - Optional flag to filter empty rooms. A room is empty if joined_members is zero. If `true`, only empty rooms are queried. If `false`, empty rooms are excluded from
   the query. When the flag is absent (the default), **both** empty and non-empty rooms are included in the search results.
+* `room_type` - The type of the room from the room's creation event; for example "m.space" if the room is a space.
+  For rooms without a type defined, leave the parameter as an empty string.
 
   Defaults to no filtering.
 

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -295,6 +295,7 @@ class ListRoomRestServlet(RestServlet):
                 errcode=Codes.INVALID_PARAM,
             )
 
+        room_type = parse_string(request, "room_type")
         public_rooms = parse_boolean(request, "public_rooms")
         empty_rooms = parse_boolean(request, "empty_rooms")
 
@@ -310,6 +311,7 @@ class ListRoomRestServlet(RestServlet):
             search_term,
             public_rooms,
             empty_rooms,
+            room_type,
         )
 
         response = {

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -605,6 +605,7 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
         search_term: str | None,
         public_rooms: bool | None,
         empty_rooms: bool | None,
+        room_type: str | None,
     ) -> tuple[list[dict[str, Any]], int]:
         """Function to retrieve a paginated list of rooms as json.
 
@@ -624,6 +625,7 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
                     If true, empty rooms are queried.
                     if false, empty rooms are excluded from the query. When it is
                     none (the default), both empty rooms and none-empty rooms are queried.
+            room_type: Optional flag to filter by the room type, e.g. m.space for spaces.
         Returns:
             A list of room dicts and an integer representing the total number of
             rooms that exist given this query
@@ -657,6 +659,13 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
                 filter_.append("curr.joined_members = 0")
             else:
                 filter_.append("curr.joined_members <> 0")
+
+        if room_type is not None:
+            if room_type == "":
+                filter_.append("state.room_type IS NULL")
+            else:
+                filter_.append("state.room_type = ?")
+                where_args.append(room_type)
 
         where_clause = "WHERE " + " AND ".join(filter_) if len(filter_) > 0 else ""
 

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -836,7 +836,7 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
 
         if room_type is not None:
             if room_type == "":
-                filter_.append("state.room_type IS NULL")
+                filter_.append("state.room_type IS NULL OR state.room_type = ''")
             else:
                 filter_.append("state.room_type = ?")
                 where_args.append(room_type)

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -1903,6 +1903,66 @@ class RoomTestCase(unittest.HomeserverTestCase):
         self.assertEqual(test_alias, r["canonical_alias"])
         self.assertEqual(RoomTypes.SPACE, r["room_type"])
 
+    def test_room_type_filtering(self) -> None:
+        custom_type = "com.example.custom_room_type"
+
+        space_room_id = self.helper.create_room_as(
+            self.admin_user,
+            tok=self.admin_user_tok,
+            extra_content={"creation_content": {"type": RoomTypes.SPACE}},
+        )
+        custom_type_room_id = self.helper.create_room_as(
+            self.admin_user,
+            tok=self.admin_user_tok,
+            extra_content={"creation_content": {"type": custom_type}},
+        )
+        normal_room_id = self.helper.create_room_as(
+            self.admin_user,
+            tok=self.admin_user_tok,
+            extra_content={"creation_content": {"type": custom_type}},
+        )
+
+        space_channel = self.make_request(
+            "GET",
+            f"/_synapse/admin/v1/rooms?room_type={RoomTypes.SPACE}",
+            access_token=self.admin_user_tok,
+        )
+        custom_type_channel = self.make_request(
+            "GET",
+            f"/_synapse/admin/v1/rooms?room_type={custom_type}",
+            access_token=self.admin_user_tok,
+        )
+        normal_channel = self.make_request(
+            "GET",
+            "/_synapse/admin/v1/rooms?room_type=",
+            access_token=self.admin_user_tok,
+        )
+
+        self.assertEqual(200, space_channel.code, msg=space_channel.json_body)
+        self.assertTrue("rooms" in space_channel.json_body)
+        self.assertEqual(200, space_channel.code, msg=custom_type_channel.json_body)
+        self.assertTrue("rooms" in custom_type_channel.json_body)
+        self.assertEqual(200, space_channel.code, msg=normal_channel.json_body)
+        self.assertTrue("rooms" in normal_channel.json_body)
+
+        space_channel_rooms = space_channel.json_body["rooms"]
+        custom_type_channel_rooms = custom_type_channel.json_body["rooms"]
+        normal_channel_rooms = normal_channel.json_body["rooms"]
+
+        self.assertEqual(len(space_channel_rooms), 1)
+        self.assertEqual(space_channel.json_body["total_rooms"], 1)
+        self.assertEqual(len(custom_type_channel_rooms), 1)
+        self.assertEqual(custom_type_channel_rooms.json_body["total_rooms"], 1)
+        self.assertEqual(len(normal_channel_rooms), 1)
+        self.assertEqual(normal_channel_rooms.json_body["total_rooms"], 1)
+
+        self.assertEqual(space_channel_rooms[0]["room_id"], space_room_id)
+        self.assertEqual(space_channel_rooms[0]["room_type"], RoomTypes.SPACE)
+        self.assertEqual(custom_type_channel_rooms[0]["room_id"], custom_type_room_id)
+        self.assertEqual(custom_type_channel_rooms[0]["room_type"], custom_type)
+        self.assertEqual(custom_type_channel_rooms[0]["room_id"], normal_room_id)
+        self.assertEqual(custom_type_channel_rooms[0]["room_type"], None)
+
     def test_room_list_sort_order(self) -> None:
         """Test room list sort ordering. alphabetical name versus number of members,
         reversing the order, etc.

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -1919,7 +1919,7 @@ class RoomTestCase(unittest.HomeserverTestCase):
         normal_room_id = self.helper.create_room_as(
             self.admin_user,
             tok=self.admin_user_tok,
-            extra_content={"creation_content": {"type": custom_type}},
+            extra_content={},
         )
 
         space_channel = self.make_request(
@@ -1952,16 +1952,16 @@ class RoomTestCase(unittest.HomeserverTestCase):
         self.assertEqual(len(space_channel_rooms), 1)
         self.assertEqual(space_channel.json_body["total_rooms"], 1)
         self.assertEqual(len(custom_type_channel_rooms), 1)
-        self.assertEqual(custom_type_channel_rooms.json_body["total_rooms"], 1)
+        self.assertEqual(custom_type_channel.json_body["total_rooms"], 1)
         self.assertEqual(len(normal_channel_rooms), 1)
-        self.assertEqual(normal_channel_rooms.json_body["total_rooms"], 1)
+        self.assertEqual(normal_channel.json_body["total_rooms"], 1)
 
         self.assertEqual(space_channel_rooms[0]["room_id"], space_room_id)
         self.assertEqual(space_channel_rooms[0]["room_type"], RoomTypes.SPACE)
         self.assertEqual(custom_type_channel_rooms[0]["room_id"], custom_type_room_id)
         self.assertEqual(custom_type_channel_rooms[0]["room_type"], custom_type)
-        self.assertEqual(custom_type_channel_rooms[0]["room_id"], normal_room_id)
-        self.assertEqual(custom_type_channel_rooms[0]["room_type"], None)
+        self.assertEqual(normal_channel_rooms[0]["room_id"], normal_room_id)
+        self.assertEqual(normal_channel_rooms[0]["room_type"], None)
 
     def test_room_list_sort_order(self) -> None:
         """Test room list sort ordering. alphabetical name versus number of members,


### PR DESCRIPTION
Adds a room type query parameter to `/_synapse/admin/v1/rooms`.

Spawning from https://matrix.to/#/!LpivaKUdewaGfawMoR:etke.cc/$gtCQG4A8soWDtk9IQdjRu8hrmR-aForMiziPvxJpVFc?via=etke.cc&via=nhjkl.com&via=unredacted.org

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
