### PR TITLE
Fix `/sync` caching transient errors for the `sync_response_cache_duration`.

### DIFF
--- a/changelog.d/19845.bugfix
+++ b/changelog.d/19845.bugfix
@@ -1,0 +1,1 @@
+Fix `/sync` caching transient errors for the `sync_response_cache_duration`.

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -98,6 +98,8 @@ class ObservableDeferred(Generic[_T], AbstractObservableDeferred[_T]):
     deferred.
 
     If consumeErrors is true errors will be captured from the origin deferred.
+    In that case, errors will NOT be propagated onto any errbacks added to this
+    `ObservableDeferred`; instead the success callbacks will be called with `None`.
 
     Cancelling or otherwise resolving an observer will not affect the original
     ObservableDeferred.

--- a/synapse/util/caches/response_cache.py
+++ b/synapse/util/caches/response_cache.py
@@ -32,6 +32,7 @@ from typing import (
 import attr
 
 from twisted.internet import defer
+from twisted.python.failure import Failure
 
 from synapse.logging.context import make_deferred_yieldable, run_in_background
 from synapse.logging.opentracing import (
@@ -226,14 +227,14 @@ class ResponseCache(Generic[KV]):
         Returns:
             The cache entry object.
         """
-        result = ObservableDeferred(deferred, consumeErrors=True)
+        result = ObservableDeferred(deferred, consumeErrors=False)
         key = context.cache_key
         entry = ResponseCacheEntry(
             result, opentracing_span_context, cancellable=cancellable
         )
         self._result_cache[key] = entry
 
-        def on_complete(r: RV) -> RV:
+        def on_succeed(r: RV) -> RV:
             # if this cache has a non-zero timeout, and the callback has not cleared
             # the should_cache bit, we leave it in the cache for now and schedule
             # its removal later.
@@ -254,10 +255,22 @@ class ResponseCache(Generic[KV]):
                 self.unset(key)
             return r
 
-        # make sure we do this *after* adding the entry to result_cache,
+        def on_fail(failure: Failure) -> None:
+            """
+            If the deferred fails, unset the cache entry.
+            """
+            self.unset(key)
+
+            # Consider the Failure handled so they don't get thrown by the reactor
+            return None
+
+        # make sure we add the callback and errback *after* adding the entry to result_cache,
         # in case the result is already complete (in which case flipping the order would
         # leave us with a stuck entry in the cache).
-        result.addBoth(on_complete)
+        result.addCallback(on_succeed)
+        # Must register errback after callback, so the `None` doesn't get processed
+        # by the result callback chain
+        result.addErrback(on_fail)
         return entry
 
     def unset(self, key: KV) -> None:

--- a/synapse/util/caches/response_cache.py
+++ b/synapse/util/caches/response_cache.py
@@ -231,7 +231,7 @@ class ResponseCache(Generic[KV]):
             deferred,
             # We set `consumeErrors=False` as we want to handle errors ourselves (`on_fail`) instead of
             # replacing them with a `None` successful result that would go to `on_succeed`
-            consumeErrors=False
+            consumeErrors=False,
         )
         key = context.cache_key
         entry = ResponseCacheEntry(
@@ -269,13 +269,20 @@ class ResponseCache(Generic[KV]):
             # Consider the Failure handled so they don't get thrown by the reactor
             return None
 
-        # make sure we add the callback and errback *after* adding the entry to result_cache,
-        # in case the result is already complete (in which case flipping the order would
-        # leave us with a stuck entry in the cache).
+        # Two ordering constraints to be aware of for registering the callback and errback:
+        # 1. Both of them must be registered _after_ adding the entry to the result_cache,
+        #    otherwise it is possible for them to trigger immediately (before the entry
+        #    is added to the result_cache), the net effect of which is that it would leave
+        #    us with a stuck entry in the cache.
+        # 2. We must register the errback after callback.
+        #    If the errback was registered first, `on_fail` returning `None` would
+        #    cause `on_succeed` to be called with that `None` as argument.
+        #    This would start a timer to remove a cache entry, even though there isn't a
+        #    valid cache entry yet.
+        #    (This could prematurely remove a future cache entry with the same key.)
         result.addCallback(on_succeed)
-        # Must register errback after callback, so the `None` doesn't get processed
-        # by the result callback chain
         result.addErrback(on_fail)
+
         return entry
 
     def unset(self, key: KV) -> None:

--- a/synapse/util/caches/response_cache.py
+++ b/synapse/util/caches/response_cache.py
@@ -227,9 +227,12 @@ class ResponseCache(Generic[KV]):
         Returns:
             The cache entry object.
         """
-        # `consumeErrors=False`: we want to handle errors ourselves (`on_fail`) instead of
-        # replacing them with a `None` successful result that would go to `on_succeed`
-        result = ObservableDeferred(deferred, consumeErrors=False)
+        result = ObservableDeferred(
+            deferred,
+            # We set `consumeErrors=False` as we want to handle errors ourselves (`on_fail`) instead of
+            # replacing them with a `None` successful result that would go to `on_succeed`
+            consumeErrors=False
+        )
         key = context.cache_key
         entry = ResponseCacheEntry(
             result, opentracing_span_context, cancellable=cancellable

--- a/synapse/util/caches/response_cache.py
+++ b/synapse/util/caches/response_cache.py
@@ -227,6 +227,8 @@ class ResponseCache(Generic[KV]):
         Returns:
             The cache entry object.
         """
+        # `consumeErrors=False`: we want to handle errors ourselves (`on_fail`) instead of
+        # replacing them with a `None` successful result that would go to `on_succeed`
         result = ObservableDeferred(deferred, consumeErrors=False)
         key = context.cache_key
         entry = ResponseCacheEntry(

--- a/tests/util/caches/test_response_cache.py
+++ b/tests/util/caches/test_response_cache.py
@@ -269,7 +269,7 @@ class ResponseCacheTestCase(TestCase):
 
         return_error = True
 
-        REQUEST_SLEEP_TIME = Duration(seconds=1)
+        REQUEST_FAKE_WORK_SLEEP_TIME = Duration(seconds=1)
 
         async def erring_then_fine(_: str) -> str:
             """
@@ -279,7 +279,7 @@ class ResponseCacheTestCase(TestCase):
             nonlocal return_error
 
             # pretend to do some work
-            await self.clock.sleep(REQUEST_SLEEP_TIME)
+            await self.clock.sleep(REQUEST_FAKE_WORK_SLEEP_TIME)
 
             if return_error:
                 return_error = False
@@ -293,7 +293,7 @@ class ResponseCacheTestCase(TestCase):
         self.assertNoResult(wrap_d)
 
         # Wait for the time it takes for the request to resolve to an error
-        self.reactor.advance(REQUEST_SLEEP_TIME.as_secs())
+        self.reactor.advance(REQUEST_FAKE_WORK_SLEEP_TIME.as_secs())
 
         # Check that the Deferred resolved to an error of the correct type
         self.failureResultOf(wrap_d, RuntimeError)
@@ -307,7 +307,7 @@ class ResponseCacheTestCase(TestCase):
         self.assertNoResult(wrap2_d)
 
         # Wait for the time it takes for the request to resolve
-        self.reactor.advance(1)
+        self.reactor.advance(REQUEST_FAKE_WORK_SLEEP_TIME.as_secs())
 
         self.assertEqual(
             self.successResultOf(wrap2_d),

--- a/tests/util/caches/test_response_cache.py
+++ b/tests/util/caches/test_response_cache.py
@@ -3,6 +3,7 @@
 #
 # Copyright 2021 The Matrix.org Foundation C.I.C.
 # Copyright (C) 2023 New Vector, Ltd
+# Copyright (C) 2026 Element Creations Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -15,7 +16,8 @@
 # Originally licensed under the Apache License, Version 2.0:
 # <http://www.apache.org/licenses/LICENSE-2.0>.
 #
-# [This file includes modifications made by New Vector Limited]
+# [This file includes modifications made by New Vector Limited
+# and Element Creations Ltd]
 #
 #
 
@@ -258,6 +260,46 @@ class ResponseCacheTestCase(TestCase):
         # both results should have completed with the error
         self.assertFailure(wrap_d, Exception)
         self.assertFailure(wrap2_d, Exception)
+
+    def test_errors_are_not_cached(self) -> None:
+        """If the callback raises an error, the error is not cached and
+        served to any subsequent requests, whether they are within the
+        cache timeout or not.
+        """
+        cache = self.with_cache("error_not_cached", ms=3000)
+
+        return_error = True
+
+        async def erring_then_fine(_: str) -> str:
+            """
+            This function raises an error the first time it is called,
+            then is fine the next time it is called.
+            """
+            nonlocal return_error
+
+            # pretend to do some work
+            await self.clock.sleep(Duration(seconds=1))
+
+            if return_error:
+                return_error = False
+                raise RuntimeError("this is a temporary error!")
+            return "fine"
+
+        # First call: should get an error
+        wrap_d = defer.ensureDeferred(cache.wrap(0, erring_then_fine, "ignored"))
+        self.assertNoResult(wrap_d)
+        self.reactor.advance(1)
+        self.failureResultOf(wrap_d, RuntimeError)
+
+        # Second call: the error shouldn't be replayed
+        # and the next call should succeed, so we should get a successful response
+        wrap2_d = defer.ensureDeferred(cache.wrap(0, erring_then_fine, "ignored"))
+        self.reactor.advance(1)
+        self.assertEqual(
+            "fine",
+            self.successResultOf(wrap2_d),
+            "should get the fresh result, not the cached error",
+        )
 
     def test_cache_cancel_first_wait(self) -> None:
         """Test that cancellation of the deferred returned by wrap() on the

--- a/tests/util/caches/test_response_cache.py
+++ b/tests/util/caches/test_response_cache.py
@@ -263,8 +263,7 @@ class ResponseCacheTestCase(TestCase):
 
     def test_errors_are_not_cached(self) -> None:
         """If the callback raises an error, the error is not cached and
-        served to any subsequent requests, whether they are within the
-        cache timeout or not.
+        served to any subsequent requests.
         """
         cache = self.with_cache("error_not_cached", ms=3000)
 

--- a/tests/util/caches/test_response_cache.py
+++ b/tests/util/caches/test_response_cache.py
@@ -236,9 +236,9 @@ class ResponseCacheTestCase(TestCase):
                 [], cache.keys(), "cache should not have the result now"
             )
 
-    def test_cache_func_errors(self) -> None:
+    def test_errors_raised_to_all_waiters(self) -> None:
         """If the callback raises an error, the error should be raised to all
-        callers and the result should not be cached"""
+        concurrent callers that were waiting on the same in-flight result."""
         cache = self.with_cache("error_cache", ms=3000)
 
         expected_error = Exception("oh no")

--- a/tests/util/caches/test_response_cache.py
+++ b/tests/util/caches/test_response_cache.py
@@ -296,8 +296,8 @@ class ResponseCacheTestCase(TestCase):
         wrap2_d = defer.ensureDeferred(cache.wrap(0, erring_then_fine, "ignored"))
         self.reactor.advance(1)
         self.assertEqual(
-            "fine",
             self.successResultOf(wrap2_d),
+            "fine",
             "should get the fresh result, not the cached error",
         )
 

--- a/tests/util/caches/test_response_cache.py
+++ b/tests/util/caches/test_response_cache.py
@@ -269,6 +269,8 @@ class ResponseCacheTestCase(TestCase):
 
         return_error = True
 
+        REQUEST_SLEEP_TIME = Duration(seconds=1)
+
         async def erring_then_fine(_: str) -> str:
             """
             This function raises an error the first time it is called,
@@ -277,7 +279,7 @@ class ResponseCacheTestCase(TestCase):
             nonlocal return_error
 
             # pretend to do some work
-            await self.clock.sleep(Duration(seconds=1))
+            await self.clock.sleep(REQUEST_SLEEP_TIME)
 
             if return_error:
                 return_error = False
@@ -286,14 +288,27 @@ class ResponseCacheTestCase(TestCase):
 
         # First call: should get an error
         wrap_d = defer.ensureDeferred(cache.wrap(0, erring_then_fine, "ignored"))
+
+        # Should be pending
         self.assertNoResult(wrap_d)
-        self.reactor.advance(1)
+
+        # Wait for the time it takes for the request to resolve to an error
+        self.reactor.advance(REQUEST_SLEEP_TIME.as_secs())
+
+        # Check that the Deferred resolved to an error of the correct type
         self.failureResultOf(wrap_d, RuntimeError)
 
         # Second call: the error shouldn't be replayed
         # and the next call should succeed, so we should get a successful response
         wrap2_d = defer.ensureDeferred(cache.wrap(0, erring_then_fine, "ignored"))
+
+        # Since this is a new request (not coalesced with the previous failed one),
+        # this should still be pending
+        self.assertNoResult(wrap2_d)
+
+        # Wait for the time it takes for the request to resolve
         self.reactor.advance(1)
+
         self.assertEqual(
             self.successResultOf(wrap2_d),
             "fine",


### PR DESCRIPTION
Fixes: #19844

Concretely, this changes `ResponseCache` to unset cache entries once they resolve to a `Failure`.

<ol>
<li>

Add test for ResponseCache not caching errors 

</li>
<li>

Fix misleading docstring on existing test 

</li>
<li>

Make ResponseCache not cache failures 

</li>
<li>

ObservableDeferred: drive-by comment tweak 

</li>
</ol>
