### PR TITLE
Configure Dependabot to only update Python dependencies in the lockfile.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     package-ecosystem: "pip"
     directory: "/"
     open-pull-requests-limit: 10
+    versioning-strategy: "lockfile-only"
     schedule:
       interval: "weekly"
     # Group patch updates to packages together into a single PR, as they rarely

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     package-ecosystem: "pip"
     directory: "/"
     open-pull-requests-limit: 10
-    versioning-strategy: "lockfile-only"
+    versioning-strategy: "increase-if-necessary"
     schedule:
       interval: "weekly"
     # Group patch updates to packages together into a single PR, as they rarely

--- a/changelog.d/19743.misc
+++ b/changelog.d/19743.misc
@@ -1,0 +1,1 @@
+Configure Dependabot to only update Python dependencies in the lockfile.

--- a/changelog.d/19743.misc
+++ b/changelog.d/19743.misc
@@ -1,1 +1,1 @@
-Configure Dependabot to only update Python dependencies in the lockfile.
+Configure Dependabot to only update Python dependencies in the lockfile, unless widening upper bounds.


### PR DESCRIPTION
See:
- https://github.com/element-hq/synapse/pull/19742
- https://github.com/element-hq/synapse/pull/19686

(etc)


Internal chat https://matrix.to/#/!SGNQGPGUwtcPBUotTL:matrix.org/$EQcbt0HlAEgZT-7bsesylDy1VtV2SOpmDZUZVpv2BVc?via=jki.re&via=element.io&via=matrix.org

Documentation https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--

We were considering `lockfile-only` but it sounds like `increase-if-necessary` would increase the upper bound for us, if we had one. Let's try it.