### PR TITLE
Stabilize MSC3266, support stable room_summary endpoint

### DIFF
--- a/changelog.d/19720.feature
+++ b/changelog.d/19720.feature
@@ -1,0 +1,1 @@
+Stabilize MSC3266, removing the experimental config flag `msc3266_enabled`. Add support for stable room summary endpoints. Contributed by @dasha-uwu.

--- a/docker/complement/conf/workers-shared-extra.yaml.j2
+++ b/docker/complement/conf/workers-shared-extra.yaml.j2
@@ -123,8 +123,6 @@ experimental_features:
   msc3874_enabled: true
   # no UIA for x-signing upload for the first time
   msc3967_enabled: true
-  # Expose a room summary for public rooms
-  msc3266_enabled: true
   # Send to-device messages to application services
   msc2409_to_device_messages_enabled: true
   # Allow application services to masquerade devices

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -386,9 +386,6 @@ class ExperimentalConfig(Config):
         # MSC3814 (dehydrated devices with SSSS)
         self.msc3814_enabled: bool = experimental.get("msc3814_enabled", False)
 
-        # MSC3266 (room summary api)
-        self.msc3266_enabled: bool = experimental.get("msc3266_enabled", False)
-
         # MSC2409 (this setting only relates to optionally sending to-device messages).
         # Presence, typing and read receipt EDUs are already sent to application services that
         # have opted in to receive them. If enabled, this adds to-device messages to that list.

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -1718,16 +1718,18 @@ class RoomHierarchyRestServlet(RestServlet):
 
 class RoomSummaryRestServlet(ResolveRoomIdMixin, RestServlet):
     PATTERNS = (
-        # deprecated endpoint, to be removed
+        # deprecated unstable endpoint, to be removed
         re.compile(
             "^/_matrix/client/unstable/im.nheko.summary"
             "/rooms/(?P<room_identifier>[^/]*)/summary$"
         ),
-        # recommended endpoint
+        # recommended unstable endpoint
         re.compile(
             "^/_matrix/client/unstable/im.nheko.summary"
             "/summary/(?P<room_identifier>[^/]*)$"
         ),
+        # stable endpoint
+        re.compile("^/_matrix/client/v1/room_summary/(?P<room_identifier>[^/]*)$"),
     )
     CATEGORY = "Client API requests"
 
@@ -1775,8 +1777,7 @@ def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:
     RoomTypingRestServlet(hs).register(http_server)
     RoomEventContextServlet(hs).register(http_server)
     RoomHierarchyRestServlet(hs).register(http_server)
-    if hs.config.experimental.msc3266_enabled:
-        RoomSummaryRestServlet(hs).register(http_server)
+    RoomSummaryRestServlet(hs).register(http_server)
     RoomEventServlet(hs).register(http_server)
     JoinedRoomsRestServlet(hs).register(http_server)
     RoomAliasListServlet(hs).register(http_server)


### PR DESCRIPTION
MSC3266 is merged in v1.15, let's stabilize it as part of #18731

1. Add support for the stable `/_matrix/client/v1/room_summary/` endpoint, keeping both unstable endpoints for compat
2. Remove the experimental `msc3266_enabled` flag

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
