### PR TITLE
Reinstate removed EventBase methods

### DIFF
--- a/changelog.d/19712.misc
+++ b/changelog.d/19712.misc
@@ -1,0 +1,1 @@
+Small simplifications to the events class.

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -219,6 +219,9 @@ class EventBase(metaclass=abc.ABCMeta):
     state_key: DictProperty[str] = DictProperty("state_key")
     type: DictProperty[str] = DictProperty("type")
 
+    # This is a deprecated property, use `sender` instead. Only used by modules.
+    user_id: DictProperty[str] = DictProperty("sender")
+
     @property
     def event_id(self) -> str:
         raise NotImplementedError()
@@ -359,6 +362,10 @@ class EventBase(metaclass=abc.ABCMeta):
             f"outlier={self.internal_metadata.is_outlier()}"
             ">"
         )
+
+    # Using `__getitem__` is deprecated. Only used by modules.
+    def __getitem__(self, field: str) -> Any | None:
+        return self._dict[field]
 
 
 class FrozenEvent(EventBase):

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -34,6 +34,7 @@ from typing import (
 )
 
 import attr
+from typing_extensions import deprecated
 from unpaddedbase64 import encode_base64
 
 from synapse.api.constants import (
@@ -364,6 +365,7 @@ class EventBase(metaclass=abc.ABCMeta):
         )
 
     # Using `__getitem__` is deprecated. Only used by modules.
+    @deprecated("Use attribute access instead")
     def __getitem__(self, field: str) -> Any | None:
         return self._dict[field]
 

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -840,10 +840,10 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
         )
         create_event = state[(EventTypes.Create, "")]
 
-        # `.user_id` is an alias for `.sender`.
+        # `.user_id` is a deprecated alias for `.sender`.
         self.assertEqual(create_event.user_id, user_id)
 
-        # The event supports looking up keys via `__getitem__`
+        # The event supports looking up keys via `__getitem__` although deprecated
         self.assertEqual(create_event["room_id"], room_id)
 
 

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -828,6 +828,24 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
         # Ensure the pushers were deleted after the callback.
         self.assertEqual(len(self.hs.get_pusherpool().pushers[user_id].values()), 0)
 
+    def test_event_deprecated_methods(self) -> None:
+        """Test that deprecated methods on events are still functional."""
+        user_id = self.register_user("user", "password")
+        tok = self.login("user", "password")
+
+        room_id = self.helper.create_room_as(tok=tok)
+
+        state = self.get_success(
+            self.hs.get_storage_controllers().state.get_current_state(room_id)
+        )
+        create_event = state[(EventTypes.Create, "")]
+
+        # `.user_id` is an alias for `.sender`.
+        self.assertEqual(create_event.user_id, user_id)
+
+        # The event supports looking up keys via `__getitem__`
+        self.assertEqual(create_event["room_id"], room_id)
+
 
 class ModuleApiWorkerTestCase(BaseModuleApiTestCase, BaseMultiWorkerStreamTestCase):
     """For testing ModuleApi functionality in a multi-worker setup"""


### PR DESCRIPTION
Both `__getitem__` and `.user_id` were removed in #19680 to simplify the event class. However, `EventBase` is exposed to modules who might also make use of those methods, so let's reinstate them (but otherwise not reinstate the usage of them in the code).