### PR TITLE
Add more validation and logging to policy server signature responses.

### DIFF
--- a/changelog.d/19807.misc
+++ b/changelog.d/19807.misc
@@ -1,0 +1,1 @@
+Add more validation and logging to policy server signature responses.

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -806,7 +806,18 @@ class FederationPullAttemptBackoffError(RuntimeError):
 
 class HttpResponseException(CodeMessageException):
     """
-    Represents an HTTP-level failure of an outbound request
+    Represents an HTTP-level failure of an outbound request,
+    where the response has an unexpected status code.
+
+    The response may contain a JSON-encoded Matrix API error
+    with an `errcode` and `error`, but this is optional.
+
+    Analogous to `InvalidResponseError`, but at the response code level
+    rather than the response body level.
+
+    Should not be allowed to bubble to an API response without handling.
+    If it does, it will yield a 500 Internal Server Error as any other
+    unhandled exception.
 
     Attributes:
         response: body of response
@@ -824,7 +835,7 @@ class HttpResponseException(CodeMessageException):
         self.response = response
 
     def to_synapse_error(self) -> SynapseError:
-        """Make a SynapseError based on an HTTPResponseException
+        """Make a SynapseError based on an HttpResponseException
 
         This is useful when a proxied request has failed, and we need to
         decide how to map the failure onto a matrix error to send back to the
@@ -854,6 +865,50 @@ class HttpResponseException(CodeMessageException):
         errmsg = j.pop("error", self.msg)
 
         return ProxiedRequestError(self.code, errmsg, errcode, j)
+
+
+class InvalidResponseError(RuntimeError):
+    """
+    Represents a failure to parse/validate the body returned
+    by an outbound request.
+    Analogous to `HttpResponseException`, but at the response body level
+    rather than the response code level.
+
+    Like `HttpResponseException`, should not be allowed to bubble to
+    an API response without handling.
+    If it does, it will yield a 500 Internal Server Error as any other
+    unhandled exception.
+
+    Attributes:
+        response: body of response
+    """
+
+    def __init__(self, msg: str):
+        """
+        Args:
+            msg: A message for logging purposes.
+        """
+        super().__init__(msg)
+
+    def to_synapse_error(self) -> SynapseError:
+        """Make a SynapseError based on this error.
+
+        The errcode is set to M_UNKNOWN
+        and the error message is set to a generic message.
+        The detail message of this error is not exposed.
+
+        (Maybe we could consider exposing the violating server's name in
+        the error message.)
+
+        Returns:
+            The error converted to a SynapseError.
+        """
+
+        return ProxiedRequestError(
+            HTTPStatus.BAD_GATEWAY,
+            "Remote server presented an invalid response over federation.",
+            Codes.UNKNOWN,
+        )
 
 
 class HomeServerNotSetupException(Exception):

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -473,7 +473,7 @@ class FederationClient(FederationBase):
     @tag_args
     async def ask_policy_server_to_sign_event(
         self, destination: str, pdu: EventBase, timeout: int | None = None
-    ) -> JsonDict:
+    ) -> PolicySignResponse:
         """Requests that the destination server (typically a policy server)
         sign the event as not spam.
 
@@ -494,9 +494,10 @@ class FederationClient(FederationBase):
             pdu.event_id,
             destination,
         )
