### PR TITLE
Document how to see Rust build failure output when using `poetry install`

### DIFF
--- a/changelog.d/19818.doc
+++ b/changelog.d/19818.doc
@@ -1,0 +1,1 @@
+Document how to see Rust build failure output when using `poetry install`.

--- a/docs/development/contributing_guide.md
+++ b/docs/development/contributing_guide.md
@@ -153,8 +153,14 @@ writing new pages, please
 to check that your contributions render correctly. The docs are written in
 [GitHub-Flavoured Markdown](https://guides.github.com/features/mastering-markdown/).
 
+## Making changes to the Rust code
+
 When changes are made to any Rust code then you must call either `poetry install`
-or `maturin develop` (if installed) to rebuild the Rust code. Using [`maturin`](https://github.com/PyO3/maturin)
+or `maturin develop` (if installed) to rebuild the Rust code.
+
+You can use `poetry install -v` or `-vv` to get more info about build failures.
+
+Using [`maturin`](https://github.com/PyO3/maturin)
 is quicker than `poetry install`, so is recommended when making frequent
 changes to the Rust code.
 


### PR DESCRIPTION
Document how to see Rust build failure output when using `poetry install`

Knowledge from @reivilibre in [`#element-backend-internal:matrix.org`](https://matrix.to/#/!SGNQGPGUwtcPBUotTL:matrix.org/$2WUfCdA02wZw-6-jhw3QbLQ44BmKJrqLuZ6wjz2r7hk?via=jki.re&via=element.io&via=matrix.org) on 2025-12-15.

Spawning from me making Rust changes but nothing useful was printed until I added `-v`,

```shell
$ poetry install --extras all
Installing dependencies from lock file

Package operations: 0 installs, 1 update, 0 removals

  - Updating pyjwt (2.11.0 -> 2.12.0)

Installing the current project: matrix-synapse (1.154.0rc1)
Failed to install /home/eric/Documents/github/element/synapse
```

I also see `poetry run maturin develop` suggested but I'd prefer not to need to install `maturin` as yet another system tool to manage myself.


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
