### PR TITLE
Fix `/sync` failing when MSC4354 Sticky Events are enabled and the sync request filters out Ephemeral Data Units (EDUs).

### DIFF
--- a/changelog.d/19787.bugfix
+++ b/changelog.d/19787.bugfix
@@ -1,0 +1,1 @@
+Fix `/sync` failing when [MSC4354 Sticky Events](https://github.com/matrix-org/matrix-spec-proposals/pull/4354) are enabled and the sync request filters out Ephemeral Data Units (EDUs).

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -2236,19 +2236,23 @@ class SyncHandler:
         if block_all_room_ephemeral:
             ephemeral_by_room: dict[str, list[JsonDict]] = {}
         else:
-            now_token, ephemeral_by_room = await self.ephemeral_by_room(
+            (
+                sync_result_builder.now_token,
+                ephemeral_by_room,
+            ) = await self.ephemeral_by_room(
                 sync_result_builder,
                 now_token=sync_result_builder.now_token,
                 since_token=sync_result_builder.since_token,
             )
-            sync_result_builder.now_token = now_token
 
         sticky_by_room: dict[str, list[str]] = {}
         if self.hs_config.experimental.msc4354_enabled:
-            now_token, sticky_by_room = await self.sticky_events_by_room(
-                sync_result_builder, now_token, since_token
+            (
+                sync_result_builder.now_token,
+                sticky_by_room,
+            ) = await self.sticky_events_by_room(
+                sync_result_builder, sync_result_builder.now_token, since_token
             )
-            sync_result_builder.now_token = now_token
 
         # 2. We check up front if anything has changed, if it hasn't then there is
         # no point in going further.


### PR DESCRIPTION
Fixes: #19779
Fixes: https://github.com/element-hq/synapse/issues/19618

See also: #19786 (which would have caught this, but currently has too many findings to enable)

<ol>
<li>

Fix UnboundLocalError when MSC4354 is enabled in sync and all EDUs are filtered out 

</li>
</ol>
