### PR TITLE
Prefer close backfill points (absolute distance)

### DIFF
--- a/changelog.d/19748.misc
+++ b/changelog.d/19748.misc
@@ -1,0 +1,1 @@
+Prefer close backfill points (absolute distance).

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -275,11 +275,20 @@ class FederationHandler:
             )
         ]
 
-        # we now have a list of potential places to backpaginate from. We prefer to
-        # start with the most recent (ie, max depth), so let's sort the list.
+        # we now have a list of potential places to backpaginate from. Figure out which
+        # ones we should prefer, so let's sort the list.
         sorted_backfill_points: list[_BackfillPoint] = sorted(
             backwards_extremities,
-            key=lambda e: -int(e.depth),
+            key=lambda e: (
+                # Prefer backfill points that are closer to the `current_depth`
+                # (absolute distance)
+                abs(current_depth - e.depth),
+                # For the tie-break, we care about events that are actually in the past
+                # as they're more likely to reveal history that we can return (something
+                # absolutely in the past is better than something can potentially extend
+                # into the past).
+                1 if current_depth >= e.depth else 0,
+            ),
         )
 
         logger.debug(
@@ -300,7 +309,7 @@ class FederationHandler:
             str(len(sorted_backfill_points)),
         )
 
-        # If we have no backfill points lower than the `current_depth` then either we
+        # If we have no backfill points lower than the `nearby_depth` then either we
         # can a) bail or b) still attempt to backfill. We opt to try backfilling anyway
         # just in case we do get relevant events. This is good for eventual consistency
         # sake but we don't need to block the client for something that is just as

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -287,7 +287,9 @@ class FederationHandler:
                 # as they're more likely to reveal history that we can return (something
                 # absolutely in the past is better than something can potentially extend
                 # into the past).
-                1 if current_depth >= e.depth else 0,
+                #
+                # This sorts ascending so 0 sorts before 1
+                0 if current_depth >= e.depth else 1,
             ),
         )
 


### PR DESCRIPTION
Prefer close backfill points (absolute distance)

This isn't fixing any particular issue. It's just a follow-up I thought about after merging https://github.com/element-hq/synapse/pull/19611 since we're now also dealing with backfill points in the nearby range ahead of the `current_depth`. And it's possible that the previous sort could bias to all nearby backfill points ahead of the `current_depth` that don't extend into the visible window of events we're paginating through.


### Todo

 - [x] Quick sanity check that the sort works with the tuple


### Dev notes

Sort sanity check:

```python
current_depth = 35
actual_sorted_list = sorted(
	[10, 20, 25, 30, 35, 40, 50],
	key=lambda depth: (
	    # Prefer backfill points that are closer to the `current_depth`
	    # (absolute distance)
	    abs(current_depth - depth),
	    # For the tie-break, we care about events that are actually in the past
	    # as they're more likely to reveal history that we can return (something
	    # absolutely in the past is better than something can potentially extend
	    # into the past).
	    #
	    # This sorts ascending so 0 sorts before 1
	    0 if current_depth >= depth else 1,
	),
)

expected_sorted_list = [35, 30, 40, 25, 20, 50, 10]

assert actual_sorted_list == expected_sorted_list, f"Expected actual list ({actual_sorted_list}) to be sorted like the expected list ({expected_sorted_list})"
print("Success")
```


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
