### PR TITLE
feat: add event_types_to_copy_on_room_upgrade in hs config

### DIFF
--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -4862,6 +4862,21 @@ properties:
     default: "off"
     examples:
       - invite
+  event_types_to_copy_on_room_upgrade:
+    type: array
+    description: >-
+      A list of additional state event types to copy when a room is upgraded.
+      Each entry should be a list containing an event type and a state key.
+      Defaults to `[]`.
+    items:
+      type: array
+      description: "Array of state event type and optionnaly a state key"
+      items:
+        - type: string
+    default: []
+    examples:
+      - ["im.vector.room.access_rules", ""]
+      - ["custom.room.policy", ""]
   user_directory:
     type: object
     description: This setting defines options related to the user directory.

--- a/synapse/config/room.py
+++ b/synapse/config/room.py
@@ -86,3 +86,23 @@ class RoomConfig(Config):
         # When enabled, users will forget rooms when they leave them, either via a
         # leave, kick or ban.
         self.forget_on_leave: bool = config.get("forget_rooms_on_leave", False)
+        
+        # Event types to copy when upgrading a room
+        self.event_types_to_copy_on_room_upgrade: list[tuple[str, str | None]] = []
+        event_types_to_copy_on_room_upgrade = config.get("event_types_to_copy_on_room_upgrade", [])
+        if event_types_to_copy_on_room_upgrade:
+            for event_type in event_types_to_copy_on_room_upgrade:
+                if not isinstance(event_type, (list, tuple)) or len(event_type) != 2:
+                    raise ConfigError(
+                        "copy_event_types_on_room_upgrade entries must be [event_type, state_key] tuples"
+                    )
+                event_type, state_key = event_type
+                if not isinstance(event_type, str):
+                    raise ConfigError(
+                        f"Event type must be a string, got {event_type(event_type).__name__}"
+                    )
+                if state_key is not None and not isinstance(state_key, str):
+                    raise ConfigError(
+                        f"State key must be a string or null, got {event_type(state_key).__name__}"
+                    )
+                self.event_types_to_copy_on_room_upgrade.append((event_type, state_key))

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -615,6 +615,8 @@ class RoomCreationHandler:
             (EventTypes.ServerACL, ""),
             (EventTypes.PowerLevels, ""),
         ]
+        # Add custom event types configured in the homeserver
+        types_to_copy.extend(self.config.room.event_types_to_copy_on_room_upgrade)
 
         room_type = old_room_create_event.content.get(EventContentFields.ROOM_TYPE)
         if room_type is not None:


### PR DESCRIPTION
Add `event_types_to_copy_on_room_upgrade` in config to allow transfering custom state events when upgrading a room

As stated here : https://spec.matrix.org/latest/client-server-api/#server-behaviour-21 "The exact details for what is transferred is left as an implementation detail"


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
