### PR TITLE
Fix the `/capabilities` endpoint returning a 500 error on non-media workers when MSC4452: Preview URL capabilities API is enabled.

### DIFF
--- a/changelog.d/19839.bugfix
+++ b/changelog.d/19839.bugfix
@@ -1,0 +1,1 @@
+Fix the `/capabilities` endpoint returning a 500 error on non-media workers when [MSC4452: Preview URL capabilities API](https://github.com/matrix-org/matrix-spec-proposals/pull/4452) is enabled.

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -139,6 +139,10 @@ class ContentRepositoryConfig(Config):
     section = "media"
 
     def read_config(self, config: JsonDict, **kwargs: Any) -> None:
+        # We need to set this configuration flag even if this worker
+        # is not a media repo worker, as it's exposed in `/capabilities`
+        self.url_preview_enabled = bool(config.get("url_preview_enabled", False))
+
         # Only enable the media repo if either the media repo is enabled or the
         # current worker app is the media repo.
         if (
@@ -242,7 +246,6 @@ class ContentRepositoryConfig(Config):
         self.thumbnail_requirements = parse_thumbnail_requirements(
             config.get("thumbnail_sizes", DEFAULT_THUMBNAIL_SIZES)
         )
-        self.url_preview_enabled = bool(config.get("url_preview_enabled", False))
 
         if self.url_preview_enabled:
             check_requirements("url-preview")


### PR DESCRIPTION
Fixes: #19825
Introduced in: #19715

<ol>
<li>

Always populate `url_preview_enabled` so `/capabilities` can expose it 

</li>
</ol>

Needed so this line can be happy:

https://github.com/element-hq/synapse/blob/106ed3623d434891fe1ac50aacc851e9804404fe/synapse/rest/client/capabilities.py#L82

