### PR TITLE
Tweak wording of Rust crate dependency update policy.

### DIFF
--- a/changelog.d/19829.doc
+++ b/changelog.d/19829.doc
@@ -1,0 +1,1 @@
+Tweak wording of Rust crate dependency update policy.

--- a/docs/deprecation_policy.md
+++ b/docs/deprecation_policy.md
@@ -82,10 +82,11 @@ maintainers. Generally, this just means avoiding the bleeding edge for a few mon
 The situation for Rust dependencies is typically different and
 the concerns around Python dependency versions typically do not apply.
 For example, for packagers of Debian, the packagers have the choice of either
-using a crate packaged in the distro, or vendoring crates in the source package for the application.
+using a crate packaged in the distro, or vendoring crates in the source package for the
+application.
 
-This freedom to vendor a dependency crate for a specific application consequently gives us even greater flexibility to
-upgrade Rust dependencies as needed for the project.
+This freedom to vendor a dependency crate for a specific application consequently gives
+us even greater flexibility to upgrade Rust dependencies as needed for the project.
 
 (This is in contrast with Python dependencies, which are generally
 installed system-wide by mainstream distributions' official packages.)

--- a/docs/deprecation_policy.md
+++ b/docs/deprecation_policy.md
@@ -79,11 +79,16 @@ concerned about the criteria for selecting minimum versions. The only thing of c
 is making sure we're not making it unnecessarily difficult for downstream package
 maintainers. Generally, this just means avoiding the bleeding edge for a few months.
 
-The situation for Rust dependencies is fundamentally different. For packagers, the
-concerns around Python dependency versions do not apply. The `cargo` tool handles
-downloading and building all libraries to satisfy dependencies, and these libraries are
-statically linked into the final binary. This means that from a packager's perspective,
-the Rust dependency versions are an internal build detail, not a runtime dependency to
-be managed on the target system. Consequently, we have even greater flexibility to
-upgrade Rust dependencies as needed for the project. Some distros (e.g. Fedora) do
-package Rust libraries, but this appears to be the outlier rather than the norm.
+The situation for Rust dependencies is typically different and
+the concerns around Python dependency versions typically do not apply.
+For example, for packagers of Debian, the packagers have the choice of either
+using a crate packaged in the distro, or vendoring crates in the source package for the application.
+
+This freedom to vendor a dependency crate for a specific application consequently gives us even greater flexibility to
+upgrade Rust dependencies as needed for the project.
+
+(This is in contrast with Python dependencies, which are generally
+installed system-wide by mainstream distributions' official packages.)
+
+Some distros (e.g. Fedora) do not vendor Rust dependencies in their
+official application packages, but these cases appear to be less common.


### PR DESCRIPTION
After looking into it, just a couple of things to pick a bone at in the old wording,
which I thought could be clarified for when I next come to look at this again.


- the claim that there's a fundamental difference; I'd argue there isn't really, it's just by convention
  on some mainstream distros. So I have changed this to 'typically'
- statements that some distros fetch dependencies at build time (probably does happen, but
  traditional distros make a point of not doing this for the reasons you'd expect).
  - This was probably meant to be talking about Debian, but my observation based on sample size of 3 is that some crates are packaged natively, others are vendored in the respective application's source package (like they do for us) and sometime they patch the bounds a bit

There could probably be room to talk about how distros vendoring packages is a maintenance burden on them,
but I guess it's a bit moot as we would struggle to conform to wide enough bounds to make everyone
happy (and anyway; I expect the distros that vendor packages have the tooling to make this easy to
update and we do keep on top of security updates and release frequently...)

---

Spawning from discussion in [`#element-backend-internal:matrix.org`](https://matrix.to/#/!SGNQGPGUwtcPBUotTL:matrix.org/$VttYPPUevn2S_W_rrzg2ZOXWI6aKebk2ganTgrLEWUc?via=jki.re&via=element.io&via=matrix.org)
