### PR TITLE
Document `thread_subscriptions` stream writer and fix documentation of `quarantined_media_changes` stream writer.

### DIFF
--- a/changelog.d/19746.doc
+++ b/changelog.d/19746.doc
@@ -1,0 +1,1 @@
+Document `thread_subscriptions` stream writer and fix documentation of `quarantined_media_changes` stream writer.

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -517,6 +517,9 @@ def add_worker_roles_to_shared_config(
         "typing",
         "push_rules",
         "thread_subscriptions",
+        # We can't include `quarantined_media_changes` here
+        # because the worker type is actually called `media_repository`
+        # "quarantined_media_changes",
     }
 
     # Worker-type specific sharding config. Now a single worker can fulfill multiple
@@ -526,6 +529,13 @@ def add_worker_roles_to_shared_config(
 
     if "federation_sender" in worker_types_set:
         shared_config.setdefault("federation_sender_instances", []).append(worker_name)
+
+    if "media_repository" in worker_types_set:
+        # Handle media_repository being the writer for quarantined_media_changes
+        # as a special-case
+        shared_config.setdefault("stream_writers", {}).setdefault(
+            "quarantined_media_changes", []
+        ).append(worker_name)
 
     # Update the list of stream writers. It's convenient that the name of the worker
     # type is the same as the stream to write. Iterate over the whole list in case there

--- a/docs/development/synapse_architecture/streams.md
+++ b/docs/development/synapse_architecture/streams.md
@@ -163,7 +163,7 @@ necessary registration and event handling.
 - [create a stream class and stream row class](https://github.com/element-hq/synapse/blob/4367fb2d078c52959aeca0fe6874539c53e8360d/synapse/replication/tcp/streams/_base.py#L728)
   - will need an [ID generator](https://github.com/element-hq/synapse/blob/4367fb2d078c52959aeca0fe6874539c53e8360d/synapse/storage/databases/main/thread_subscriptions.py#L75)
     - may need [writer configuration](https://github.com/element-hq/synapse/blob/4367fb2d078c52959aeca0fe6874539c53e8360d/synapse/config/workers.py#L177), if there isn't already an obvious source of configuration for which workers should be designated as writers to your new stream.
-      - if adding new writer configuration, add Docker-worker configuration, which lets us configure the writer worker in Complement tests: [[1]](https://github.com/element-hq/synapse/blob/4367fb2d078c52959aeca0fe6874539c53e8360d/docker/configure_workers_and_start.py#L331), [[2]](https://github.com/element-hq/synapse/blob/4367fb2d078c52959aeca0fe6874539c53e8360d/docker/configure_workers_and_start.py#L440)
+      - if adding new writer configuration (`stream_writers`), add Docker-worker configuration, which lets us configure the writer worker in Complement tests: [[1]](https://github.com/element-hq/synapse/blob/4367fb2d078c52959aeca0fe6874539c53e8360d/docker/configure_workers_and_start.py#L331), [[2]](https://github.com/element-hq/synapse/blob/4367fb2d078c52959aeca0fe6874539c53e8360d/docker/configure_workers_and_start.py#L440)
 - most of the time, you will likely introduce a new datastore class for the concept represented by the new stream, unless there is already an obvious datastore that covers it.
 - consider whether it may make sense to introduce a handler
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -576,6 +576,17 @@ configured as stream writer for the `device_lists` stream:
     ^/_matrix/client/(api/v1|r0|v3|unstable)/keys/device_signing/upload$
     ^/_matrix/client/(api/v1|r0|v3|unstable)/keys/signatures/upload$
 
+##### The `thread_subscriptions` stream
+
+This stream is only used for MSC4306 (experimental).
+It is not used when that experimental feature is disabled.
+
+The `thread_subscriptions` stream supports multiple writers.
+The following endpoints should be routed directly to one of the workers
+configured as stream writer for the `thread_subscriptions` stream:
+
+    ^/_matrix/client/unstable/io.element.msc4306/.*
+
 ##### The `quarantined_media_changes` stream
 
 The `quarantined_media_changes` stream supports multiple writers. The following endpoints

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -589,8 +589,7 @@ configured as stream writer for the `thread_subscriptions` stream:
 
 ##### The `quarantined_media_changes` stream
 
-The `quarantined_media_changes` stream supports multiple writers. The following endpoints
-can be handled by any worker, but should be routed directly to one of the workers
+The `quarantined_media_changes` stream supports multiple writers. The following endpoints should be routed directly to one of the workers
 configured as stream writer for the `quarantined_media_changes` stream:
 
     ^/_synapse/admin/v1/quarantine_media/.*$


### PR DESCRIPTION
And a drive-by `configure_workers_and_start.py` improvement (not necessary, but spotted it and thought it'd be better to touch it up)


Original commit schedule, with full messages:

<ol>
<li>

Fix `quarantined_media_changes` not being configured for Complement \
(Although I guess it's not used in there yet, it'd be good to have it
set up properly)


</li>
<li>

Tweak streams cheatsheet 

</li>
<li>

Document `thread_subscriptions` stream_writer 

</li>
<li>

Fix documentation of `quarantined_media_changes` `stream_writer` \
It doesn't have any internal re-routing, so you can't point those
endpoints at any worker (as it said)


</li>
</ol>
