### PR TITLE
Suppress raw JSON logs in Complement CI when debug disabled.

### DIFF
--- a/.github/workflows/complement_tests.yml
+++ b/.github/workflows/complement_tests.yml
@@ -98,6 +98,7 @@ jobs:
         # real-time.
         run: |
           set -o pipefail
+
           COMPLEMENT_DIR=`pwd`/complement synapse/scripts-dev/complement.sh --in-repo -p 1 -json -run 'TestSynapseVersion/Synapse_version_matches_current_git_checkout' 2>&1 | tee /tmp/gotest-sanity-check-complement.log
         shell: bash
         env:
@@ -122,12 +123,26 @@ jobs:
         # -json: Output JSON format so that gotestfmt can parse it.
         #
         # tee /tmp/gotest-complement.log: We tee the output to a file so that we can re-process it
-        # later on for better formatting with gotestfmt. But we still want the command
+        # later on for better formatting with gotestfmt.
+        # But we still want the ability for the command
         # to output to the terminal as it runs so we can see what's happening in
         # real-time.
+        # When not running in pipeline debug mode, we only show the last 50 lines
+        # of the JSON output from the build log because it is not human-readable,
+        # the extreme volume makes it very unwieldy to access in the web UI
+        # and the resultant log download extremely large.
         run: |
           set -o pipefail
-          COMPLEMENT_DIR=`pwd`/complement synapse/scripts-dev/complement.sh -p 1 -json 2>&1 | tee /tmp/gotest-complement.log
+
+          # To see the full build log, start a re-run with
+          # the debug mode enabled in the GitHub UI.
+          if [ "$RUNNER_DEBUG" = "1" ]; then
+            debug_pipe="cat"
+          else
+            debug_pipe="tail -n 50"
+          fi
+
+          COMPLEMENT_DIR=`pwd`/complement synapse/scripts-dev/complement.sh -p 1 -json 2>&1 | tee /tmp/gotest-complement.log | $debug_pipe
         shell: bash
         env:
           POSTGRES: ${{ (matrix.database == 'Postgres') && 1 || '' }}
@@ -151,12 +166,26 @@ jobs:
         #     are underpowered and don't like running tons of Synapse instances at once.
         # -json: Output JSON format so that gotestfmt can parse it.
         #
-        # tee /tmp/gotest-in-repo-complement.log: We tee the output to a file so that we can re-process it
-        # later on for better formatting with gotestfmt. But we still want the command
+        # tee /tmp/gotest-complement.log: We tee the output to a file so that we can re-process it
+        # later on for better formatting with gotestfmt.
+        # But we still want the ability for the command
         # to output to the terminal as it runs so we can see what's happening in
         # real-time.
+        # When not running in pipeline debug mode, we only show the last 50 lines
+        # of the JSON output from the build log because it is not human-readable,
+        # the extreme volume makes it very unwieldy to access in the web UI
+        # and the resultant log download extremely large.
         run: |
           set -o pipefail
+
+          # To see the full build log, start a re-run with
+          # the debug mode enabled in the GitHub UI.
+          if [ "$RUNNER_DEBUG" = "1" ]; then
+            debug_pipe="cat"
+          else
+            debug_pipe="tail -n 50"
+          fi
+
           COMPLEMENT_DIR=`pwd`/complement synapse/scripts-dev/complement.sh --in-repo -p 1 -json 2>&1 | tee /tmp/gotest-in-repo-complement.log
         shell: bash
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,7 @@ jobs:
               - '.ci/**'
               - 'scripts-dev/complement.sh'
               - '.github/workflows/tests.yml'
+              - '.github/workflows/complement_tests.yml'
 
             linting:
               - 'synapse/**'

--- a/changelog.d/19745.misc
+++ b/changelog.d/19745.misc
@@ -1,0 +1,1 @@
+Suppress raw JSON logs in Complement CI when debug disabled.


### PR DESCRIPTION
I was trying to debug some flakes and the webUI to get the logs was just so sluggish.

I tried to download the log file and the download got interrupted, presumably because of the size.
Multiple attempts did not help and it was not resumable.

I don't like the ugly JSON logs (they don't seem useful to me); I'm somewhat sympathetic with it being nice
to see that it's *doing something* but from memory this is a vanishingly rare requirement for me.

If you need to see it, the best proposal I have is for you to re-run the workflow whilst ticking the 'debug mode' box,
which is what this PR suggests as the mechanism to get the live-streamed JSON log dump.

Open to alternative suggestions.
