### PR TITLE
Reduce `WORKER_LOCK_MAX_RETRY_INTERVAL` to 5 seconds

### DIFF
--- a/changelog.d/19755.misc
+++ b/changelog.d/19755.misc
@@ -1,0 +1,1 @@
+Reduce `WORKER_LOCK_MAX_RETRY_INTERVAL` to 5 seconds to reduce idle time after lock is released.

--- a/synapse/handlers/worker_lock.py
+++ b/synapse/handlers/worker_lock.py
@@ -62,7 +62,7 @@ Better to retry more quickly than have workers wait around. 5 seconds is still a
 reasonable gap in time to not overwhelm the CPU/Database.
 
 This matters most in cross-worker scenarios. When locks are on the same worker, when the
-locker holder releases, we signal to other locks (with the same name/key) that they
+lock holder releases, we signal to other locks (with the same name/key) that they
 should try reacquiring the lock immediately. But locks on other workers only re-check
 based on their retry `_timeout_interval`.
 """

--- a/synapse/handlers/worker_lock.py
+++ b/synapse/handlers/worker_lock.py
@@ -59,7 +59,7 @@ WORKER_LOCK_MAX_RETRY_INTERVAL = Duration(seconds=5)
 The maximum wait time before retrying to acquire the lock.
 
 Better to retry more quickly than have workers wait around. 5 seconds is still a
-reasonable gap in time to no overwhelm the CPU/Database.
+reasonable gap in time to not overwhelm the CPU/Database.
 
 This matters most in cross-worker scenarios. When locks are on the same worker, when the
 locker holder releases, we signal to other locks (with the same name/key) that they

--- a/synapse/handlers/worker_lock.py
+++ b/synapse/handlers/worker_lock.py
@@ -54,7 +54,18 @@ logger = logging.getLogger(__name__)
 # will not disappear under our feet as long as we don't delete the room.
 NEW_EVENT_DURING_PURGE_LOCK_NAME = "new_event_during_purge_lock"
 
-WORKER_LOCK_MAX_RETRY_INTERVAL = Duration(seconds=60)
+WORKER_LOCK_MAX_RETRY_INTERVAL = Duration(seconds=5)
+"""
+The maximum wait time before retrying to acquire the lock.
+
+Better to retry more quickly than have workers wait around. 5 seconds is still a
+reasonable gap in time to no overwhelm the CPU/Database.
+
+This matters most in cross-worker scenarios. When locks are on the same worker, when the
+locker holder releases, we signal to other locks (with the same name/key) that they
+should try reacquiring the lock immediately. But locks on other workers only re-check
+based on their retry `_timeout_interval`.
+"""
 WORKER_LOCK_EXCESSIVE_WAITING_WARN_DURATION = Duration(minutes=10)
 
 


### PR DESCRIPTION
Reduce `WORKER_LOCK_MAX_RETRY_INTERVAL` to 5 seconds.

Better to retry more quickly than have workers wait around. 5 seconds is still a reasonable gap in time to not overwhelm anything.

This matters most in cross-worker scenarios. When locks are on the same worker, when the lock holder releases, we signal to other locks (with the same name/key) that they should try reacquiring the lock immediately. But locks on other workers only re-check based on their retry `_timeout_interval`.

Updating to 5 seconds to match the previous intentions based on the [flawed code](https://github.com/element-hq/synapse/blob/6100f6e4f7fb0c72f1ae2802683ebc811c0e3a77/synapse/handlers/worker_lock.py#L278). We can assume they were trying to have 5 seconds as the max value to retry.

Spawning from https://github.com/element-hq/synapse/pull/19394#discussion_r3168458070


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
