### PR TITLE
Forbid changing display name in local rooms if `enable_set_displayname` is disabled.

### DIFF
--- a/changelog.d/19811.bugfix
+++ b/changelog.d/19811.bugfix
@@ -1,0 +1,1 @@
+Forbid changing display name in membership events in local rooms if `enable_set_displayname` is disabled.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -839,11 +839,20 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         ):
             is_admin = await self.auth.is_server_admin(requester)
             if not is_admin:
-                profile = await self.store.get_profileinfo(target)
-                if (
-                    profile.display_name is not None
-                    and content["displayname"] != profile.display_name
-                ):
+                member_event = (
+                    await self._storage_controllers.state.get_current_state_event(
+                        room_id=room_id,
+                        event_type=EventTypes.Member,
+                        state_key=target.to_string(),
+                    )
+                )
+
+                displayname = None
+                if member_event is not None:
+                    if member_event.membership == Membership.JOIN:
+                        displayname = member_event.content.get("displayname")
+
+                if displayname is not None and content["displayname"] != displayname:
                     raise SynapseError(
                         400,
                         "Changing display name is disabled on this server",

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -831,6 +831,26 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             ):
                 raise SynapseError(403, "This avatar is not allowed", Codes.FORBIDDEN)
 
+        # Check if the displayname in the membership event differs from what's
+        # stored in the user's profile when changing displayname is disabled.
+        if (
+            self.hs.is_mine(target)
+            and "displayname" in content
+            and not self.hs.config.registration.enable_set_displayname
+        ):
+            is_admin = await self.auth.is_server_admin(requester)
+            if not is_admin:
+                profile = await self.store.get_profileinfo(target)
+                if (
+                    profile.display_name is not None
+                    and content["displayname"] != profile.display_name
+                ):
+                    raise SynapseError(
+                        400,
+                        "Changing display name is disabled on this server",
+                        Codes.FORBIDDEN,
+                    )
+
         # The event content should *not* include the authorising user as
         # it won't be properly signed. Strip it out since it might come
         # back from a client updating a display name / avatar.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -831,8 +831,8 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             ):
                 raise SynapseError(403, "This avatar is not allowed", Codes.FORBIDDEN)
 
-        # Check if the displayname in the membership event differs from what's
-        # stored in the user's profile when changing displayname is disabled.
+        # Prevent local users from changing their per-room displayname if
+        # `enable_set_displayname` is disabled.
         if (
             self.hs.is_mine(target)
             and "displayname" in content

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -834,7 +834,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         # Prevent local users from changing their per-room displayname if
         # `enable_set_displayname` is disabled.
         if (
-            self.hs.is_mine(target)
             and "displayname" in content
             and not self.hs.config.registration.enable_set_displayname
         ):


### PR DESCRIPTION
Forbid changing display name in local rooms if `enable_set_displayname` is disabled

Fixes #17048

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
