### PR TITLE
Reduce log spam from to-device stream logging

### DIFF
--- a/changelog.d/19821.misc
+++ b/changelog.d/19821.misc
@@ -1,0 +1,1 @@
+Add more logging to the to-device message replication stream.

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -828,9 +828,11 @@ class MultiWriterIdGenerator(AbstractStreamIdGenerator):
                 # do.
                 break
 
-        # Hacky debug logging to attempt to trace https://github.com/element-hq/synapse/issues/19795
+        # Hacky debug logging to attempt to trace https://github.com/element-hq/synapse/issues/19795.
+        # If this is the to-device stream, and we are a writer for that stream, log some stats
         if (
             issue9533_logger.isEnabledFor(logging.DEBUG)
+            and our_current_position > 0
             and self._stream_name == "to_device"
         ):
             issue9533_logger.debug(


### PR DESCRIPTION
Followup to https://github.com/element-hq/synapse/pull/19801: I only meant for this logging to happen on the instance that is doing the persisting.