### PR TITLE
Expose tombstone status in room details

### DIFF
--- a/changelog.d/19737.feature
+++ b/changelog.d/19737.feature
@@ -1,0 +1,1 @@
+Exposes `tombstoned` and `replacement_room` in room details on admin API endpoint `GET /_synapse/admin/v1/rooms/<room_id>`. Contributed by Noah Markert.

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -308,6 +308,9 @@ The following fields are possible in the JSON response body:
   If the room does not define a type, the value will be `null`.
 * `forgotten` - Whether all local users have
   [forgotten](https://spec.matrix.org/latest/client-server-api/#leaving-rooms) the room.
+* `tombstoned` - Whether the room has been tombstoned (permanently closed).
+* `replacement_room` - The room ID of the new room that users should join instead, if this room was tombstoned. Will be 
+  `null` if the room has not been tombstoned, or if it was tombstoned without designating a successor room.
 
 The API is:
 

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -337,7 +337,9 @@ A response body like the following is returned:
   "history_visibility": "shared",
   "state_events": 93534,
   "room_type": "m.space",
-  "forgotten": false
+  "forgotten": false,
+  "tombstoned": false,
+  "replacement_room": null
 }
 ```
 

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -367,6 +367,7 @@ class RoomRestServlet(RestServlet):
         self.store = hs.get_datastores().main
         self.room_shutdown_handler = hs.get_room_shutdown_handler()
         self.pagination_handler = hs.get_pagination_handler()
+        self._storage_controllers = hs.get_storage_controllers()
 
     async def on_GET(
         self, request: SynapseRequest, room_id: str
@@ -383,6 +384,15 @@ class RoomRestServlet(RestServlet):
             members
         )
         result["forgotten"] = await self.store.is_locally_forgotten_room(room_id)
+        tombstone_event = await self._storage_controllers.state.get_current_state_event(
+            room_id,
+            EventTypes.Tombstone,
+            "",
+        )
+        result["tombstoned"] = tombstone_event is not None
+        result["replacement_room"] = (
+            tombstone_event.content.get("replacement_room") if tombstone_event else None
+        )
 
         return HTTPStatus.OK, result
 

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -2311,10 +2311,14 @@ class RoomTestCase(unittest.HomeserverTestCase):
         self.assertIn("state_events", channel.json_body)
         self.assertIn("room_type", channel.json_body)
         self.assertIn("forgotten", channel.json_body)
+        self.assertIn("tombstoned", channel.json_body)
+        self.assertIn("replacement_room", channel.json_body)
 
         self.assertEqual(room_id_1, channel.json_body["room_id"])
         self.assertIs(True, channel.json_body["federatable"])
         self.assertIs(True, channel.json_body["public"])
+        self.assertIs(False, channel.json_body["tombstoned"])
+        self.assertIs(None, channel.json_body["replacement_room"])
 
     def test_single_room_devices(self) -> None:
         """Test that `joined_local_devices` can be requested correctly"""


### PR DESCRIPTION
Exposes `tombstoned` and `replacement_room` in room details on admin API endpoint `GET /_synapse/admin/v1/rooms/<room_id>`. Resolves #18347 
### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
