### PR TITLE
Follow #19468 (Fix sending heroes in Sliding Sync) with small tweaks

### DIFF
--- a/changelog.d/19791.bugfix
+++ b/changelog.d/19791.bugfix
@@ -1,0 +1,1 @@
+Fix a bug in [MSC4186: Simplified Sliding Sync](https://github.com/matrix-org/matrix-spec-proposals/pull/4186) that could prevent user avatars from showing if the room had an empty name.

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -966,7 +966,7 @@ class SlidingSyncHandler:
         # care to treat an empty string as unset). But we only need to get them
         # on initial syncs (or the first time we send down the room) or if the
         # membership has changed which may change the heroes.
-        if not room_name and (initial or (not initial and membership_changed)):
+        if not room_name and (initial or membership_changed):
             # We need the room summary to extract the heroes from
             if room_membership_for_user_at_to_token.membership != Membership.JOIN:
                 # TODO: Figure out how to get the membership summary for left/banned rooms

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -1185,8 +1185,6 @@ class SlidingSyncHandler:
             (EventTypes.Member, hero_user_id) for hero_user_id in hero_user_ids
         ]
         meta_room_state = list(hero_room_state)
-        if initial or name_changed:
-            meta_room_state.append((EventTypes.Name, ""))
         if initial or avatar_changed:
             meta_room_state.append((EventTypes.RoomAvatar, ""))
 


### PR DESCRIPTION
Follows: #19468


The main change is from this comment https://github.com/element-hq/synapse/pull/19468#discussion_r2810364196
I am pretty sure it's safe and was tempted to add it to that PR, but for easier bisection and reversion in case it goes wrong, thought a separate commit would be the best.

The other drive-by change is a boolean logic simplification


<ol>
<li>

Simplify condition (boolean equivalence) 

</li>
<li>

Don't fetch name state from `meta_room_state` since it's no longer used there 

</li>
</ol>
