### PR TITLE
Improve `We can't get valid state history.` logging

### DIFF
--- a/changelog.d/19765.misc
+++ b/changelog.d/19765.misc
@@ -1,0 +1,1 @@
+Improve Synapse logging around when someone encounters `We can't get valid state history.` so you can correlate everything by `event_id`.

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1166,7 +1166,7 @@ class FederationEventHandler:
             return await self._state_handler.compute_event_context(event)
 
         logger.info(
-            "_compute_event_context_with_maybe_missing_prevs: Event %s in room %s is missing prev_events %s: "
+            "_compute_event_context_with_maybe_missing_prevs(event_id=%s): Event in room %s is missing prev_events %s: "
             "calculating state for a backwards extremity",
             event_id,
             room_id,
@@ -1187,16 +1187,21 @@ class FederationEventHandler:
 
             # Ask the remote server for the states we don't
             # know about
-            for p in missing_prevs:
-                logger.info("Requesting state after missing prev_event %s", p)
+            for missing_prev in missing_prevs:
+                logger.info(
+                    "_compute_event_context_with_maybe_missing_prevs(event_id=%s): Requesting state from %s for missing prev_event %s",
+                    event_id,
+                    dest,
+                    missing_prev,
+                )
 
-                with nested_logging_context(p):
+                with nested_logging_context(missing_prev):
                     # note that if any of the missing prevs share missing state or
                     # auth events, the requests to fetch those events are deduped
                     # by the get_pdu_cache in federation_client.
                     remote_state_map = (
                         await self._get_state_ids_after_missing_prev_event(
-                            dest, room_id, p
+                            dest, room_id, missing_prev
                         )
                     )
 
@@ -1226,10 +1231,10 @@ class FederationEventHandler:
 
         except Exception as e:
             logger.warning(
-                "_compute_event_context_with_maybe_missing_prevs: Error attempting to resolve state for "
-                "event_id=%s in room_id=%s that has missing prev_events: %s",
+                "_compute_event_context_with_maybe_missing_prevs(event_id=%s): Error attempting to resolve state from "
+                "%s for missing prev_events: %s",
                 event_id,
-                room_id,
+                dest,
                 e,
             )
             raise FederationError(

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1166,9 +1166,10 @@ class FederationEventHandler:
             return await self._state_handler.compute_event_context(event)
 
         logger.info(
-            "Event %s is missing prev_events %s: calculating state for a "
-            "backwards extremity",
+            "_compute_event_context_with_maybe_missing_prevs: Event %s in room %s is missing prev_events %s: "
+            "calculating state for a backwards extremity",
             event_id,
+            room_id,
             shortstr(missing_prevs),
         )
         # Calculate the state after each of the previous events, and
@@ -1225,7 +1226,11 @@ class FederationEventHandler:
 
         except Exception as e:
             logger.warning(
-                "Error attempting to resolve state at missing prev_events: %s", e
+                "_compute_event_context_with_maybe_missing_prevs: Error attempting to resolve state for "
+                "event_id=%s in room_id=%s that has missing prev_events: %s",
+                event_id,
+                room_id,
+                e,
             )
             raise FederationError(
                 "ERROR",


### PR DESCRIPTION
Improve `We can't get valid state history.` logging. Add `event_id` so you can actually correlate everything together in the logs.

Spawning from @jakobrss [asking](https://matrix.to/#/!SGNQGPGUwtcPBUotTL:matrix.org/$T60jxAbhmdB2OcNp0lvIRyN-oAWdTbfdoXJgxz1Kd4A?via=jki.re&via=element.io&via=matrix.org) about what to look for when someone encounters this error


### Dev notes

These logs originate from https://github.com/matrix-org/synapse/pull/3904 where they used to have the `room_id` and `event_id` included directly but then was updated in https://github.com/matrix-org/synapse/pull/9596 to rely on the log context holding this info.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
