### PR TITLE
Commit stray Rust change that keeps popping up (`rust/src/canonical_json.rs`)

### DIFF
--- a/changelog.d/19763.misc
+++ b/changelog.d/19763.misc
@@ -1,0 +1,1 @@
+Lint and format `rust/src/canonical_json.rs`.

--- a/rust/src/canonical_json.rs
+++ b/rust/src/canonical_json.rs
@@ -824,7 +824,7 @@ mod tests {
 
         // Serialize the keys in the reverse order.
         for (c, _) in ascii_order.iter().rev() {
-            map_serializer.serialize_entry(c.into(), &1).unwrap();
+            map_serializer.serialize_entry(c, &1).unwrap();
         }
         SerializeMap::end(map_serializer).unwrap();
 


### PR DESCRIPTION
Commit stray Rust change that keeps popping up in `rust/src/canonical_json.rs` (introduced in https://github.com/element-hq/synapse/pull/19739)

Seems like some automatic change from `poetry run ./scripts-dev/lint.sh`

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
