### PR TITLE
Force keyword-only args for `Duration` (prevent footgun)

### DIFF
--- a/changelog.d/19756.misc
+++ b/changelog.d/19756.misc
@@ -1,0 +1,1 @@
+Force keyword-only args for `Duration` (prevent footgun) so people have to specify which time unit they want to us.

--- a/synapse/util/duration.py
+++ b/synapse/util/duration.py
@@ -32,9 +32,13 @@ class Duration(timedelta):
     ```
     """
 
-    # Using `__new__` because that's what `timedelta` uses
+    # Using `__new__` (instead of `__init__`) because that's what `timedelta` uses
     def __new__(
         cls,
+        # The whole goal of overriding `__new__` is to require keyword-only arguments.
+        # Without this, `Duration(5)` would create a duration represnting 5 *days*
+        # (timedelta's default), but callers almost certainly want to specify which unit
+        # like seconds or hours.
         *,
         days: float = 0,
         seconds: float = 0,

--- a/synapse/util/duration.py
+++ b/synapse/util/duration.py
@@ -32,6 +32,29 @@ class Duration(timedelta):
     ```
     """
 
+    # Using `__new__` because that's what `timedelta` uses
+    def __new__(
+        cls,
+        *,
+        days: float = 0,
+        seconds: float = 0,
+        microseconds: float = 0,
+        milliseconds: float = 0,
+        minutes: float = 0,
+        hours: float = 0,
+        weeks: float = 0,
+    ) -> "Duration":
+        return super().__new__(
+            cls,
+            days=days,
+            seconds=seconds,
+            microseconds=microseconds,
+            milliseconds=milliseconds,
+            minutes=minutes,
+            hours=hours,
+            weeks=weeks,
+        )
+
     def as_millis(self) -> int:
         """Returns the duration in milliseconds."""
         return int(self / _ONE_MILLISECOND)


### PR DESCRIPTION
Force keyword-only args for `Duration` (prevent footgun) so people have to specify which time unit they want to use.

Spawning from https://github.com/element-hq/synapse/pull/19394#discussion_r3188418426

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
