### PR TITLE
Cap worker-lock retry interval to fix int-str overflow crash (fixes #19315 #18221)

### DIFF
--- a/changelog.d/19777.bugfix
+++ b/changelog.d/19777.bugfix
@@ -1,0 +1,1 @@
+Fix a crash in the worker-lock retry loop that could be triggered by a client repeatedly uploading one-time keys, causing Synapse to spew `ValueError: Exceeds the limit (4300 digits)` tracebacks until restarted. Contributed by @George3d6.

--- a/changelog.d/19777.bugfix
+++ b/changelog.d/19777.bugfix
@@ -1,1 +1,0 @@
-Fix a crash in the worker-lock retry loop that could be triggered by a client repeatedly uploading one-time keys, causing Synapse to spew `ValueError: Exceeds the limit (4300 digits)` tracebacks until restarted. Contributed by @George3d6.

--- a/synapse/handlers/worker_lock.py
+++ b/synapse/handlers/worker_lock.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+_LOCK_RETRY_CAP_SECS = Duration(minutes=10).as_secs()
 
 # This lock is used to avoid creating an event while we are purging the room.
 # We take a read lock when creating an event, and a write one when purging a room.
@@ -274,11 +275,11 @@ class WaitingLock:
         return r
 
     def _get_next_retry_interval(self) -> float:
-        next = self._retry_interval
-        self._retry_interval = max(5, next * 2)
-        if self._retry_interval > Duration(minutes=10).as_secs():  # >7 iterations
+        prev = self._retry_interval
+        self._retry_interval = min(_LOCK_RETRY_CAP_SECS, max(5, prev * 2))
+        if self._retry_interval == _LOCK_RETRY_CAP_SECS and prev < _LOCK_RETRY_CAP_SECS:
             logger.warning(
-                "Lock timeout is getting excessive: %ss. There may be a deadlock.",
+                "Lock timeout hit cap of %ss. There may be a deadlock.",
                 self._retry_interval,
             )
         return next * random.uniform(0.9, 1.1)
@@ -361,11 +362,11 @@ class WaitingMultiLock:
         return r
 
     def _get_next_retry_interval(self) -> float:
-        next = self._retry_interval
-        self._retry_interval = max(5, next * 2)
-        if self._retry_interval > Duration(minutes=10).as_secs():  # >7 iterations
+        prev = self._retry_interval
+        self._retry_interval = min(_LOCK_RETRY_CAP_SECS, max(5, prev * 2))
+        if self._retry_interval == _LOCK_RETRY_CAP_SECS and prev < _LOCK_RETRY_CAP_SECS:
             logger.warning(
-                "Lock timeout is getting excessive: %ss. There may be a deadlock.",
+                "Lock timeout hit cap of %ss. There may be a deadlock.",
                 self._retry_interval,
             )
         return next * random.uniform(0.9, 1.1)


### PR DESCRIPTION
Cap `WaitingLock` / `WaitingMultiLock` retry interval at 10 minutes.

Without a cap, `max(5, next * 2)` silently promotes `self._retry_interval` to an `int` on the second call (Python's `max` preserves the larger operand's type, and `5` is an int), and it doubles without bound. Once it crosses the existing 10-minute "getting excessive" warning threshold, the warning log line calls `str()` on the int and eventually trips Python 3.11+'s 4300-digit `int_max_str_digits` limit (PEP 644), raising `ValueError` from inside the warning itself. `__aenter__`'s broad `except Exception: pass` (intended to absorb `TimeoutError` from `timeout_deferred`) swallows the `ValueError` before the retry loop sleeps, so the loop re-raises as fast as Python can emit tracebacks until the process is restarted.

The cap is hoisted into a module-level `_LOCK_RETRY_CAP_SECS` so both classes share it, and the excessive-timeout warning is restructured to fire exactly once per waiter (on the iteration that first reaches the cap) instead of either spamming every iteration or being silently suppressed.

Fixes #19315 and #18221.