### PR TITLE
Add warning about known problems when configuring `use_frozen_dicts`

### DIFF
--- a/changelog.d/19711.doc
+++ b/changelog.d/19711.doc
@@ -1,0 +1,1 @@
+Add warning about known problems when configuring `use_frozen_dicts`.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -194,7 +194,8 @@ user_agent_suffix: ' (I''m a teapot; Linux x86_64)'
 ---
 ### `use_frozen_dicts`
 
-*(boolean)* Determines whether we should freeze the internal dict object in `FrozenEvent`. Freezing prevents bugs where we accidentally share e.g. signature dicts. However, freezing a dict is expensive. Defaults to `false`.
+*(boolean)* Determines whether we should freeze the internal dict object in `FrozenEvent`. Freezing prevents bugs where we accidentally share e.g. signature dicts. However, freezing a dict is expensive.
+> ⚠️ **Warning** – This option is known to introduce a new class of [comparison bugs](https://github.com/element-hq/synapse/issues/18117) in Synapse. Defaults to `false`.
 
 Example configuration:
 ```yaml

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -195,7 +195,10 @@ user_agent_suffix: ' (I''m a teapot; Linux x86_64)'
 ### `use_frozen_dicts`
 
 *(boolean)* Determines whether we should freeze the internal dict object in `FrozenEvent`. Freezing prevents bugs where we accidentally share e.g. signature dicts. However, freezing a dict is expensive.
-> ⚠️ **Warning** – This option is known to introduce a new class of [comparison bugs](https://github.com/element-hq/synapse/issues/18117) in Synapse. Defaults to `false`.
+
+> ⚠️ **Warning** – This option is known to introduce a new class of [comparison bugs](https://github.com/element-hq/synapse/issues/18117) in Synapse.
+
+Defaults to `false`.
 
 Example configuration:
 ```yaml

--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -95,6 +95,7 @@ properties:
       `FrozenEvent`. Freezing prevents bugs where we accidentally share e.g.
       signature dicts. However, freezing a dict is expensive.
 
+
       > ⚠️ **Warning** – This option is known to introduce a new class of [comparison
       bugs](https://github.com/element-hq/synapse/issues/18117) in Synapse.
     default: false

--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -94,6 +94,9 @@ properties:
       Determines whether we should freeze the internal dict object in
       `FrozenEvent`. Freezing prevents bugs where we accidentally share e.g.
       signature dicts. However, freezing a dict is expensive.
+
+      > ⚠️ **Warning** – This option is known to introduce a new class of [comparison
+      bugs](https://github.com/element-hq/synapse/issues/18117) in Synapse.
     default: false
     examples:
       - true

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -62,6 +62,10 @@ dict to frozen_dicts is expensive.
 NOTE: This is overridden by the configuration by the Synapse worker apps, but
 for the sake of tests, it is set here because it cannot be configured on the
 homeserver object itself.
+
+FIXME: Because of how this option works (changing the underlying types), it causes
+subtle downstream bugs that makes type comparisons brittle, tracked by
+https://github.com/element-hq/synapse/issues/18117
 """
 
 T = TypeVar("T")


### PR DESCRIPTION
Add warning about [known problems](https://github.com/element-hq/synapse/issues/18117) when configuring `use_frozen_dicts`

As a follow-up, we should consider removing this config option altogether. It's "expensive" and claims to "prevent bugs" but actually introduces a whole new class of bugs. It could be re-introduced with a more holistic solution to the typing. Or a completely new approach (safe mode that blows up when someone mutates the event content, always make deep clones when handing out references, etc)


### Dev notes

The `use_frozen_dict` config option was there [since inception](https://github.com/element-hq/synapse/commit/a7b65bdedf512f646a3ca2478fb96a914856de35) but was only recently [documented](https://github.com/element-hq/synapse/pull/18122) for completeness sake.


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
