### PR TITLE
Add workaround for missing events in `_should_perform_remote_join`

### DIFF
--- a/changelog.d/19730.bugfix
+++ b/changelog.d/19730.bugfix
@@ -1,0 +1,1 @@
+Work around bug that sometimes breaks joining restricted rooms that require a remote join. Contributed by @tulir @ Beeper.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -1355,7 +1355,15 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         current_state = {
             state_key: event_map[event_id]
             for state_key, event_id in state_before_join.items()
+            # TODO figure out why events present in state_before_join are sometimes not found in event_map
+            #  See https://github.com/element-hq/synapse/issues/19465
+            if event_id in event_map
         }
+        if len(current_state) < len(state_before_join):
+            logger.warning(
+                "Some events from state_before_join were not found in event_map: %s",
+                set(state_before_join.values()) - set(event_map.keys()),
+            )
         servers_that_can_issue_invite = get_servers_from_users(
             get_users_which_can_issue_invite(current_state)
         )


### PR DESCRIPTION
Not really a fix, but hopefully works around https://github.com/element-hq/synapse/issues/19465

Also, the bug has only been observed on matrix.org (where it occurs 100% of the time for certain rooms), so I can't actually confirm that this works

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog)
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
