### PR TITLE
Fix loading 'invalid' event from the database

### DIFF
--- a/changelog.d/19816.misc
+++ b/changelog.d/19816.misc
@@ -1,0 +1,1 @@
+Port the python Event classes to Rust.

--- a/rust/src/events/utils.rs
+++ b/rust/src/events/utils.rs
@@ -75,15 +75,14 @@ pub fn compute_event_reference_hash(
     redacted_value_mut.remove(UNSIGNED);
     redacted_value_mut.remove(AGE_TS);
 
-    let canonicalization_options = if room_version.strict_canonicaljson {
-        CanonicalizationOptions::strict()
-    } else {
-        CanonicalizationOptions::relaxed()
-    };
-
-    let json =
-        crate::canonical_json::to_string_canonical(&redacted_value_mut, canonicalization_options)
-            .map_err(|err| anyhow::anyhow!(err))?;
+    // We use `CanonicalizationOptions::relaxed()` as we have some events that
+    // have already been accepted with int fields outside the valid range. We
+    // still want to be able to load them and calculate their event ID.
+    let json = crate::canonical_json::to_string_canonical(
+        &redacted_value_mut,
+        CanonicalizationOptions::relaxed(),
+    )
+    .map_err(|err| anyhow::anyhow!(err))?;
 
     let hash = Sha256::digest(json.as_bytes());
 

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -1523,8 +1523,8 @@ class EventsWorkerStore(SQLBaseStore):
                     internal_metadata_dict=internal_metadata,
                     rejected_reason=rejected_reason,
                 )
-            except SynapseError:
-                logger.error("Unable to parse event from database: %s", event_id)
+            except SynapseError as e:
+                logger.error("Unable to parse event from database %s: %s", event_id, e)
                 continue
 
             original_ev.internal_metadata.stream_ordering = row.stream_ordering


### PR DESCRIPTION
Follow on from #19701.

Some Synapse servers may have events in their database that don't pass the canonical JSON checks. This is bad, but we still want to be able to load them nonetheless.