### PR TITLE
MSC4242: State DAGs (storage)

### DIFF
--- a/changelog.d/19718.misc
+++ b/changelog.d/19718.misc
@@ -1,0 +1,1 @@
+Add storage functions for future MSC4242 work.

--- a/changelog.d/19718.misc
+++ b/changelog.d/19718.misc
@@ -1,1 +1,1 @@
-Add storage functions for future MSC4242 work.
+Add storage functions for future [MSC4242](https://github.com/matrix-org/matrix-spec-proposals/pull/4242) work.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -2637,6 +2637,9 @@ def make_in_list_sql_clause(
     using the `ANY` form on postgres means that it views queries with
     different length iterables as the same, helping the query stats.
 
+    An empty `iterable` yields a constant clause: nothing can be a member of an empty
+    list, so the clause is `FALSE` (or `TRUE` when `negative`).
+
     Args:
         database_engine
         column: Name of the column
@@ -2646,6 +2649,11 @@ def make_in_list_sql_clause(
     Returns:
         A tuple of SQL query and the args
     """
+
+    if not iterable:
+        # Spell the empty case out rather than relying on each engine's handling of an
+        # empty list: sqlite permits `IN ()` but postgres does not.
+        return ("TRUE" if negative else "FALSE"), []
 
     if database_engine.supports_using_any_list:
         # This should hopefully be faster, but also makes postgres query

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1314,16 +1314,18 @@ class EventFederationWorkerStore(
             "LIMIT ?"
         )
         while front_queue and len(event_id_results) < limit:
-            event_id = front_queue.pop(0)
-            txn.execute(query, (room_id, event_id, limit - len(event_id_results)))
+            front_event_id = front_queue.pop(0)
+            txn.execute(query, (room_id, front_event_id, limit - len(event_id_results)))
             # None check because the m.room.create event has NULL prev_state_events
-            new_event_id_results = [
+            prev_state_event_ids_for_front_event = [
                 t[0] for t in txn if t[0] is not None and t[0] not in seen_event_ids
             ]
-            for next in new_event_id_results:
+            for next in (
+                prev_state_event_ids_for_front_event
+            ):  # Sort lexicographically for determinism
                 front_queue.append(next)
-            seen_event_ids |= set(new_event_id_results)
-            event_id_results.extend(new_event_id_results)
+            seen_event_ids |= set(prev_state_event_ids_for_front_event)
+            event_id_results.extend(prev_state_event_ids_for_front_event)
 
         return event_id_results
 

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -37,7 +37,7 @@ from prometheus_client import Counter, Gauge
 from synapse.api.constants import MAX_DEPTH
 from synapse.api.errors import StoreError
 from synapse.api.room_versions import EventFormatVersions, RoomVersion
-from synapse.events import EventBase, make_event_from_dict
+from synapse.events import EventBase, FrozenEventVMSC4242, make_event_from_dict
 from synapse.logging.opentracing import tag_args, trace
 from synapse.metrics import SERVER_NAME_LABEL
 from synapse.metrics.background_process_metrics import wrap_as_background_process
@@ -1193,6 +1193,116 @@ class EventFederationWorkerStore(
 
         # Return all events where not all sets can reach them.
         return {eid for eid, n in event_to_missing_sets.items() if n}
+
+    # 22/04/2026: Unused currently, but will be used in future MSC4242 PRs.
+    # Remove comment when used.
+    async def get_state_dag(
+        self, room_id: str, forward_extrems: set[str]
+    ) -> dict[str, FrozenEventVMSC4242]:
+        """Get the current state DAG for the given room.
+
+        This function is called when calculating a /send_join response.
+        This does not check that the room is an state DAG room, so check this
+        before calling this function!
+
+        This functions guarantees that the returned state DAG is connected.
+
+        Args:
+            room_id: The room to get the state dag for
+            forward_extrems: latest event IDs in the room. The state DAG is all events reachable from these events.
+        Returns:
+            A map of event_id => event
+        """
+
+        def _get_state_events_txn(txn: LoggingTransaction, room_id: str) -> list[str]:
+            sql = """
+                SELECT event_id FROM msc4242_state_dag_edges WHERE room_id = ?
+            """
+            txn.execute(sql, (room_id,))
+            event_ids = [ev_id for (ev_id,) in txn]
+            return event_ids
+
+        # Pull out all state events for this room using the events_by_room_and_type index.
+        event_ids = await self.db_pool.runInteraction(
+            "_get_state_events_txn",
+            _get_state_events_txn,
+            room_id,
+        )
+        event_map = await self.get_events(event_ids)
+        # Filter the returned state events to only include ones on the paths back from the forward
+        # extremities.
+        result: dict[str, FrozenEventVMSC4242] = {}
+        next = forward_extrems
+        seen: set[str] = set()
+        while len(next) > 0:
+            # Pull the event and add the prev_state_events.
+            # We must have the event.
+            event_id = next.pop()
+            if event_id in seen:
+                continue
+            seen.add(event_id)
+            ev = event_map[event_id]
+            assert isinstance(ev, FrozenEventVMSC4242)
+            result[event_id] = ev
+            for prev_state_event_id in ev.prev_state_events:
+                next.add(prev_state_event_id)
+        return result
+
+    # 22/04/2026: Unused currently, but will be used in future MSC4242 PRs.
+    # Remove comment when used.
+    async def get_missing_events_state_dag(
+        self,
+        room_id: str,
+        earliest_events: list[str],
+        latest_events: list[str],
+        limit: int,
+    ) -> list[EventBase]:
+        ids = await self.db_pool.runInteraction(
+            "get_missing_events_state_dag",
+            self._get_missing_events_state_dag_txn,
+            room_id,
+            earliest_events,
+            latest_events,
+            limit,
+        )
+        return await self.get_events_as_list(ids)
+
+    # 22/04/2026: Unused currently, but will be used in future MSC4242 PRs.
+    # Remove comment when used.
+    def _get_missing_events_state_dag_txn(
+        self,
+        txn: LoggingTransaction,
+        room_id: str,
+        earliest_events: list[str],
+        latest_events: list[str],
+        limit: int,
+    ) -> list[str]:
+        seen_events = set(earliest_events)
+        # lexicographical sort
+        front_queue = sorted(set(latest_events) - seen_events)
+        event_results: list[str] = []
+        # TODO(kegan): use a recursive CTE?
+        # The limit is usually pretty low, so it's cheaper to select the events we need via querying
+        # rather than selecting all events and filtering python-side.
+        query = (
+            "SELECT prev_state_event_id FROM msc4242_state_dag_edges "
+            "WHERE room_id = ? AND event_id = ? "
+            "ORDER BY prev_state_event_id ASC "
+            "LIMIT ?"
+        )
+        while front_queue and len(event_results) < limit:
+            event_id = front_queue.pop(0)
+            txn.execute(query, (room_id, event_id, limit - len(event_results)))
+            # None check because the m.room.create event has NULL prev_state_events
+            new_results = [
+                t[0] for t in txn if t[0] is not None and t[0] not in seen_events
+            ]
+            for next in new_results:
+                front_queue.append(next)
+            seen_events |= set(new_results)
+            event_results.extend(new_results)
+
+        return event_results
 
     @trace
     @tag_args

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1252,6 +1252,7 @@ class EventFederationWorkerStore(
     # Remove comment when used.
     async def get_missing_events_state_dag(
         self,
+        *,
         room_id: str,
         earliest_events: list[str],
         latest_events: list[str],
@@ -1267,8 +1268,8 @@ class EventFederationWorkerStore(
         )
         return await self.get_events_as_list(ids)
 
-    # 22/04/2026: Unused currently, but will be used in future MSC4242 PRs.
-    # Remove comment when used.
+    # FIXME(2026-04-22): Remove comment when used. Unused currently, but will be used in
+    # future MSC4242 PRs.
     def _get_missing_events_state_dag_txn(
         self,
         txn: LoggingTransaction,

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1232,12 +1232,12 @@ class EventFederationWorkerStore(
         # Filter the returned state events to only include ones on the paths back from the forward
         # extremities.
         result: dict[str, FrozenEventVMSC4242] = {}
-        next = forward_extrems
+        next_ids = forward_extrems
         seen: set[str] = set()
-        while len(next) > 0:
+        while len(next_ids) > 0:
             # Pull the event and add the prev_state_events.
             # We must have the event.
-            event_id = next.pop()
+            event_id = next_ids.pop()
             if event_id in seen:
                 continue
             seen.add(event_id)
@@ -1245,7 +1245,19 @@ class EventFederationWorkerStore(
             assert isinstance(ev, FrozenEventVMSC4242)
             result[event_id] = ev
             for prev_state_event_id in ev.prev_state_events:
-                next.add(prev_state_event_id)
+                next_ids.add(prev_state_event_id)
+
+        # Validate the result has a create event.
+        if len(result) > 0:
+            # Assert that the create event was returned. Pick the first event (any will do) to verify
+            # that this room version supports room IDs as hashes.
+            first_event: FrozenEventVMSC4242 = next(iter(result.values()))
+            if first_event.room_version.msc4291_room_ids_as_hashes:
+                create_event_id = f"${room_id[1:]}"
+                # If we're walking back, ensure that the create event was included.
+                if create_event_id not in forward_extrems:
+                    assert create_event_id in result
+
         return result
 
     # 22/04/2026: Unused currently, but will be used in future MSC4242 PRs.
@@ -1254,16 +1266,26 @@ class EventFederationWorkerStore(
         self,
         *,
         room_id: str,
-        earliest_events: list[str],
-        latest_events: list[str],
+        earliest_event_ids: list[str],
+        latest_event_ids: list[str],
         limit: int,
     ) -> list[EventBase]:
+        """Get parts of the state DAG in response to a /get_missing_events query.
+
+        Args:
+            room_id: The state DAG to look at
+            earliest_event_ids: Which events the caller has seen. These events will not be returned.
+            latest_event_ids: Which events to start walking back from via prev_state_events.
+            limit: The max number of events to return.
+        Returns:
+            A list of events, deterministically ordered according to MSC4242.
+        """
         ids = await self.db_pool.runInteraction(
             "get_missing_events_state_dag",
             self._get_missing_events_state_dag_txn,
             room_id,
-            earliest_events,
-            latest_events,
+            earliest_event_ids,
+            latest_event_ids,
             limit,
         )
         return await self.get_events_as_list(ids)
@@ -1274,14 +1296,14 @@ class EventFederationWorkerStore(
         self,
         txn: LoggingTransaction,
         room_id: str,
-        earliest_events: list[str],
-        latest_events: list[str],
+        earliest_event_ids: list[str],
+        latest_event_ids: list[str],
         limit: int,
     ) -> list[str]:
-        seen_events = set(earliest_events)
-        # lexicographical sort
-        front_queue = sorted(set(latest_events) - seen_events)
-        event_results: list[str] = []
+        seen_event_ids = set(earliest_event_ids)
+        # lexicographical sort to ensure that responses are deterministic (for caching/tests)
+        front_queue = sorted(set(latest_event_ids) - seen_event_ids)
+        event_id_results: list[str] = []
         # TODO(kegan): use a recursive CTE?
         # The limit is usually pretty low, so it's cheaper to select the events we need via querying
         # rather than selecting all events and filtering python-side.
@@ -1291,19 +1313,19 @@ class EventFederationWorkerStore(
             "ORDER BY prev_state_event_id ASC "
             "LIMIT ?"
         )
-        while front_queue and len(event_results) < limit:
+        while front_queue and len(event_id_results) < limit:
             event_id = front_queue.pop(0)
-            txn.execute(query, (room_id, event_id, limit - len(event_results)))
+            txn.execute(query, (room_id, event_id, limit - len(event_id_results)))
             # None check because the m.room.create event has NULL prev_state_events
-            new_results = [
-                t[0] for t in txn if t[0] is not None and t[0] not in seen_events
+            new_event_id_results = [
+                t[0] for t in txn if t[0] is not None and t[0] not in seen_event_ids
             ]
-            for next in new_results:
+            for next in new_event_id_results:
                 front_queue.append(next)
-            seen_events |= set(new_results)
-            event_results.extend(new_results)
+            seen_event_ids |= set(new_event_id_results)
+            event_id_results.extend(new_event_id_results)
 
-        return event_results
+        return event_id_results
 
     @trace
     @tag_args

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1247,16 +1247,13 @@ class EventFederationWorkerStore(
             for prev_state_event_id in ev.prev_state_events:
                 next_ids.add(prev_state_event_id)
 
-        # Validate the result has a create event.
-        if len(result) > 0:
-            # Assert that the create event was returned. Pick the first event (any will do) to verify
-            # that this room version supports room IDs as hashes.
-            first_event: FrozenEventVMSC4242 = next(iter(result.values()))
-            if first_event.room_version.msc4291_room_ids_as_hashes:
-                create_event_id = f"${room_id[1:]}"
-                # If we're walking back, ensure that the create event was included.
-                if create_event_id not in forward_extrems:
-                    assert create_event_id in result
+        assert len(result) > 0  # we always return the forward extremities
+        # Assert that the create event was returned. Pick the first event (any will do) to verify
+        # that this room version supports room IDs as hashes.
+        first_event: FrozenEventVMSC4242 = next(iter(result.values()))
+        if first_event.room_version.msc4291_room_ids_as_hashes:
+            create_event_id = f"${room_id[1:]}"
+            assert create_event_id in result
 
         return result
 
@@ -1290,8 +1287,6 @@ class EventFederationWorkerStore(
         )
         return await self.get_events_as_list(ids)
 
-    # FIXME(2026-04-22): Remove comment when used. Unused currently, but will be used in
-    # future MSC4242 PRs.
     def _get_missing_events_state_dag_txn(
         self,
         txn: LoggingTransaction,

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1295,34 +1295,81 @@ class EventFederationWorkerStore(
         latest_event_ids: list[str],
         limit: int,
     ) -> list[str]:
-        seen_event_ids = set(earliest_event_ids)
-        # lexicographical sort to ensure that responses are deterministic (for caching/tests)
-        front_queue = sorted(set(latest_event_ids) - seen_event_ids)
-        event_id_results: list[str] = []
-        # TODO(kegan): use a recursive CTE?
-        # The limit is usually pretty low, so it's cheaper to select the events we need via querying
-        # rather than selecting all events and filtering python-side.
-        query = (
-            "SELECT prev_state_event_id FROM msc4242_state_dag_edges "
-            "WHERE room_id = ? AND event_id = ? "
-            "ORDER BY prev_state_event_id ASC "
-            "LIMIT ?"
-        )
-        while front_queue and len(event_id_results) < limit:
-            front_event_id = front_queue.pop(0)
-            txn.execute(query, (room_id, front_event_id, limit - len(event_id_results)))
-            # None check because the m.room.create event has NULL prev_state_events
-            prev_state_event_ids_for_front_event = [
-                t[0] for t in txn if t[0] is not None and t[0] not in seen_event_ids
-            ]
-            for next in (
-                prev_state_event_ids_for_front_event
-            ):  # Sort lexicographically for determinism
-                front_queue.append(next)
-            seen_event_ids |= set(prev_state_event_ids_for_front_event)
-            event_id_results.extend(prev_state_event_ids_for_front_event)
+        """Walk the state DAG backward from `latest_event_ids`, stopping at
+        `limit` results or the beginning of the DAG, whichever comes first.
 
-        return event_id_results
+        Earliest events are treated as already-visited: they are not emitted,
+        and their predecessors are not traversed via them.
+
+        Results are deterministic and ordered by BFS, with lexicographic tie-breaking among
+        siblings at the same # hops away.
+
+        Executes as a single recursive CTE in both SQLite and Postgres.
+        """
+        earliest_set = set(earliest_event_ids)
+        seed_ids = sorted(set(latest_event_ids) - earliest_set)
+        if not seed_ids or limit <= 0:
+            return []
+
+        seed_clause, seed_args = make_in_list_sql_clause(
+            self.database_engine, "e.event_id", seed_ids
+        )
+
+        # `make_in_list_sql_clause` doesn't handle empty iterables, so guard
+        # the no-earliest case explicitly with an always-true clause.
+        if earliest_event_ids:
+            earliest_clause, earliest_args = make_in_list_sql_clause(
+                self.database_engine,
+                "e.prev_state_event_id",
+                earliest_event_ids,
+                negative=True,
+            )
+        else:
+            # No-op clause that is TRUE for every row, in both dialects.
+            earliest_clause = "1=1"
+            earliest_args = []
+
+        query = f"""
+            WITH RECURSIVE walk(event_id, hops) AS (
+                SELECT
+                    e.prev_state_event_id,
+                    1
+                FROM msc4242_state_dag_edges e
+                WHERE e.room_id = ?
+                AND {seed_clause}
+                AND e.prev_state_event_id IS NOT NULL
+                AND {earliest_clause}
+
+                UNION
+
+                SELECT
+                    e.prev_state_event_id,
+                    w.hops + 1
+                FROM walk w
+                JOIN msc4242_state_dag_edges e
+                ON e.room_id = ?
+                AND e.event_id = w.event_id
+                WHERE e.prev_state_event_id IS NOT NULL
+                AND {earliest_clause}
+                AND w.hops < ?
+            )
+            SELECT event_id, MIN(hops) AS hops
+            FROM walk
+            GROUP BY event_id
+            ORDER BY hops, event_id
+            LIMIT ?
+        """
+
+        params: list = [room_id]
+        params.extend(seed_args)
+        params.extend(earliest_args)
+        params.append(room_id)
+        params.extend(earliest_args)
+        params.append(limit)
+        params.append(limit)
+
+        txn.execute(query, params)
+        return [row[0] for row in txn]
 
     @trace
     @tag_args

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1340,6 +1340,10 @@ class EventFederationWorkerStore(
                 FROM msc4242_state_dag_edges e
                 WHERE e.room_id = ?
                 AND {seed_clause}
+                -- The create event has no edges, so it is stored as a single row with a NULL
+                -- `prev_state_event_id`. Skipping NULLs therefore only skips that sentinel
+                -- row: the create event is still returned by the walk, because it appears as
+                -- the `prev_state_event_id` of the events that reference it.
                 AND e.prev_state_event_id IS NOT NULL
                 AND {earliest_clause}
 

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1194,8 +1194,8 @@ class EventFederationWorkerStore(
         # Return all events where not all sets can reach them.
         return {eid for eid, n in event_to_missing_sets.items() if n}
 
-    # 22/04/2026: Unused currently, but will be used in future MSC4242 PRs.
-    # Remove comment when used.
+    # FIXME(2026-04-22): Remove comment when used. Unused currently, but will be used in
+    # future MSC4242 PRs.
     async def get_state_dag(
         self, room_id: str, forward_extrems: set[str]
     ) -> dict[str, FrozenEventVMSC4242]:
@@ -1257,8 +1257,8 @@ class EventFederationWorkerStore(
 
         return result
 
-    # 22/04/2026: Unused currently, but will be used in future MSC4242 PRs.
-    # Remove comment when used.
+    # FIXME(2026-04-22): Remove comment when used. Unused currently, but will be used in
+    # future MSC4242 PRs.
     async def get_missing_events_state_dag(
         self,
         *,
@@ -1301,12 +1301,15 @@ class EventFederationWorkerStore(
         Earliest events are treated as already-visited: they are not emitted,
         and their predecessors are not traversed via them.
 
-        Results are deterministic and ordered by BFS, with lexicographic tie-breaking among
-        siblings at the same # hops away.
+        Results are deterministic and ordered by breadth-first search (BFS), with lexicographic
+        tie-breaking among siblings at the same hops away.
 
         Executes as a single recursive CTE in both SQLite and Postgres.
         """
         earliest_set = set(earliest_event_ids)
+        # Sort the seeds lexicographically by event ID: seeds are all 0 hops away from
+        # themselves, so the event ID is the only tie-breaker available for them and we need
+        # the walk to start from a deterministic order.
         seed_ids = sorted(set(latest_event_ids) - earliest_set)
         if not seed_ids or limit <= 0:
             return []
@@ -1340,6 +1343,9 @@ class EventFederationWorkerStore(
                 AND e.prev_state_event_id IS NOT NULL
                 AND {earliest_clause}
 
+                -- `UNION` rather than `UNION ALL`: the same (event_id, hops) pair can be
+                -- reached via multiple children, and de-duplicating here stops us expanding
+                -- the same row over and over.
                 UNION
 
                 SELECT
@@ -1351,8 +1357,15 @@ class EventFederationWorkerStore(
                 AND e.event_id = w.event_id
                 WHERE e.prev_state_event_id IS NOT NULL
                 AND {earliest_clause}
+                -- Bound the recursion by `limit`: every extra hop adds at least one event to
+                -- the result, so events more than `limit` hops away can never make it into a
+                -- `limit`-sized response. This also caps the work done for a single query.
                 AND w.hops < ?
             )
+            -- An event can be reached by several paths with different hop counts. MSC4242
+            -- orders by distance from the seed events, which is the *shortest* such path, so
+            -- collapse each event to its minimum hop count before sorting. `hops` is only
+            -- selected because we need it as the primary sort key.
             SELECT event_id, MIN(hops) AS hops
             FROM walk
             GROUP BY event_id

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -38,6 +38,7 @@ from synapse.api.constants import MAX_DEPTH
 from synapse.api.errors import StoreError
 from synapse.api.room_versions import EventFormatVersions, RoomVersion
 from synapse.events import EventBase, make_event_from_dict
+from synapse.events.py_protocol import MSC4242Event, supports_msc4242_state_dag
 from synapse.logging.opentracing import tag_args, trace
 from synapse.metrics import SERVER_NAME_LABEL
 from synapse.metrics.background_process_metrics import wrap_as_background_process
@@ -1198,7 +1199,7 @@ class EventFederationWorkerStore(
     # future MSC4242 PRs.
     async def get_state_dag(
         self, room_id: str, forward_extrems: set[str]
-    ) -> dict[str, EventBase]:
+    ) -> dict[str, MSC4242Event]:
         """Get the current state DAG for the given room.
 
         This function is called when calculating a /send_join response.
@@ -1231,7 +1232,7 @@ class EventFederationWorkerStore(
         event_map = await self.get_events(event_ids)
         # Filter the returned state events to only include ones on the paths back from the forward
         # extremities.
-        result: dict[str, EventBase] = {}
+        result: dict[str, MSC4242Event] = {}
         next_ids = forward_extrems
         seen: set[str] = set()
         while len(next_ids) > 0:
@@ -1244,7 +1245,7 @@ class EventFederationWorkerStore(
             ev = event_map[event_id]
             # `prev_state_events` only exists on MSC4242 event formats, and this is only
             # called for state DAG rooms.
-            assert ev.room_version.msc4242_state_dags
+            assert supports_msc4242_state_dag(ev)
             result[event_id] = ev
             for prev_state_event_id in ev.prev_state_events:
                 next_ids.add(prev_state_event_id)
@@ -1252,7 +1253,7 @@ class EventFederationWorkerStore(
         assert len(result) > 0  # we always return the forward extremities
         # Assert that the create event was returned. Pick the first event (any will do) to verify
         # that this room version supports room IDs as hashes.
-        first_event: EventBase = next(iter(result.values()))
+        first_event: MSC4242Event = next(iter(result.values()))
         if first_event.room_version.msc4291_room_ids_as_hashes:
             create_event_id = f"${room_id[1:]}"
             assert create_event_id in result

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -37,7 +37,7 @@ from prometheus_client import Counter, Gauge
 from synapse.api.constants import MAX_DEPTH
 from synapse.api.errors import StoreError
 from synapse.api.room_versions import EventFormatVersions, RoomVersion
-from synapse.events import EventBase, FrozenEventVMSC4242, make_event_from_dict
+from synapse.events import EventBase, make_event_from_dict
 from synapse.logging.opentracing import tag_args, trace
 from synapse.metrics import SERVER_NAME_LABEL
 from synapse.metrics.background_process_metrics import wrap_as_background_process
@@ -1198,7 +1198,7 @@ class EventFederationWorkerStore(
     # future MSC4242 PRs.
     async def get_state_dag(
         self, room_id: str, forward_extrems: set[str]
-    ) -> dict[str, FrozenEventVMSC4242]:
+    ) -> dict[str, EventBase]:
         """Get the current state DAG for the given room.
 
         This function is called when calculating a /send_join response.
@@ -1231,7 +1231,7 @@ class EventFederationWorkerStore(
         event_map = await self.get_events(event_ids)
         # Filter the returned state events to only include ones on the paths back from the forward
         # extremities.
-        result: dict[str, FrozenEventVMSC4242] = {}
+        result: dict[str, EventBase] = {}
         next_ids = forward_extrems
         seen: set[str] = set()
         while len(next_ids) > 0:
@@ -1242,7 +1242,9 @@ class EventFederationWorkerStore(
                 continue
             seen.add(event_id)
             ev = event_map[event_id]
-            assert isinstance(ev, FrozenEventVMSC4242)
+            # `prev_state_events` only exists on MSC4242 event formats, and this is only
+            # called for state DAG rooms.
+            assert ev.room_version.msc4242_state_dags
             result[event_id] = ev
             for prev_state_event_id in ev.prev_state_events:
                 next_ids.add(prev_state_event_id)
@@ -1250,7 +1252,7 @@ class EventFederationWorkerStore(
         assert len(result) > 0  # we always return the forward extremities
         # Assert that the create event was returned. Pick the first event (any will do) to verify
         # that this room version supports room IDs as hashes.
-        first_event: FrozenEventVMSC4242 = next(iter(result.values()))
+        first_event: EventBase = next(iter(result.values()))
         if first_event.room_version.msc4291_room_ids_as_hashes:
             create_event_id = f"${room_id[1:]}"
             assert create_event_id in result

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1318,19 +1318,13 @@ class EventFederationWorkerStore(
             self.database_engine, "e.event_id", seed_ids
         )
 
-        # `make_in_list_sql_clause` doesn't handle empty iterables, so guard
-        # the no-earliest case explicitly with an always-true clause.
-        if earliest_event_ids:
-            earliest_clause, earliest_args = make_in_list_sql_clause(
-                self.database_engine,
-                "e.prev_state_event_id",
-                earliest_event_ids,
-                negative=True,
-            )
-        else:
-            # No-op clause that is TRUE for every row, in both dialects.
-            earliest_clause = "1=1"
-            earliest_args = []
+        # With no earliest events this is a no-op clause that is TRUE for every row.
+        earliest_clause, earliest_args = make_in_list_sql_clause(
+            self.database_engine,
+            "e.prev_state_event_id",
+            earliest_event_ids,
+            negative=True,
+        )
 
         query = f"""
             WITH RECURSIVE walk(event_id, hops) AS (
@@ -1363,7 +1357,10 @@ class EventFederationWorkerStore(
                 AND {earliest_clause}
                 -- Bound the recursion by `limit`: every extra hop adds at least one event to
                 -- the result, so events more than `limit` hops away can never make it into a
-                -- `limit`-sized response. This also caps the work done for a single query.
+                -- `limit`-sized response. This is also what makes the query safe against a
+                -- cyclic edge set: a cycle cannot be created via the normal write path, but
+                -- if one did exist the walk would still stop after `limit` hops rather than
+                -- spinning forever.
                 AND w.hops < ?
             )
             -- An event can be reached by several paths with different hop counts. MSC4242

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1313,6 +1313,7 @@ class EventFederationWorkerStore(
         # Sort the seeds lexicographically by event ID: seeds are all 0 hops away from
         # themselves, so the event ID is the only tie-breaker available for them and we need
         # the walk to start from a deterministic order.
+        # See https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/placeholder-1/proposals/4242-state-dags.md#get_missing_events
         seed_ids = sorted(set(latest_event_ids) - earliest_set)
         if not seed_ids or limit <= 0:
             return []

--- a/synapse/synapse_rust/events.pyi
+++ b/synapse/synapse_rust/events.pyi
@@ -274,6 +274,14 @@ class Event:
     @property
     def unsigned(self) -> Unsigned: ...
     @property
+    def prev_state_events(self) -> list[str]:
+        """The `prev_state_events` field of this event (MSC4242 state DAGs).
+
+        Raises `AttributeError` for event formats which do not support MSC4242, so only
+        access this after checking the room version supports state DAGs.
+        """
+
+    @property
     def internal_metadata(self) -> EventInternalMetadata: ...
     @property
     def rejected_reason(self) -> str | None: ...

--- a/synapse/synapse_rust/events.pyi
+++ b/synapse/synapse_rust/events.pyi
@@ -274,14 +274,6 @@ class Event:
     @property
     def unsigned(self) -> Unsigned: ...
     @property
-    def prev_state_events(self) -> list[str]:
-        """The `prev_state_events` field of this event (MSC4242 state DAGs).
-
-        Raises `AttributeError` for event formats which do not support MSC4242, so only
-        access this after checking the room version supports state DAGs.
-        """
-
-    @property
     def internal_metadata(self) -> EventInternalMetadata: ...
     @property
     def rejected_reason(self) -> str | None: ...

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -28,6 +28,7 @@ from typing import (
     TypeVar,
     cast,
 )
+from unittest import mock
 
 import attr
 from parameterized import parameterized
@@ -41,6 +42,7 @@ from synapse.api.room_versions import (
     RoomVersion,
 )
 from synapse.events import EventBase, FrozenEventVMSC4242
+from synapse.events.snapshot import EventContext
 from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
@@ -1469,7 +1471,7 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
         # A <- B             E
         #       `- R -- W --`
         #           `-- T -`
-        graph = {
+        graph: dict[str, list[str]] = {
             "A": [],
             "B": ["A"],
             "C": ["B"],
@@ -1479,64 +1481,18 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
             "T": ["R"],
             "E": ["W", "D", "T"],
         }
-        room_id = "@state_dag:local"
-        events = [
-            cast(
-                FrozenEventVMSC4242,
-                StateDAGFakeEvent(
-                    event_id,
-                    room_id,
-                    EventTypes.Create if len(graph[event_id]) == 0 else "foo",
-                    graph[event_id],
-                ),
-            )
-            for event_id in graph
-        ]
+        creator = "@test_get_missing_events_state_dag:localhost"
+        (room_id, graph_events) = build_state_dag(creator, graph)
 
         def insert(txn: LoggingTransaction) -> None:
-            # store these to satisfy fk constraints
-            self.persist_events.db_pool.simple_insert_many_txn(
-                txn,
-                table="events",
-                keys=(
-                    "instance_name",
-                    "stream_ordering",
-                    "topological_ordering",
-                    "depth",
-                    "event_id",
-                    "room_id",
-                    "type",
-                    "processed",
-                    "outlier",
-                    "origin_server_ts",
-                    "received_ts",
-                    "sender",
-                    "contains_url",
-                    "state_key",
-                    "rejection_reason",
-                ),
-                values=[
-                    (
-                        "test",
-                        event.internal_metadata.stream_ordering,
-                        event.depth,  # topological_ordering
-                        event.depth,  # depth
-                        event.event_id,
-                        event.room_id,
-                        event.type,
-                        True,  # processed
-                        False,  # outlier
-                        1337,
-                        1741622420,
-                        event.sender,
-                        False,  # contains url
-                        event.state_key,
-                        False,  # rejected
-                    )
-                    for event in events
-                ],
-            )
-            for ev in events:
+            mock_context = mock.Mock(spec=EventContext)
+            mock_context.rejected = False
+            for ev in graph_events.values():
+                # store the event first to satisfy fk constraints
+                self.persist_events._store_event_txn(
+                    txn,
+                    [(ev, mock_context)],
+                )
                 self.persist_events._store_state_dag_edges(
                     txn,
                     ev,
@@ -1544,7 +1500,7 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
 
         # satisfy fk constraints
         self.get_success(
-            self.store.store_room(room_id, "foo", False, RoomVersions.MSC4242v12)
+            self.store.store_room(room_id, creator, False, RoomVersions.MSC4242v12)
         )
         self.get_success(
             self.store.db_pool.runInteraction(
@@ -1559,6 +1515,8 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
         TestCase = namedtuple("TestCase", "latest want limit")
         test_cases = [
             TestCase(latest=["E"], want=["D", "T", "W"], limit=3),
+            TestCase(latest=["E"], want=["D"], limit=1),
+            TestCase(latest=["E"], want=["D", "T"], limit=2),
             TestCase(latest=["W", "T", "D"], want=["C", "R"], limit=2),
             # breadth first and new entries are added to the end, sorted lexicographically
             TestCase(latest=["E"], want=["D", "T", "W", "C", "R", "B", "A"], limit=100),
@@ -1573,19 +1531,23 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
             TestCase(latest=["W", "E"], want=["D", "T", "W", "R"], limit=4),
         ]
         for test_case in test_cases:
-
-            def do_test(txn: LoggingTransaction) -> None:
-                got = self.store._get_missing_events_state_dag_txn(
-                    txn,
-                    room_id,
-                    [],
-                    test_case.latest,
-                    test_case.limit,
-                )
-                self.assertEquals(got, test_case.want)
-
-            self.get_success(
-                self.store.db_pool.runInteraction("test_case", do_test),
+            got = self.get_success(
+                self.store.get_missing_events_state_dag(
+                    room_id=room_id,
+                    earliest_event_ids=[],
+                    latest_event_ids=[
+                        graph_events[graph_event_id].event_id
+                        for graph_event_id in test_case.latest
+                    ],
+                    limit=test_case.limit,
+                ),
+            )
+            self.assertEquals(
+                [ev.event_id for ev in got],
+                [
+                    graph_events[graph_event_id].event_id
+                    for graph_event_id in test_case.want
+                ],
             )
 
 
@@ -1607,17 +1569,64 @@ class FakeEvent:
         return True
 
 
-@attr.s(auto_attribs=True)
-class StateDAGFakeEvent:
-    event_id: str
-    room_id: str
-    type: str
-    prev_state_events: list[str]
-    state_key = "foo"
-    depth = 1
-    sender = "foo"
+def build_state_dag(
+    creator: str, graph: dict[str, list[str]]
+) -> tuple[str, dict[str, FrozenEventVMSC4242]]:
+    """Build an MSC4242 state DAG.
 
-    internal_metadata = EventInternalMetadata({})
-
-    def is_state(self) -> bool:
-        return True
+    Args:
+        creator: The user ID creating the graph. Should be unique per-test to ensure room IDs change between tests.
+        graph: A map of fake event ID e.g. "B" to a list of prev_state_events e.g. ["A"]. Graphs must
+        be created in causal order (earliest events first).
+    Returns:
+        A tuple of the room ID and a map from fake event ID e.g. "B" to real event which you can use .event_id
+        to extract the real event ID. Guarantees that the real event IDs start with the fake event ID e.g.
+        the real event for "B" is guarantees to start "$B...." which makes sorting tests much easier to reason about.
+    """
+    graph_events: dict[str, FrozenEventVMSC4242] = {}  # graph ID => built event
+    create_event = FrozenEventVMSC4242(
+        {
+            "type": EventTypes.Create,
+            "state_key": "",
+            "content": {
+                "room_version": RoomVersions.MSC4242v12.identifier,
+            },
+            "sender": creator,
+            "origin_server_ts": 1,
+            "prev_state_events": [],
+            "prev_events": [],
+            "depth": 1,
+        },
+        RoomVersions.MSC4242v12,
+    )
+    room_id = create_event.room_id
+    entropy = 1
+    for graph_event_id in graph:
+        if len(graph[graph_event_id]) == 0:  # create event
+            graph_events[graph_event_id] = create_event
+            continue
+        # Map previous event IDs to real event IDs. Requires us to build events in causal order.
+        prev_state_event_ids = [
+            graph_events[prev_graph_event_id].event_id
+            for prev_graph_event_id in graph[graph_event_id]
+        ]
+        while graph_event_id not in graph_events:
+            graph_event = FrozenEventVMSC4242(
+                {
+                    "type": "foo",
+                    "state_key": graph_event_id,  # modify state_key as that forms part of the event hash
+                    "content": {},
+                    "sender": creator,
+                    "origin_server_ts": 1 + entropy,
+                    "prev_state_events": prev_state_event_ids,
+                    "prev_events": [],  # nothing should be looking at this field so keep it empty
+                    "room_id": room_id,
+                    "depth": 1,
+                },
+                RoomVersions.MSC4242v12,
+            )
+            if not graph_event.event_id[1:].startswith(graph_event_id):
+                entropy += 1
+                continue
+            graph_events[graph_event_id] = graph_event
+    return (room_id, graph_events)

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -19,6 +19,7 @@
 #
 
 import datetime
+from collections import namedtuple
 from typing import (
     Collection,
     Iterable,
@@ -39,13 +40,14 @@ from synapse.api.room_versions import (
     EventFormatVersions,
     RoomVersion,
 )
-from synapse.events import EventBase
+from synapse.events import EventBase, FrozenEventVMSC4242
 from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.storage.database import LoggingTransaction
 from synapse.storage.types import Cursor
 from synapse.synapse_rust.events import EventInternalMetadata
+from synapse.synapse_rust.room_versions import RoomVersions
 from synapse.types import JsonDict
 from synapse.util.clock import Clock
 from synapse.util.json import json_encoder
@@ -1414,6 +1416,178 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
         # elapsed past the backoff range so there is no events to backoff from.
         self.assertEqual(event_ids_with_backoff, {})
 
+    @tests.unittest.override_config(
+        {"experimental_features": {"msc4242_enabled": True}}
+    )
+    def test_get_state_dag(self) -> None:
+        """
+        Test that MSC4242 state dag rooms can return the complete state dag on request.
+        """
+        # Create the room
+        user_id = self.register_user("alice", "test")
+        tok = self.login("alice", "test")
+        room_id = self.helper.create_room_as(
+            room_creator=user_id,
+            tok=tok,
+            room_version=RoomVersions.MSC4242v12.identifier,
+        )
+        resp = self.helper.send_state(
+            room_id,
+            "m.room.join_rules",
+            {"join_rule": "knock"},
+            tok=tok,
+        )
+        latest = resp["event_id"]
+        state_dag = self.get_success(
+            self.store.get_state_dag(room_id, {latest}),
+        )
+        # create <- member <- pl <- join_rules <- his vis <- join_rules
+        self.assertEquals(len(state_dag), 6)
+        want_types = [
+            EventTypes.Create,
+            EventTypes.Member,
+            EventTypes.PowerLevels,
+            EventTypes.JoinRules,
+            EventTypes.RoomHistoryVisibility,
+            EventTypes.JoinRules,
+        ]
+        curr = {latest}
+        while len(curr) > 0:
+            event_id = curr.pop()
+            ev = state_dag[event_id]
+            want_type = want_types.pop()
+            self.assertEqual(ev.type, want_type)
+            curr.update(ev.prev_state_events)
+
+    @tests.unittest.override_config(
+        {"experimental_features": {"msc4242_enabled": True}}
+    )
+    def test_get_missing_events_state_dag(self) -> None:
+        # Primarily testing to make sure that we sort events
+        # correctly when there are multiple prev_state_events
+        #       .- C -- D ---.
+        # A <- B             E
+        #       `- R -- W --`
+        #           `-- T -`
+        graph = {
+            "A": [],
+            "B": ["A"],
+            "C": ["B"],
+            "R": ["B"],
+            "D": ["C"],
+            "W": ["R"],
+            "T": ["R"],
+            "E": ["W", "D", "T"],
+        }
+        room_id = "@state_dag:local"
+        events = [
+            cast(
+                FrozenEventVMSC4242,
+                StateDAGFakeEvent(
+                    event_id,
+                    room_id,
+                    EventTypes.Create if len(graph[event_id]) == 0 else "foo",
+                    graph[event_id],
+                ),
+            )
+            for event_id in graph
+        ]
+
+        def insert(txn: LoggingTransaction) -> None:
+            # store these to satisfy fk constraints
+            self.persist_events.db_pool.simple_insert_many_txn(
+                txn,
+                table="events",
+                keys=(
+                    "instance_name",
+                    "stream_ordering",
+                    "topological_ordering",
+                    "depth",
+                    "event_id",
+                    "room_id",
+                    "type",
+                    "processed",
+                    "outlier",
+                    "origin_server_ts",
+                    "received_ts",
+                    "sender",
+                    "contains_url",
+                    "state_key",
+                    "rejection_reason",
+                ),
+                values=[
+                    (
+                        "test",
+                        event.internal_metadata.stream_ordering,
+                        event.depth,  # topological_ordering
+                        event.depth,  # depth
+                        event.event_id,
+                        event.room_id,
+                        event.type,
+                        True,  # processed
+                        False,  # outlier
+                        1337,
+                        1741622420,
+                        event.sender,
+                        False,  # contains url
+                        event.state_key,
+                        False,  # rejected
+                    )
+                    for event in events
+                ],
+            )
+            for ev in events:
+                self.persist_events._store_state_dag_edges(
+                    txn,
+                    ev,
+                )
+
+        # satisfy fk constraints
+        self.get_success(
+            self.store.store_room(room_id, "foo", False, RoomVersions.MSC4242v12)
+        )
+        self.get_success(
+            self.store.db_pool.runInteraction(
+                "_store_state_dag_edges",
+                insert,
+            )
+        )
+        #       .- C -- D ---.
+        # A <- B             E
+        #       `- R -- W --`
+        #           `-- T -`
+        TestCase = namedtuple("TestCase", "latest want limit")
+        test_cases = [
+            TestCase(latest=["E"], want=["D", "T", "W"], limit=3),
+            TestCase(latest=["W", "T", "D"], want=["C", "R"], limit=2),
+            # breadth first and new entries are added to the end, sorted lexicographically
+            TestCase(latest=["E"], want=["D", "T", "W", "C", "R", "B", "A"], limit=100),
+            # we should sort the latest values initially
+            TestCase(latest=["E", "C"], want=["B", "D", "T", "W"], limit=4),
+            TestCase(latest=["C", "E"], want=["B", "D", "T", "W"], limit=4),
+            # dupes are ignored
+            TestCase(
+                latest=["E", "E", "C", "C", "C"], want=["B", "D", "T", "W"], limit=4
+            ),
+            # include latest events in response. W included because reachable from E.
+            TestCase(latest=["W", "E"], want=["D", "T", "W", "R"], limit=4),
+        ]
+        for test_case in test_cases:
+
+            def do_test(txn: LoggingTransaction) -> None:
+                got = self.store._get_missing_events_state_dag_txn(
+                    txn,
+                    room_id,
+                    [],
+                    test_case.latest,
+                    test_case.limit,
+                )
+                self.assertEquals(got, test_case.want)
+
+            self.get_success(
+                self.store.db_pool.runInteraction("test_case", do_test),
+            )
+
 
 @attr.s(auto_attribs=True)
 class FakeEvent:
@@ -1428,6 +1602,22 @@ class FakeEvent:
 
     def auth_event_ids(self) -> list[str]:
         return self.auth_events
+
+    def is_state(self) -> bool:
+        return True
+
+
+@attr.s(auto_attribs=True)
+class StateDAGFakeEvent:
+    event_id: str
+    room_id: str
+    type: str
+    prev_state_events: list[str]
+    state_key = "foo"
+    depth = 1
+    sender = "foo"
+
+    internal_metadata = EventInternalMetadata({})
 
     def is_state(self) -> bool:
         return True

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -1453,13 +1453,27 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
             EventTypes.RoomHistoryVisibility,
             EventTypes.JoinRules,
         ]
+        got_types = []
+        create_event_id = None
         curr = {latest}
         while len(curr) > 0:
             event_id = curr.pop()
             ev = state_dag[event_id]
-            want_type = want_types.pop()
-            self.assertEqual(ev.type, want_type)
+            got_types.append(ev.type)
             curr.update(ev.prev_state_events)
+            if ev.type == EventTypes.Create:
+                create_event_id = ev.event_id
+        got_types.reverse()  # we walked up the graph but want_types is walking down
+        self.assertEqual(got_types, want_types)
+
+        # Check that getting the state DAG from the create event returns nothing as there are
+        # no earlier events.
+        assert create_event_id is not None
+        state_dag = self.get_success(
+            self.store.get_state_dag(room_id, {create_event_id}),
+        )
+        self.assertEquals(len(state_dag), 1)
+        assert create_event_id in state_dag
 
     @tests.unittest.override_config(
         {"experimental_features": {"msc4242_enabled": True}}

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -19,7 +19,6 @@
 #
 
 import datetime
-from collections import namedtuple
 from typing import (
     Collection,
     Iterable,
@@ -1476,7 +1475,9 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
         assert create_event_id in state_dag
 
 
-class EventFederationGetMissingEventsStateDAGTestCase(tests.unittest.HomeserverTestCase):
+class EventFederationGetMissingEventsStateDAGTestCase(
+    tests.unittest.HomeserverTestCase
+):
     servlets = [
         admin.register_servlets,
         room.register_servlets,
@@ -1534,28 +1535,32 @@ class EventFederationGetMissingEventsStateDAGTestCase(tests.unittest.HomeserverT
         )
         self.room_id = room_id
         self.graph_events = graph_events
-    
-    @parameterized.expand([
-        (["E"], ["D","T","W"], 3),
-        (["E"], ["D","T"], 2),
-        (["E"], ["D"], 1),
-        (["W", "T", "D"], ["C", "R"], 2),
-        # breadth first and new entries are added to the end, sorted lexicographically
-        (["E"], ["D", "T", "W", "C", "R", "B", "A"], 100),
-        # we should sort the latest values initially
-        (["E", "C"], ["B", "D", "T", "W"], 4),
-        (["C", "E"], ["B", "D", "T", "W"], 4),
-        # dupes are ignored
-        (["E", "E", "C", "C", "C"], ["B", "D", "T", "W"], 4),
-        # include latest events in response. W included because reachable from E.
-        # sort order is based on # hops not processing order of parents
-        # (which would produce D,T,W,R as E is processed first, then W).
-        (["W", "E"], ["D", "R", "T", "W"], 4),
-    ])
+
+    @parameterized.expand(
+        [
+            (["E"], ["D", "T", "W"], 3),
+            (["E"], ["D", "T"], 2),
+            (["E"], ["D"], 1),
+            (["W", "T", "D"], ["C", "R"], 2),
+            # breadth first and new entries are added to the end, sorted lexicographically
+            (["E"], ["D", "T", "W", "C", "R", "B", "A"], 100),
+            # we should sort the latest values initially
+            (["E", "C"], ["B", "D", "T", "W"], 4),
+            (["C", "E"], ["B", "D", "T", "W"], 4),
+            # dupes are ignored
+            (["E", "E", "C", "C", "C"], ["B", "D", "T", "W"], 4),
+            # include latest events in response. W included because reachable from E.
+            # sort order is based on # hops not processing order of parents
+            # (which would produce D,T,W,R as E is processed first, then W).
+            (["W", "E"], ["D", "R", "T", "W"], 4),
+        ]
+    )
     @tests.unittest.override_config(
         {"experimental_features": {"msc4242_enabled": True}}
     )
-    def test_get_missing_events_state_dag(self, latest: list[str], want: list[str], limit: int) -> None:
+    def test_get_missing_events_state_dag(
+        self, latest: list[str], want: list[str], limit: int
+    ) -> None:
         #       .- C -- D ---.
         # A <- B             E
         #       `- R -- W --`
@@ -1573,14 +1578,10 @@ class EventFederationGetMissingEventsStateDAGTestCase(tests.unittest.HomeserverT
         )
         self.assertEquals(
             [ev.event_id for ev in got],
-            [
-                self.graph_events[graph_event_id].event_id
-                for graph_event_id in want
-            ],
-            f"latest={latest} want={want} limit={limit}"
+            [self.graph_events[graph_event_id].event_id for graph_event_id in want],
+            f"latest={latest} want={want} limit={limit}",
         )
 
-    
 
 @attr.s(auto_attribs=True)
 class FakeEvent:

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -1542,7 +1542,9 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
                 latest=["E", "E", "C", "C", "C"], want=["B", "D", "T", "W"], limit=4
             ),
             # include latest events in response. W included because reachable from E.
-            TestCase(latest=["W", "E"], want=["D", "T", "W", "R"], limit=4),
+            # sort order is based on # hops not processing order of parents
+            # (which would produce D,T,W,R as E is processed first, then W).
+            TestCase(latest=["W", "E"], want=["D", "R", "T", "W"], limit=4),
         ]
         for test_case in test_cases:
             got = self.get_success(

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -1475,10 +1475,20 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
         self.assertEquals(len(state_dag), 1)
         assert create_event_id in state_dag
 
-    @tests.unittest.override_config(
-        {"experimental_features": {"msc4242_enabled": True}}
-    )
-    def test_get_missing_events_state_dag(self) -> None:
+
+class EventFederationGetMissingEventsStateDAGTestCase(tests.unittest.HomeserverTestCase):
+    servlets = [
+        admin.register_servlets,
+        room.register_servlets,
+        login.register_servlets,
+    ]
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.store = hs.get_datastores().main
+        persist_events = hs.get_datastores().persist_events
+        assert persist_events is not None
+        self.persist_events = persist_events
+
         # Primarily testing to make sure that we sort events
         # correctly when there are multiple prev_state_events
         #       .- C -- D ---.
@@ -1522,50 +1532,55 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
                 insert,
             )
         )
+        self.room_id = room_id
+        self.graph_events = graph_events
+    
+    @parameterized.expand([
+        (["E"], ["D","T","W"], 3),
+        (["E"], ["D","T"], 2),
+        (["E"], ["D"], 1),
+        (["W", "T", "D"], ["C", "R"], 2),
+        # breadth first and new entries are added to the end, sorted lexicographically
+        (["E"], ["D", "T", "W", "C", "R", "B", "A"], 100),
+        # we should sort the latest values initially
+        (["E", "C"], ["B", "D", "T", "W"], 4),
+        (["C", "E"], ["B", "D", "T", "W"], 4),
+        # dupes are ignored
+        (["E", "E", "C", "C", "C"], ["B", "D", "T", "W"], 4),
+        # include latest events in response. W included because reachable from E.
+        # sort order is based on # hops not processing order of parents
+        # (which would produce D,T,W,R as E is processed first, then W).
+        (["W", "E"], ["D", "R", "T", "W"], 4),
+    ])
+    @tests.unittest.override_config(
+        {"experimental_features": {"msc4242_enabled": True}}
+    )
+    def test_get_missing_events_state_dag(self, latest: list[str], want: list[str], limit: int) -> None:
         #       .- C -- D ---.
         # A <- B             E
         #       `- R -- W --`
         #           `-- T -`
-        TestCase = namedtuple("TestCase", "latest want limit")
-        test_cases = [
-            TestCase(latest=["E"], want=["D", "T", "W"], limit=3),
-            TestCase(latest=["E"], want=["D"], limit=1),
-            TestCase(latest=["E"], want=["D", "T"], limit=2),
-            TestCase(latest=["W", "T", "D"], want=["C", "R"], limit=2),
-            # breadth first and new entries are added to the end, sorted lexicographically
-            TestCase(latest=["E"], want=["D", "T", "W", "C", "R", "B", "A"], limit=100),
-            # we should sort the latest values initially
-            TestCase(latest=["E", "C"], want=["B", "D", "T", "W"], limit=4),
-            TestCase(latest=["C", "E"], want=["B", "D", "T", "W"], limit=4),
-            # dupes are ignored
-            TestCase(
-                latest=["E", "E", "C", "C", "C"], want=["B", "D", "T", "W"], limit=4
-            ),
-            # include latest events in response. W included because reachable from E.
-            # sort order is based on # hops not processing order of parents
-            # (which would produce D,T,W,R as E is processed first, then W).
-            TestCase(latest=["W", "E"], want=["D", "R", "T", "W"], limit=4),
-        ]
-        for test_case in test_cases:
-            got = self.get_success(
-                self.store.get_missing_events_state_dag(
-                    room_id=room_id,
-                    earliest_event_ids=[],
-                    latest_event_ids=[
-                        graph_events[graph_event_id].event_id
-                        for graph_event_id in test_case.latest
-                    ],
-                    limit=test_case.limit,
-                ),
-            )
-            self.assertEquals(
-                [ev.event_id for ev in got],
-                [
-                    graph_events[graph_event_id].event_id
-                    for graph_event_id in test_case.want
+        got = self.get_success(
+            self.store.get_missing_events_state_dag(
+                room_id=self.room_id,
+                earliest_event_ids=[],
+                latest_event_ids=[
+                    self.graph_events[graph_event_id].event_id
+                    for graph_event_id in latest
                 ],
-            )
+                limit=limit,
+            ),
+        )
+        self.assertEquals(
+            [ev.event_id for ev in got],
+            [
+                self.graph_events[graph_event_id].event_id
+                for graph_event_id in want
+            ],
+            f"latest={latest} want={want} limit={limit}"
+        )
 
+    
 
 @attr.s(auto_attribs=True)
 class FakeEvent:

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -1465,8 +1465,9 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
         got_types.reverse()  # we walked up the graph but want_types is walking down
         self.assertEqual(got_types, want_types)
 
-        # Check that getting the state DAG from the create event returns nothing as there are
-        # no earlier events.
+        # Check that getting the state DAG from the create event returns just the create event
+        # itself: we always return the requested forward extremities, and there are no earlier
+        # events to walk back to.
         assert create_event_id is not None
         state_dag = self.get_success(
             self.store.get_state_dag(room_id, {create_event_id}),
@@ -1642,11 +1643,19 @@ def build_state_dag(
             graph_events[prev_graph_event_id].event_id
             for prev_graph_event_id in graph[graph_event_id]
         ]
+        # Event IDs are hashes of the event, so we cannot choose them directly. Instead, keep
+        # rebuilding the event with a different `origin_server_ts` until the hash happens to
+        # start with the fake event ID (e.g. "B" produces "$B..."). Ordering in the state DAG
+        # breaks ties lexicographically on the real event ID, so having the real IDs sort in
+        # the same order as the fake names is what makes the expectations in these tests
+        # readable.
         while graph_event_id not in graph_events:
             graph_event = FrozenEventVMSC4242(
                 {
                     "type": "foo",
-                    "state_key": graph_event_id,  # modify state_key as that forms part of the event hash
+                    # All the fake events share a `type`, so the `state_key` is what makes
+                    # each one a distinct piece of state.
+                    "state_key": graph_event_id,
                     "content": {},
                     "sender": creator,
                     "origin_server_ts": 1 + entropy,

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -41,7 +41,7 @@ from synapse.api.room_versions import (
     EventFormatVersions,
     RoomVersion,
 )
-from synapse.events import EventBase, FrozenEventVMSC4242
+from synapse.events import EventBase, make_event_from_dict
 from synapse.events.snapshot import EventContext
 from synapse.rest import admin
 from synapse.rest.client import login, room
@@ -1527,7 +1527,7 @@ class EventFederationGetMissingEventsStateDAGTestCase(
 
     def _persist_state_dag(
         self, creator: str, graph: dict[str, list[str]]
-    ) -> tuple[str, dict[str, FrozenEventVMSC4242]]:
+    ) -> tuple[str, dict[str, EventBase]]:
         """Build and persist a state DAG in its own room, as `build_state_dag` returns it."""
         (room_id, graph_events) = build_state_dag(creator, graph)
 
@@ -1563,7 +1563,7 @@ class EventFederationGetMissingEventsStateDAGTestCase(
         earliest: list[str],
         limit: int,
         room_id: str | None = None,
-        graph_events: dict[str, FrozenEventVMSC4242] | None = None,
+        graph_events: dict[str, EventBase] | None = None,
     ) -> list[str]:
         """Run `get_missing_events_state_dag` in terms of fake event IDs, returning the fake
         event IDs which came back. Queries the room built in `prepare` unless told otherwise.
@@ -1791,7 +1791,7 @@ class FakeEvent:
 
 def walk_state_dag(
     graph: dict[str, list[str]],
-    graph_events: dict[str, FrozenEventVMSC4242],
+    graph_events: dict[str, EventBase],
     latest: list[str],
     earliest: list[str],
     limit: int,
@@ -1830,7 +1830,7 @@ def walk_state_dag(
 
 def build_state_dag(
     creator: str, graph: dict[str, list[str]]
-) -> tuple[str, dict[str, FrozenEventVMSC4242]]:
+) -> tuple[str, dict[str, EventBase]]:
     """Build an MSC4242 state DAG.
 
     Args:
@@ -1845,8 +1845,8 @@ def build_state_dag(
         The create event is the exception: its ID is fixed by the room ID, so it does not start with its
         fake event ID.
     """
-    graph_events: dict[str, FrozenEventVMSC4242] = {}  # graph ID => built event
-    create_event = FrozenEventVMSC4242(
+    graph_events: dict[str, EventBase] = {}  # graph ID => built event
+    create_event = make_event_from_dict(
         {
             "type": EventTypes.Create,
             "state_key": "",
@@ -1888,7 +1888,7 @@ def build_state_dag(
         # the same order as the fake names is what makes the expectations in these tests
         # readable.
         while graph_event_id not in graph_events:
-            graph_event = FrozenEventVMSC4242(
+            graph_event = make_event_from_dict(
                 {
                     "type": "foo",
                     # All the fake events share a `type`, so the `state_key` is what makes

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -1417,14 +1417,12 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
         # elapsed past the backoff range so there is no events to backoff from.
         self.assertEqual(event_ids_with_backoff, {})
 
-    @tests.unittest.override_config(
-        {"experimental_features": {"msc4242_enabled": True}}
-    )
-    def test_get_state_dag(self) -> None:
+    def _create_msc4242_room(self) -> tuple[str, str]:
+        """Create an MSC4242 room with an additional join rules state event.
+
+        Returns:
+            A tuple of the room ID and the event ID of the most recent state event.
         """
-        Test that MSC4242 state dag rooms can return the complete state dag on request.
-        """
-        # Create the room
         user_id = self.register_user("alice", "test")
         tok = self.login("alice", "test")
         room_id = self.helper.create_room_as(
@@ -1438,7 +1436,16 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
             {"join_rule": "knock"},
             tok=tok,
         )
-        latest = resp["event_id"]
+        return room_id, resp["event_id"]
+
+    @tests.unittest.override_config(
+        {"experimental_features": {"msc4242_enabled": True}}
+    )
+    def test_get_state_dag(self) -> None:
+        """
+        Test that MSC4242 state dag rooms can return the complete state dag on request.
+        """
+        room_id, latest = self._create_msc4242_room()
         state_dag = self.get_success(
             self.store.get_state_dag(room_id, {latest}),
         )
@@ -1453,27 +1460,32 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
             EventTypes.JoinRules,
         ]
         got_types = []
-        create_event_id = None
         curr = {latest}
         while len(curr) > 0:
             event_id = curr.pop()
             ev = state_dag[event_id]
             got_types.append(ev.type)
             curr.update(ev.prev_state_events)
-            if ev.type == EventTypes.Create:
-                create_event_id = ev.event_id
         got_types.reverse()  # we walked up the graph but want_types is walking down
         self.assertEqual(got_types, want_types)
 
-        # Check that getting the state DAG from the create event returns just the create event
-        # itself: we always return the requested forward extremities, and there are no earlier
-        # events to walk back to.
-        assert create_event_id is not None
+    @tests.unittest.override_config(
+        {"experimental_features": {"msc4242_enabled": True}}
+    )
+    def test_get_state_dag_at_create_event(self) -> None:
+        """
+        Test that asking for the state DAG at the create event returns just the create event:
+        we always return the requested forward extremities, and there are no earlier events to
+        walk back to.
+        """
+        room_id, _ = self._create_msc4242_room()
+        # Room IDs are the hash of the create event in this room version, so the create event
+        # ID is derivable from the room ID.
+        create_event_id = f"${room_id[1:]}"
         state_dag = self.get_success(
             self.store.get_state_dag(room_id, {create_event_id}),
         )
-        self.assertEquals(len(state_dag), 1)
-        assert create_event_id in state_dag
+        self.assertEqual(list(state_dag), [create_event_id])
 
 
 class EventFederationGetMissingEventsStateDAGTestCase(
@@ -1581,6 +1593,48 @@ class EventFederationGetMissingEventsStateDAGTestCase(
             [ev.event_id for ev in got],
             [self.graph_events[graph_event_id].event_id for graph_event_id in want],
             f"latest={latest} want={want} limit={limit}",
+        )
+
+    @tests.unittest.override_config(
+        {"experimental_features": {"msc4242_enabled": True}}
+    )
+    def test_get_missing_events_state_dag_with_cycle(self) -> None:
+        """The walk must terminate even if the edges table contains a cycle.
+
+        A cycle cannot be produced by the normal write path, as an event's prev_state_events
+        are fixed at creation and its event ID is a hash of them. Insert one directly to check
+        that the query is bounded regardless.
+        """
+        # Claim that A (the create event) has E as a prev_state_event, so walking back from E
+        # eventually reaches A and then E again.
+        self.get_success(
+            self.store.db_pool.simple_insert(
+                table="msc4242_state_dag_edges",
+                values={
+                    "room_id": self.room_id,
+                    "event_id": self.graph_events["A"].event_id,
+                    "prev_state_event_id": self.graph_events["E"].event_id,
+                },
+                desc="insert_state_dag_cycle",
+            )
+        )
+
+        got = self.get_success(
+            self.store.get_missing_events_state_dag(
+                room_id=self.room_id,
+                earliest_event_ids=[],
+                latest_event_ids=[self.graph_events["E"].event_id],
+                limit=100,
+            ),
+        )
+        # Same as the acyclic walk from E, with E itself now reachable via A at the end. Each
+        # event appears exactly once: the CTE groups by event ID and keeps the fewest hops.
+        self.assertEquals(
+            [ev.event_id for ev in got],
+            [
+                self.graph_events[graph_event_id].event_id
+                for graph_event_id in ["D", "T", "W", "C", "R", "B", "A", "E"]
+            ],
         )
 
 

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -42,6 +42,7 @@ from synapse.api.room_versions import (
     RoomVersion,
 )
 from synapse.events import EventBase, make_event_from_dict
+from synapse.events.py_protocol import MSC4242Event, supports_msc4242_state_dag
 from synapse.events.snapshot import EventContext
 from synapse.rest import admin
 from synapse.rest.client import login, room
@@ -1527,7 +1528,7 @@ class EventFederationGetMissingEventsStateDAGTestCase(
 
     def _persist_state_dag(
         self, creator: str, graph: dict[str, list[str]]
-    ) -> tuple[str, dict[str, EventBase]]:
+    ) -> tuple[str, dict[str, MSC4242Event]]:
         """Build and persist a state DAG in its own room, as `build_state_dag` returns it."""
         (room_id, graph_events) = build_state_dag(creator, graph)
 
@@ -1563,7 +1564,7 @@ class EventFederationGetMissingEventsStateDAGTestCase(
         earliest: list[str],
         limit: int,
         room_id: str | None = None,
-        graph_events: dict[str, EventBase] | None = None,
+        graph_events: dict[str, MSC4242Event] | None = None,
     ) -> list[str]:
         """Run `get_missing_events_state_dag` in terms of fake event IDs, returning the fake
         event IDs which came back. Queries the room built in `prepare` unless told otherwise.
@@ -1791,7 +1792,7 @@ class FakeEvent:
 
 def walk_state_dag(
     graph: dict[str, list[str]],
-    graph_events: dict[str, EventBase],
+    graph_events: dict[str, MSC4242Event],
     latest: list[str],
     earliest: list[str],
     limit: int,
@@ -1830,7 +1831,7 @@ def walk_state_dag(
 
 def build_state_dag(
     creator: str, graph: dict[str, list[str]]
-) -> tuple[str, dict[str, EventBase]]:
+) -> tuple[str, dict[str, MSC4242Event]]:
     """Build an MSC4242 state DAG.
 
     Args:
@@ -1845,7 +1846,7 @@ def build_state_dag(
         The create event is the exception: its ID is fixed by the room ID, so it does not start with its
         fake event ID.
     """
-    graph_events: dict[str, EventBase] = {}  # graph ID => built event
+    graph_events: dict[str, MSC4242Event] = {}  # graph ID => built event
     create_event = make_event_from_dict(
         {
             "type": EventTypes.Create,
@@ -1861,6 +1862,8 @@ def build_state_dag(
         },
         RoomVersions.MSC4242v12,
     )
+    # Narrow to an MSC4242 event, so that `prev_state_events` can be used.
+    assert supports_msc4242_state_dag(create_event)
     room_id = create_event.room_id
     entropy = 1
     for index, graph_event_id in enumerate(graph):
@@ -1906,6 +1909,7 @@ def build_state_dag(
                 },
                 RoomVersions.MSC4242v12,
             )
+            assert supports_msc4242_state_dag(graph_event)
             if not graph_event.event_id[1:].startswith(graph_event_id):
                 entropy += 1
                 continue

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -19,6 +19,7 @@
 #
 
 import datetime
+import random
 from typing import (
     Collection,
     Iterable,
@@ -1519,7 +1520,15 @@ class EventFederationGetMissingEventsStateDAGTestCase(
             "T": ["R"],
             "E": ["W", "D", "T"],
         }
-        creator = "@test_get_missing_events_state_dag:localhost"
+        self.graph = graph
+        (self.room_id, self.graph_events) = self._persist_state_dag(
+            "@test_get_missing_events_state_dag:localhost", graph
+        )
+
+    def _persist_state_dag(
+        self, creator: str, graph: dict[str, list[str]]
+    ) -> tuple[str, dict[str, FrozenEventVMSC4242]]:
+        """Build and persist a state DAG in its own room, as `build_state_dag` returns it."""
         (room_id, graph_events) = build_state_dag(creator, graph)
 
         def insert(txn: LoggingTransaction) -> None:
@@ -1546,8 +1555,32 @@ class EventFederationGetMissingEventsStateDAGTestCase(
                 insert,
             )
         )
-        self.room_id = room_id
-        self.graph_events = graph_events
+        return room_id, graph_events
+
+    def _get_missing_events(
+        self,
+        latest: list[str],
+        earliest: list[str],
+        limit: int,
+        room_id: str | None = None,
+        graph_events: dict[str, FrozenEventVMSC4242] | None = None,
+    ) -> list[str]:
+        """Run `get_missing_events_state_dag` in terms of fake event IDs, returning the fake
+        event IDs which came back. Queries the room built in `prepare` unless told otherwise.
+        """
+        if room_id is None or graph_events is None:
+            room_id = self.room_id
+            graph_events = self.graph_events
+        fake_event_ids = {ev.event_id: fake for fake, ev in graph_events.items()}
+        got = self.get_success(
+            self.store.get_missing_events_state_dag(
+                room_id=room_id,
+                earliest_event_ids=[graph_events[fake].event_id for fake in earliest],
+                latest_event_ids=[graph_events[fake].event_id for fake in latest],
+                limit=limit,
+            ),
+        )
+        return [fake_event_ids[ev.event_id] for ev in got]
 
     @parameterized.expand(
         [
@@ -1578,22 +1611,133 @@ class EventFederationGetMissingEventsStateDAGTestCase(
         # A <- B             E
         #       `- R -- W --`
         #           `-- T -`
-        got = self.get_success(
-            self.store.get_missing_events_state_dag(
-                room_id=self.room_id,
-                earliest_event_ids=[],
-                latest_event_ids=[
-                    self.graph_events[graph_event_id].event_id
-                    for graph_event_id in latest
-                ],
-                limit=limit,
-            ),
-        )
         self.assertEquals(
-            [ev.event_id for ev in got],
-            [self.graph_events[graph_event_id].event_id for graph_event_id in want],
+            self._get_missing_events(latest=latest, earliest=[], limit=limit),
+            want,
             f"latest={latest} want={want} limit={limit}",
         )
+        # These expectations are written by hand, so use them to check `walk_state_dag`, which
+        # the randomly generated graphs below are compared against.
+        self.assertEquals(
+            walk_state_dag(self.graph, self.graph_events, latest, [], limit),
+            want,
+            f"latest={latest} want={want} limit={limit}",
+        )
+
+    @tests.unittest.override_config(
+        {"experimental_features": {"msc4242_enabled": True}}
+    )
+    def test_get_missing_events_state_dag_limit_truncates(self) -> None:
+        """Lowering `limit` must truncate the result rather than change it.
+
+        `limit` also bounds how many hops the walk takes, so this checks the two uses agree:
+        as every extra hop contributes at least one event, a shallower walk cannot miss an
+        event that a `limit`-sized response should have contained.
+        """
+        full = self._get_missing_events(
+            latest=["E"], earliest=[], limit=len(self.graph_events)
+        )
+        self.assertEquals(full, ["D", "T", "W", "C", "R", "B", "A"])
+        for limit in range(1, len(full) + 1):
+            self.assertEquals(
+                self._get_missing_events(latest=["E"], earliest=[], limit=limit),
+                full[:limit],
+                f"limit={limit}",
+            )
+
+    @tests.unittest.override_config(
+        {"experimental_features": {"msc4242_enabled": True}}
+    )
+    def test_get_missing_events_state_dag_returns_nothing(self) -> None:
+        """The cases where there is nothing to walk back to."""
+        # Nothing was asked for.
+        self.assertEquals(
+            self._get_missing_events(latest=["E"], earliest=[], limit=0), []
+        )
+        # Every event in the room has already been seen.
+        self.assertEquals(
+            self._get_missing_events(
+                latest=["E"], earliest=list(self.graph), limit=100
+            ),
+            [],
+        )
+        # Every event walked back from has already been seen.
+        self.assertEquals(
+            self._get_missing_events(latest=["E", "C"], earliest=["C", "E"], limit=100),
+            [],
+        )
+
+    @tests.unittest.override_config(
+        {"experimental_features": {"msc4242_enabled": True}}
+    )
+    def test_get_missing_events_state_dag_random_graphs(self) -> None:
+        """Check the query against a direct implementation of the MSC4242 ordering.
+
+        Uses randomly generated DAGs, as the hand-written cases above can only cover the
+        shapes we thought to write down. The seed is fixed so that a failure is reproducible
+        and cannot appear on an unrelated change.
+        """
+        rand = random.Random(42)
+        # Single letters keep `build_state_dag`'s hash mining cheap. At least 4 events, as
+        # smaller graphs have too little to order for the walk to be interesting.
+        names = "ABCDEFGH"
+        for room_number in range(20):
+            # Each event picks its prev_state_events from the events before it, which keeps
+            # the graph acyclic and in causal order. "A" is the create event.
+            graph: dict[str, list[str]] = {names[0]: []}
+            for index in range(1, rand.randint(4, len(names))):
+                graph[names[index]] = sorted(
+                    rand.sample(names[:index], rand.randint(1, index))
+                )
+            built = list(graph)
+            (room_id, graph_events) = self._persist_state_dag(
+                f"@test_random_state_dag_{room_number}:localhost", graph
+            )
+
+            for _ in range(3):
+                # `latest` is sampled with replacement, as callers can repeat an event ID.
+                latest = [
+                    rand.choice(built) for _ in range(rand.randint(1, len(built)))
+                ]
+                earliest = rand.sample(built, rand.randint(0, len(built) // 2))
+                limit = rand.randint(0, len(built) + 1)
+                message = (
+                    f"graph={graph} latest={latest} earliest={earliest} limit={limit}"
+                )
+                self.assertEquals(
+                    self._get_missing_events(
+                        latest=latest,
+                        earliest=earliest,
+                        limit=limit,
+                        room_id=room_id,
+                        graph_events=graph_events,
+                    ),
+                    walk_state_dag(graph, graph_events, latest, earliest, limit),
+                    message,
+                )
+
+                # Lowering `limit` must truncate the result rather than change it. Take the
+                # limit from the events actually available rather than from the random one,
+                # which is often high enough that nothing is dropped.
+                full = self._get_missing_events(
+                    latest=latest,
+                    earliest=earliest,
+                    limit=len(built),
+                    room_id=room_id,
+                    graph_events=graph_events,
+                )
+                if len(full) > 1:
+                    self.assertEquals(
+                        self._get_missing_events(
+                            latest=latest,
+                            earliest=earliest,
+                            limit=len(full) - 1,
+                            room_id=room_id,
+                            graph_events=graph_events,
+                        ),
+                        full[:-1],
+                        message,
+                    )
 
     @tests.unittest.override_config(
         {"experimental_features": {"msc4242_enabled": True}}
@@ -1619,22 +1763,11 @@ class EventFederationGetMissingEventsStateDAGTestCase(
             )
         )
 
-        got = self.get_success(
-            self.store.get_missing_events_state_dag(
-                room_id=self.room_id,
-                earliest_event_ids=[],
-                latest_event_ids=[self.graph_events["E"].event_id],
-                limit=100,
-            ),
-        )
         # Same as the acyclic walk from E, with E itself now reachable via A at the end. Each
         # event appears exactly once: the CTE groups by event ID and keeps the fewest hops.
         self.assertEquals(
-            [ev.event_id for ev in got],
-            [
-                self.graph_events[graph_event_id].event_id
-                for graph_event_id in ["D", "T", "W", "C", "R", "B", "A", "E"]
-            ],
+            self._get_missing_events(latest=["E"], earliest=[], limit=100),
+            ["D", "T", "W", "C", "R", "B", "A", "E"],
         )
 
 
@@ -1656,6 +1789,45 @@ class FakeEvent:
         return True
 
 
+def walk_state_dag(
+    graph: dict[str, list[str]],
+    graph_events: dict[str, FrozenEventVMSC4242],
+    latest: list[str],
+    earliest: list[str],
+    limit: int,
+) -> list[str]:
+    """Work out what `get_missing_events_state_dag` should return, from the MSC4242 rules.
+
+    Walks back from `latest` via prev_state_events, then orders the events found by how many
+    hops they are from `latest`, breaking ties on the real event ID. An `earliest` event is
+    never returned and is never walked through, though its predecessors are still returned if
+    some other path reaches them.
+
+    Takes the graph and events as `build_state_dag` returns them, in terms of fake event IDs,
+    and returns the fake event IDs which should come back, in order. Ties break on the real
+    event ID rather than the fake one because the create event is the one event whose real ID
+    does not start with its fake ID.
+    """
+    hops: dict[str, int] = {}
+    # An event `limit` hops away can only be reached by returning an event at every hop
+    # before it, so a walk deeper than `limit` cannot contribute to the response.
+    frontier = sorted(set(latest) - set(earliest))
+    for hop in range(1, limit + 1):
+        next_frontier = set()
+        for fake_event_id in frontier:
+            for prev_fake_event_id in graph[fake_event_id]:
+                if prev_fake_event_id in earliest or prev_fake_event_id in hops:
+                    continue
+                # The first time we see an event is by definition its fewest hops.
+                hops[prev_fake_event_id] = hop
+                next_frontier.add(prev_fake_event_id)
+        frontier = sorted(next_frontier)
+    return sorted(
+        hops,
+        key=lambda fake: (hops[fake], graph_events[fake].event_id),
+    )[:limit]
+
+
 def build_state_dag(
     creator: str, graph: dict[str, list[str]]
 ) -> tuple[str, dict[str, FrozenEventVMSC4242]]:
@@ -1670,6 +1842,8 @@ def build_state_dag(
         A tuple of the room ID and a map from fake event ID e.g. "B" to real event which you can use .event_id
         to extract the real event ID. Guarantees that the real event IDs start with the fake event ID e.g.
         the real event for "B" is guarantees to start "$B...." which makes sorting tests much easier to reason about.
+        The create event is the exception: its ID is fixed by the room ID, so it does not start with its
+        fake event ID.
     """
     graph_events: dict[str, FrozenEventVMSC4242] = {}  # graph ID => built event
     create_event = FrozenEventVMSC4242(

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -1610,7 +1610,8 @@ def build_state_dag(
     Args:
         creator: The user ID creating the graph. Should be unique per-test to ensure room IDs change between tests.
         graph: A map of fake event ID e.g. "B" to a list of prev_state_events e.g. ["A"]. Graphs must
-        be created in causal order (earliest events first).
+        be created in causal order (earliest events first). The first entry is assumed to be the
+        create event, so it must have no prev_state_events; every later entry must have at least one.
     Returns:
         A tuple of the room ID and a map from fake event ID e.g. "B" to real event which you can use .event_id
         to extract the real event ID. Guarantees that the real event IDs start with the fake event ID e.g.
@@ -1634,10 +1635,19 @@ def build_state_dag(
     )
     room_id = create_event.room_id
     entropy = 1
-    for graph_event_id in graph:
-        if len(graph[graph_event_id]) == 0:  # create event
+    for index, graph_event_id in enumerate(graph):
+        if index == 0:
+            # The first entry is the create event, which roots the state DAG.
+            assert len(graph[graph_event_id]) == 0, (
+                f"the first graph event {graph_event_id} is the create event, so it cannot "
+                "have any prev_state_events"
+            )
             graph_events[graph_event_id] = create_event
             continue
+        assert len(graph[graph_event_id]) > 0, (
+            f"graph event {graph_event_id} has no prev_state_events, but only the create event "
+            "(the first entry) may be missing them"
+        )
         # Map previous event IDs to real event IDs. Requires us to build events in causal order.
         prev_state_event_ids = [
             graph_events[prev_graph_event_id].event_id
@@ -1660,7 +1670,9 @@ def build_state_dag(
                     "sender": creator,
                     "origin_server_ts": 1 + entropy,
                     "prev_state_events": prev_state_event_ids,
-                    "prev_events": [],  # nothing should be looking at this field so keep it empty
+                    # Nothing in these tests looks at the message DAG, so just mirror the
+                    # state DAG here.
+                    "prev_events": prev_state_event_ids,
                     "room_id": room_id,
                     "depth": 1,
                 },

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -41,7 +41,7 @@ from synapse.api.room_versions import (
     EventFormatVersions,
     RoomVersion,
 )
-from synapse.events import EventBase, make_event_from_dict
+from synapse.events import EventBase
 from synapse.events.py_protocol import MSC4242Event, supports_msc4242_state_dag
 from synapse.events.snapshot import EventContext
 from synapse.rest import admin
@@ -57,6 +57,7 @@ from synapse.util.json import json_encoder
 
 import tests.unittest
 import tests.utils
+from tests.test_utils.event_builders import make_test_event
 
 # The silly auth graph we use to test the auth difference algorithm,
 # where the top are the most recent events.
@@ -1847,7 +1848,7 @@ def build_state_dag(
         fake event ID.
     """
     graph_events: dict[str, MSC4242Event] = {}  # graph ID => built event
-    create_event = make_event_from_dict(
+    create_event = make_test_event(
         {
             "type": EventTypes.Create,
             "state_key": "",
@@ -1856,11 +1857,8 @@ def build_state_dag(
             },
             "sender": creator,
             "origin_server_ts": 1,
-            "prev_state_events": [],
-            "prev_events": [],
-            "depth": 1,
         },
-        RoomVersions.MSC4242v12,
+        room_version=RoomVersions.MSC4242v12,
     )
     # Narrow to an MSC4242 event, so that `prev_state_events` can be used.
     assert supports_msc4242_state_dag(create_event)
@@ -1891,7 +1889,7 @@ def build_state_dag(
         # the same order as the fake names is what makes the expectations in these tests
         # readable.
         while graph_event_id not in graph_events:
-            graph_event = make_event_from_dict(
+            graph_event = make_test_event(
                 {
                     "type": "foo",
                     # All the fake events share a `type`, so the `state_key` is what makes
@@ -1905,9 +1903,8 @@ def build_state_dag(
                     # state DAG here.
                     "prev_events": prev_state_event_ids,
                     "room_id": room_id,
-                    "depth": 1,
                 },
-                RoomVersions.MSC4242v12,
+                room_version=RoomVersions.MSC4242v12,
             )
             assert supports_msc4242_state_dag(graph_event)
             if not graph_event.event_id[1:].startswith(graph_event_id):


### PR DESCRIPTION
Split out from https://github.com/element-hq/synapse/pull/19425

Add storage functions needed for federation support for MSC4242:
 - `get_missing_events_state_dag`: will be used to satisfy `/get_missing_events` requests.
 - `get_state_dag`: will be used to satisfy `/send_join` requests.


Part of a series of 5x PRs to land the federation part of MSC4242 (storage, fedclient, serving, inbound-joins, inbound-pulls).


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
