### PR TITLE
Partially revert "Bump authlib from 1.6.9 to 1.6.11 (#19703)"

### DIFF
--- a/changelog.d/19742.bugfix
+++ b/changelog.d/19742.bugfix
@@ -1,0 +1,1 @@
+Fix packaging for Fedora and EPEL caused by unnecessary bumping `authlib` minimum version requirement in `pyproject.toml` file. Contributed by Oleg Girko.

--- a/poetry.lock
+++ b/poetry.lock
@@ -3756,4 +3756,4 @@ url-preview = ["lxml"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<4.0.0"
-content-hash = "8c52685a47cc4affa09d79a044e0aed4c15131a5581e2c4f641ffb5e538eec13"
+content-hash = "d97bee07fec0f4048d964aa7127a50813920bce77b00e5191aa1815f83922c85"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ saml2 = [
     "defusedxml>=0.7.1", # via pysaml2
     "pytz>=2018.3",  # via pysaml2
 ]
-oidc = ["authlib>=1.6.11"]
+oidc = ["authlib>=0.15.1"]
 url-preview = ["lxml>=4.6.3"]
 sentry = ["sentry-sdk>=0.7.2"]
 opentracing = [
@@ -179,7 +179,7 @@ all = [
     # saml2
     "pysaml2>=4.5.0",
     # oidc and jwt
-    "authlib>=1.6.11",
+    "authlib>=0.15.1",
     # url-preview
     "lxml>=4.6.3",
     # sentry


### PR DESCRIPTION
This actually changes minimal required version os authlib in `pyproject.toml` from `0.15.1` to `1.6.11`, and this is a disaster for Fedora packaging because it has version `1.4.0` in Fedora 43, `1.5.2` in Fedora 44, and `1.3.2` in EPEL 10.

This reverts commit bdb1cf7416b46a637b3dae323cb05b4d94fafc82 (from https://github.com/element-hq/synapse/pull/19703).

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