-        return await self.transport_layer.ask_policy_server_to_sign_event(
+        json_response = await self.transport_layer.ask_policy_server_to_sign_event(
             destination, pdu, timeout=timeout
         )
+        return validate_response(json_response, PolicySignResponse)
 
     @trace
     @tag_args

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -48,6 +48,7 @@ from synapse.api.errors import (
     Codes,
     FederationDeniedError,
     HttpResponseException,
+    InvalidResponseError,
     RequestSendFailed,
     SynapseError,
     UnsupportedRoomVersionError,
@@ -102,12 +103,6 @@ class PulledPduInfo:
     pdu: EventBase
     # Which homeserver we pulled the PDU from
     pull_origin: str
-
-
-class InvalidResponseError(RuntimeError):
-    """Helper for _try_destination_list: indicates that the server returned a response
-    we couldn't parse
-    """
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -19,8 +19,6 @@
 # [This file includes modifications made by New Vector Limited]
 #
 #
-
-
 import copy
 import itertools
 import logging
@@ -37,10 +35,12 @@ from typing import (
     Optional,
     Sequence,
     TypeVar,
+    overload,
 )
 
 import attr
 from prometheus_client import Counter
+from pydantic import ValidationError
 
 from synapse.api.constants import Direction, EventContentFields, EventTypes, Membership
 from synapse.api.errors import (
@@ -73,9 +73,11 @@ from synapse.http.types import QueryParams
 from synapse.logging.opentracing import SynapseTags, log_kv, set_tag, tag_args, trace
 from synapse.metrics import SERVER_NAME_LABEL
 from synapse.types import JsonDict, StrCollection, UserID, get_domain_from_id
+from synapse.types.federation.policy import PolicySignResponse
 from synapse.util.async_helpers import concurrently_execute
 from synapse.util.caches.expiringcache import ExpiringCache
 from synapse.util.duration import Duration
+from synapse.util.pydantic_models import ParseModel, StrictRootModel
 from synapse.util.retryutils import NotRetryingDestination
 
 if TYPE_CHECKING:
@@ -120,6 +122,41 @@ class SendJoinResult:
     # If 'partial_state' is set, a set of the servers in the room (otherwise empty).
     # Always contains the server we joined off.
     servers_in_room: AbstractSet[str]
+
+
+MODEL_ROOT = TypeVar("MODEL_ROOT", bound=StrictRootModel)
+MODEL_PARSE = TypeVar("MODEL_PARSE", bound=ParseModel)
+
+
+@overload
+def validate_response(
+    content: JsonDict, model_type: type[MODEL_ROOT]
+) -> MODEL_ROOT: ...
+
+
+@overload
+def validate_response(
+    content: JsonDict, model_type: type[MODEL_PARSE]
+) -> MODEL_PARSE: ...
+
+
+# note: this signature is supposed to be ignored by the overload,
+# but yet required, with `no-untyped-def` error given if omitted
+def validate_response(
+    content: JsonDict, model_type: type[MODEL_ROOT] | type[MODEL_PARSE]
+) -> MODEL_ROOT | MODEL_PARSE:
+    """Validate a deserialized JSON object using the given pydantic model.
+
+    Raises:
+        SynapseError if the request body couldn't be decoded as JSON or
+            if it wasn't a JSON object.
+    """
+    try:
+        instance = model_type.model_validate(content)
+    except ValidationError as e:
+        raise InvalidResponseError(str(e))
+
+    return instance
 
 
 class FederationClient(FederationBase):

--- a/synapse/handlers/room_policy.py
+++ b/synapse/handlers/room_policy.py
@@ -269,6 +269,13 @@ class RoomPolicyHandler:
                     event.signatures.add_signature(
                         policy_server.server_name, key_id, signature_b64
                     )
+                else:
+                    logger.warning(
+                        "Policy server %r attempted to overwrite existing signature by key_id = %r on event %s, ignoring",
+                        policy_server.server_name,
+                        key_id,
+                        event.event_id,
+                    )
         except HttpResponseException as ex:
             # re-wrap HTTP errors as `SynapseError` so they can be proxied to clients directly
             raise ex.to_synapse_error() from ex

--- a/synapse/handlers/room_policy.py
+++ b/synapse/handlers/room_policy.py
@@ -225,7 +225,7 @@ class RoomPolicyHandler:
 
         # Ask the policy server to sign this event.
         try:
-            signature = await self._federation_client.ask_policy_server_to_sign_event(
+            sign_response = await self._federation_client.ask_policy_server_to_sign_event(
                 policy_server.server_name,
                 event,
                 # We set a smallish timeout here as we don't want to block event sending
@@ -241,7 +241,7 @@ class RoomPolicyHandler:
             # also be implementation bugs. Whoever reads this when removing unstable MSC4284
             # stuff, make a decision on whether to remove this bit.
             # https://github.com/element-hq/synapse/issues/19502
-            if not signature or len(signature) == 0:
+            if len(sign_response.root) == 0:
                 raise SynapseError(
                     403,
                     "This event has been rejected as probable spam by the policy server",
@@ -261,7 +261,14 @@ class RoomPolicyHandler:
             # servers need to manually fetch signatures for. This is the code that allows
             # those events to continue working (because they're legally sent, even if missing
             # the policy server signature).
-            event.signatures.update(signature)
+            for key_id, signature_b64 in sign_response.root.items():
+                if (
+                    event.signatures.get_signature(policy_server.server_name, key_id)
+                    is None
+                ):
+                    event.signatures.add_signature(
+                        policy_server.server_name, key_id, signature_b64
+                    )
         except HttpResponseException as ex:
             # re-wrap HTTP errors as `SynapseError` so they can be proxied to clients directly
             raise ex.to_synapse_error() from ex

--- a/synapse/handlers/room_policy.py
+++ b/synapse/handlers/room_policy.py
@@ -22,7 +22,12 @@ from signedjson.key import decode_verify_key_bytes
 from unpaddedbase64 import decode_base64
 
 from synapse.api.constants import EventTypes
-from synapse.api.errors import Codes, HttpResponseException, SynapseError
+from synapse.api.errors import (
+    Codes,
+    HttpResponseException,
+    InvalidResponseError,
+    SynapseError,
+)
 from synapse.crypto.keyring import VerifyJsonRequest
 from synapse.events import EventBase
 from synapse.util.stringutils import parse_and_validate_server_name
@@ -276,7 +281,7 @@ class RoomPolicyHandler:
                         key_id,
                         event.event_id,
                     )
-        except HttpResponseException as ex:
+        except (HttpResponseException, InvalidResponseError) as ex:
             # re-wrap HTTP errors as `SynapseError` so they can be proxied to clients directly
             raise ex.to_synapse_error() from ex
 

--- a/synapse/types/federation/policy.py
+++ b/synapse/types/federation/policy.py
@@ -1,0 +1,51 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 Element Creations Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl_3.0.html>.
+#
+from pydantic import model_validator
+from typing_extensions import Self
+
+from synapse.util.pydantic_models import StrictRootModel
+
+
+class PolicySignResponse(StrictRootModel[dict[str, str]]):
+    """
+    Response to `POST /_matrix/policy/v1/sign`
+    Spec: https://spec.matrix.org/v1.18/server-server-api/#post_matrixpolicyv1sign
+
+    Example:
+        {
+          "policy.example.org": {
+            "ed25519:policy_server": "zLFxllD0pbBuBpfHh8NuHNaICpReF/PAOpUQTsw+bFGKiGfDNAsnhcP7pbrmhhpfbOAxIdLraQLeeiXBryLmBw"
+          }
+        }
+    """
+
+    @model_validator(mode="after")
+    def check_rules(self) -> Self:
+        """
+        > The Policy Server has signed the event, indicating that it recommends the event for inclusion in the room.
+        > Only the Policy Server’s signature is returned.
+        > This signature is to be added to the event before sending or processing the event further.
+        >
+        > `ed25519:policy_server` is always used for Ed25519 signatures.
+        > — https://spec.matrix.org/v1.18/server-server-api/#validating-policy-server-signatures
+        """
+
+        for key_id in self.root.keys():
+            if key_id.startswith("ed25519:") and key_id != "ed25519:policy_server":
+                # > `ed25519:policy_server` is always used for Ed25519 signatures.
+                raise ValueError(
+                    "policy servers must only use ed25519:policy_server for Ed25519 signatures"
+                )
+
+        return self

--- a/synapse/util/pydantic_models.py
+++ b/synapse/util/pydantic_models.py
@@ -13,9 +13,16 @@
 #
 #
 
-from typing import Annotated
+from typing import Annotated, TypeVar
 
-from pydantic import AfterValidator, BaseModel, ConfigDict, StrictStr, StringConstraints
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    RootModel,
+    StrictStr,
+    StringConstraints,
+)
 
 from synapse.api.errors import SynapseError
 from synapse.types import EventID
@@ -42,10 +49,23 @@ class ParseModel(BaseModel):
     server operators.
 
     Subclassing in this way is recommended by
-    https://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally
+    https://pydantic.dev/docs/validation/latest/concepts/config/#change-behaviour-globally
+    [accessed at 2026-05-26]
     """
 
     model_config = ConfigDict(extra="ignore", frozen=True, strict=True)
+
+
+T = TypeVar("T")
+
+
+class StrictRootModel(RootModel[T]):
+    """
+    A custom version of Pydantic's RootModel, in the same vein as `ParseModel`.
+    Refer to `ParseModel` above for the configuration details.
+    """
+
+    model_config = ConfigDict(frozen=True, strict=True)
 
 
 def validate_event_id_v1_and_2(value: str) -> str:


### PR DESCRIPTION
Was working on this to fix #19796 but didn't notice that #19797 was already opened to fix it.

Have now merged in develop to build on top.

Notable changes:

- Now avoid overwriting any signature at all, even if it's from the same server name as the policy server.
  (It didn't sit right with me to overwrite an existing signature)
  - We now log in this case
- Validate that the policy server responds with the spec-mandated key ID. The spec only applies this to ed25519 keys, awkwardly, so the validation is equally awkward, but non-zero.
- Validation on the response body format of the policy server response in general.
- Introduces a Pydantic-based approach for validating federation responses.
  - Now raises a 502 like you'd expect, rather than 500 with an unhandled exception.
  - I'd like to see this machinery used more widely in the federation client.


Review guidance: Commit-by-commit review is generally fine, just beware that 'Validate policy server response.....' is partially conflicting with concurrent work on develop and the merge conflict resolves the difference. It may be easier to review that alongside the merge commit at the same time?

Original commit schedule, with full messages:

<ol>
<li>

Promote InvalidResponseError to a 'real' error type 

</li>
<li>

pydantic_models: Fix broken link, add RootModel equivalent 

</li>
<li>

federation_client: Add Pydantic validation machinery 

</li>
<li>

Validate policy server response and prevent overwriting signatures 

</li>
<li>

Merge branch 'develop' into rei/fix_ps_signature_overwrite 

</li>
<li>

Add a log for the case when the policy server tries to overwrite 

</li>
</ol>
