### PR TITLE
Document that the SQLite version included in Ubuntu LTS, aside from ESM-only versions, is included in our support policy.

### DIFF
--- a/changelog.d/19823.doc
+++ b/changelog.d/19823.doc
@@ -1,0 +1,1 @@
+Document that the SQLite version included in Ubuntu LTS, aside from ESM-only versions, is included in our support policy.

--- a/docs/deprecation_policy.md
+++ b/docs/deprecation_policy.md
@@ -22,7 +22,7 @@ people building from source should ensure they can fetch recent versions of Rust
 
 The oldest supported version of SQLite is the version
 [provided](https://packages.debian.org/oldstable/libsqlite3-0) by
-[Debian oldstable](https://wiki.debian.org/DebianOldStable).
+[Debian oldstable](https://wiki.debian.org/DebianOldStable) or the oldest maintenance/security-supported [Ubuntu LTS](https://endoflife.date/ubuntu) (Ubuntu versions with only Expanded Security Maintenance are not included).
 
 
 ### Context


### PR DESCRIPTION
This was [discussed months ago (private)](https://docs.google.com/document/d/12RZKPk3a4__JUSH9wYHODo9rRyKzsHg6BSCAcmqmbOU/edit?tab=t.0#bookmark=id.fcdvoc88dy5s) and I never got around to writing it up here.


