### PR TITLE
Fix `Event.__repr__`

### DIFF
--- a/changelog.d/19817.misc
+++ b/changelog.d/19817.misc
@@ -1,0 +1,1 @@
+Port the python Event classes to Rust.

--- a/rust/src/events/internal_metadata.rs
+++ b/rust/src/events/internal_metadata.rs
@@ -563,7 +563,7 @@ impl EventInternalMetadata {
         Ok(dict.into())
     }
 
-    fn is_outlier(&self) -> PyResult<bool> {
+    pub fn is_outlier(&self) -> PyResult<bool> {
         Ok(self.read_inner()?.is_outlier())
     }
 

--- a/rust/src/events/mod.rs
+++ b/rust/src/events/mod.rs
@@ -404,6 +404,53 @@ impl Event {
         Some(duration)
     }
 
+    fn __str__(&self) -> PyResult<String> {
+        self.__repr__()
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        // We want to include some representative fields in the repr for
+        // debugging purposes.
+        //
+        // The end result will look something like:
+        // `<Event event_id=$def:example.com, type=m.room.message>`
+        let mut fields: Vec<(&str, &str)> = Vec::with_capacity(6);
+
+        fields.push(("event_id", &self.event_id));
+        fields.push(("type", self.r#type()));
+
+        if let Some(state_key) = self.get_state_key() {
+            fields.push(("state_key", state_key));
+        };
+
+        // Include the membership field for membership events.
+        if self.r#type() == MEMBERSHIP && self.is_state() {
+            let content = &self.parsed_event.common_fields.content;
+            let membership_field = content.get_field(MEMBERSHIP).and_then(|m| m.as_str());
+
+            if let Some(membership_str) = membership_field {
+                fields.push(("membership", membership_str));
+            }
+        }
+
+        let is_outlier = self.internal_metadata.is_outlier()?.to_string();
+        if is_outlier == "true" {
+            fields.push(("outlier", &is_outlier));
+        }
+
+        if let Some(reason) = self.rejected_reason.as_deref() {
+            fields.push(("REJECTED", reason));
+        };
+
+        let fields_str = fields
+            .into_iter()
+            .map(|(name, value)| format!("{}={}", name, value))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        Ok(format!("<Event {}>", fields_str))
+    }
+
     // Below are the methods for interacting with the event as a mapping.
     //
     // These are rarely used, so we take the easy approach of re-serializing the

--- a/rust/src/events/mod.rs
+++ b/rust/src/events/mod.rs
@@ -60,6 +60,7 @@ use pyo3::{
 use pythonize::{depythonize, pythonize};
 
 use crate::events::{
+    constants::event_type::M_ROOM_MEMBER,
     formats::{
         EventFormatEnum, EventFormatV1, EventFormatV2V3, EventFormatV4, EventFormatVMSC4242,
         FormattedEvent,
@@ -424,7 +425,7 @@ impl Event {
         };
 
         // Include the membership field for membership events.
-        if self.r#type() == MEMBERSHIP && self.is_state() {
+        if self.r#type() == M_ROOM_MEMBER && self.is_state() {
             let content = &self.parsed_event.common_fields.content;
             let membership_field = content.get_field(MEMBERSHIP).and_then(|m| m.as_str());
 

--- a/rust/src/events/mod.rs
+++ b/rust/src/events/mod.rs
@@ -409,12 +409,12 @@ impl Event {
         self.__repr__()
     }
 
+    /// We want to include some representative fields in the repr for
+    /// debugging purposes.
+    ///
+    /// The end result will look something like:
+    /// `<Event event_id=$def:example.com, type=m.room.message>`
     fn __repr__(&self) -> PyResult<String> {
-        // We want to include some representative fields in the repr for
-        // debugging purposes.
-        //
-        // The end result will look something like:
-        // `<Event event_id=$def:example.com, type=m.room.message>`
         let mut fields: Vec<(&str, &str)> = Vec::with_capacity(6);
 
         if let Some(reason) = self.rejected_reason.as_deref() {

--- a/rust/src/events/mod.rs
+++ b/rust/src/events/mod.rs
@@ -417,6 +417,10 @@ impl Event {
         // `<Event event_id=$def:example.com, type=m.room.message>`
         let mut fields: Vec<(&str, &str)> = Vec::with_capacity(6);
 
+        if let Some(reason) = self.rejected_reason.as_deref() {
+            fields.push(("REJECTED", reason));
+        };
+
         fields.push(("event_id", &self.event_id));
         fields.push(("type", self.r#type()));
 
@@ -438,10 +442,6 @@ impl Event {
         if is_outlier {
             fields.push(("outlier", "true"));
         }
-
-        if let Some(reason) = self.rejected_reason.as_deref() {
-            fields.push(("REJECTED", reason));
-        };
 
         let fields_str = fields
             .into_iter()

--- a/rust/src/events/mod.rs
+++ b/rust/src/events/mod.rs
@@ -433,9 +433,9 @@ impl Event {
             }
         }
 
-        let is_outlier = self.internal_metadata.is_outlier()?.to_string();
-        if is_outlier == "true" {
-            fields.push(("outlier", &is_outlier));
+        let is_outlier = self.internal_metadata.is_outlier()?;
+        if is_outlier {
+            fields.push(("outlier", "true"));
         }
 
         if let Some(reason) = self.rejected_reason.as_deref() {

--- a/rust/src/events/mod.rs
+++ b/rust/src/events/mod.rs
@@ -438,8 +438,7 @@ impl Event {
             }
         }
 
-        let is_outlier = self.internal_metadata.is_outlier()?;
-        if is_outlier {
+        if self.internal_metadata.is_outlier()? {
             fields.push(("outlier", "true"));
         }
 


### PR DESCRIPTION
Follow on from #19701 

This (more or less) matches what we had before. Otherwise we just get a default `<builtins.Event at 0x...>`