### PR TITLE
When building releases, don't cancel Debian package builds when one of them fails.

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -50,6 +50,10 @@ jobs:
     name: "Build .deb packages"
     runs-on: ubuntu-latest
     strategy:
+      # If the deb build is flaky during a release,
+      # failing fast can mean it takes many more retries
+      # before managing to get a full successful set.
+      fail-fast: false
       matrix:
         distro: ${{ fromJson(needs.get-distros.outputs.distros) }}
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -50,9 +50,11 @@ jobs:
     name: "Build .deb packages"
     runs-on: ubuntu-latest
     strategy:
-      # If the deb build is flaky during a release,
-      # failing fast can mean it takes many more retries
-      # before managing to get a full successful set.
+      # Prevent all Debian package builds from being cancelled
+      # when one of them fails. Especially helpful when things are
+      # flaky during a release.
+      #
+      # `fail-fast` defaults to true and applies to the entire test matrix
       fail-fast: false
       matrix:
         distro: ${{ fromJson(needs.get-distros.outputs.distros) }}

--- a/changelog.d/19842.misc
+++ b/changelog.d/19842.misc
@@ -1,0 +1,1 @@
+When building releases, don't cancel Debian package builds when one of them fails.


### PR DESCRIPTION
When building v1.155.0rc1, flaky deb builds combined with fail-fast behaviour
meant that I had to press the retry button 5 times to get a full set.

Without fail-fast, I suspect 1 or 2 retries would have done the job.

<ol>
<li>

Make deb builds fail slow 

</li>
</ol>
