### PR TITLE
Improve SSO/delegated authentication worker docs

### DIFF
--- a/changelog.d/19752.1.doc
+++ b/changelog.d/19752.1.doc
@@ -1,0 +1,1 @@
+Document the paths that can be handled on workers with stabilised delegated authentication.

--- a/changelog.d/19752.doc
+++ b/changelog.d/19752.doc
@@ -1,0 +1,1 @@
+Improve documentation around endpoints that can be enabled with MSC3861.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -345,6 +345,10 @@ set to `true`), the following endpoints can be handled by the worker:
     ^/_synapse/admin/v1/users/[^/]+/_allow_cross_signing_replacement_without_uia$
     ^/_synapse/admin/v1/users/[^/]+/devices$
 
+Do note that these endpoints can't be handled by workers if the stabilised delegated
+authentication support is enabled (`matrix_authentication_service.enabled` set to
+`true`).
+
 Note that a [HTTP listener](usage/configuration/config_documentation.md#listeners)
 with `client` and `federation` `resources` must be configured in the
 [`worker_listeners`](usage/configuration/config_documentation.md#worker_listeners)

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -317,7 +317,7 @@ for the room are in flight:
 
 Additionally, the following endpoints should be included if Synapse is configured
 to use SSO (you only need to include the ones for whichever SSO provider you're
-using):
+using) and delegated authentication isn't enabled:
 
     # for all SSO providers
     ^/_matrix/client/(api/v1|r0|v3|unstable)/login/sso/redirect

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -290,6 +290,9 @@ information.
     # Unstable MSC4140 support
     ^/_matrix/client/unstable/org.matrix.msc4140/delayed_events(/.*/restart)?$
 
+    # Stabilised Delegated Authentication support (`matrix_authentication_service.enabled: true`)
+    ^/_synapse/mas/
+
 Additionally, the following REST endpoints can be handled for GET requests:
 
     # Push rules requests

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -343,7 +343,7 @@ set to `true`), the following endpoints can be handled by the worker:
     ^/_synapse/admin/v2/users/[^/]+$
     ^/_synapse/admin/v1/username_available$
     ^/_synapse/admin/v1/users/[^/]+/_allow_cross_signing_replacement_without_uia$
-    ^/_synapse/admin/v1/users/[^/]+/devices$
+    ^/_synapse/admin/v2/users/[^/]+/devices(/|$)
 
 Do note that these endpoints can't be handled by workers if the stabilised delegated
 authentication support is enabled (`matrix_authentication_service.enabled` set to


### PR DESCRIPTION
Improve SSO/delegated authentication (MSC3861) worker docs


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Documenting the state of the world as of https://github.com/element-hq/synapse/pull/18759. It is unclear to me whether these endpoints were excluded from normal delegated auth support as they won't work or just because they weren't needed.

Also the `/devices` endpoint(s) had the wrong version and were incomplete as per https://github.com/element-hq/synapse/blob/v1.152.0/synapse/rest/admin/devices.py#L47 and https://github.com/element-hq/synapse/blob/v1.152.0/synapse/rest/admin/devices.py#L121