### PR TITLE
Force keyword-args for clear `default_config(server_name="test")` usage

### DIFF
--- a/changelog.d/19849.misc
+++ b/changelog.d/19849.misc
@@ -1,0 +1,1 @@
+Force keyword-args for clear `default_config(server_name="test")` usage in test utilities.

--- a/tests/config/test_oauth_delegation.py
+++ b/tests/config/test_oauth_delegation.py
@@ -60,7 +60,7 @@ class MSC3861OAuthDelegation(TestCase):
 
     def setUp(self) -> None:
         self.config_dict: JsonDict = {
-            **default_config("test"),
+            **default_config(server_name="test"),
             "public_baseurl": BASE_URL,
             "enable_registration": False,
             "experimental_features": {
@@ -287,7 +287,7 @@ class MasAuthDelegation(TestCase):
 
     def setUp(self) -> None:
         self.config_dict: JsonDict = {
-            **default_config("test"),
+            **default_config(server_name="test"),
             "public_baseurl": BASE_URL,
             "enable_registration": False,
             "matrix_authentication_service": {

--- a/tests/config/test_ratelimiting.py
+++ b/tests/config/test_ratelimiting.py
@@ -57,7 +57,7 @@ class ParseRatelimitSettingsTestcase(TestCase):
 
 class RatelimitConfigTestCase(TestCase):
     def test_parse_rc_federation(self) -> None:
-        config_dict = default_config("test")
+        config_dict = default_config(server_name="test")
         config_dict["rc_federation"] = {
             "window_size": 20000,
             "sleep_limit": 693,

--- a/tests/config/test_registration_config.py
+++ b/tests/config/test_registration_config.py
@@ -37,7 +37,7 @@ class RegistrationConfigTestCase(ConfigFileTestCase):
         Test that the user is faced with configuration errors if they make it
         smaller, as that configuration doesn't make sense.
         """
-        config_dict = default_config("test")
+        config_dict = default_config(server_name="test")
 
         # First test all the error conditions
         with self.assertRaises(ConfigError):

--- a/tests/handlers/test_room_list.py
+++ b/tests/handlers/test_room_list.py
@@ -31,7 +31,7 @@ class RoomListHandlerTestCase(unittest.HomeserverTestCase):
         return room_id
 
     def default_config(self) -> JsonDict:
-        config = default_config("test")
+        config = default_config(server_name="test")
         config["room_list_publication_rules"] = [{"action": "allow"}]
         return config
 

--- a/tests/http/federation/test_matrix_federation_agent.py
+++ b/tests/http/federation/test_matrix_federation_agent.py
@@ -77,7 +77,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
 
         self.mock_resolver = AsyncMock(spec=SrvResolver)
 
-        config_dict = default_config("test", parse=False)
+        config_dict = default_config(server_name="test", parse=False)
         config_dict["federation_custom_ca_list"] = [get_test_ca_cert_file()]
 
         self._config = config = HomeServerConfig()
@@ -1019,7 +1019,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
         self.mock_resolver.resolve_service.return_value = []
         self.reactor.lookups["testserv"] = "1.2.3.4"
 
-        config = default_config("test", parse=True)
+        config = default_config(server_name="test", parse=True)
 
         # Build a new agent and WellKnownResolver with a different tls factory
         tls_factory = FederationPolicyForHTTPS(config)

--- a/tests/media/test_media_storage.py
+++ b/tests/media/test_media_storage.py
@@ -930,7 +930,7 @@ class SpamCheckerTestCaseLegacy(unittest.HomeserverTestCase):
         return resources
 
     def default_config(self) -> dict[str, Any]:
-        config = default_config("test")
+        config = default_config(server_name="test")
 
         config.update(
             {

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -2785,7 +2785,7 @@ class PublicRoomsRoomTypeFilterTestCase(unittest.HomeserverTestCase):
         )
 
     def default_config(self) -> JsonDict:
-        config = default_config("test")
+        config = default_config(server_name="test")
         config["room_list_publication_rules"] = [{"action": "allow"}]
         return config
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -1108,7 +1108,7 @@ def setup_test_homeserver(
         reactor = ThreadedMemoryReactorClock()
 
     if config is None:
-        config = default_config(server_name, parse=True)
+        config = default_config(server_name=server_name, parse=True)
 
     server_name = config.server.server_name
     if not isinstance(server_name, str):

--- a/tests/server_notices/__init__.py
+++ b/tests/server_notices/__init__.py
@@ -44,7 +44,7 @@ class ServerNoticesTests(unittest.HomeserverTestCase):
     ]
 
     def default_config(self) -> JsonDict:
-        config = default_config("test")
+        config = default_config(server_name="test")
 
         config.update({"server_notices": DEFAULT_SERVER_NOTICES_CONFIG})
 

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -40,7 +40,7 @@ from tests.utils import default_config
 
 class TestResourceLimitsServerNotices(unittest.HomeserverTestCase):
     def default_config(self) -> JsonDict:
-        config = default_config("test")
+        config = default_config(server_name="test")
 
         config.update(
             {

--- a/tests/storage/test_monthly_active_users.py
+++ b/tests/storage/test_monthly_active_users.py
@@ -41,7 +41,7 @@ def gen_3pids(count: int) -> list[dict[str, Any]]:
 
 class MonthlyActiveUsersTestCase(unittest.HomeserverTestCase):
     def default_config(self) -> dict[str, Any]:
-        config = default_config("test")
+        config = default_config(server_name="test")
 
         config.update({"limit_usage_by_mau": True, "max_mau_value": 50})
 

--- a/tests/test_mau.py
+++ b/tests/test_mau.py
@@ -39,7 +39,7 @@ class TestMauLimit(unittest.HomeserverTestCase):
     servlets = [register.register_servlets, sync.register_servlets]
 
     def default_config(self) -> JsonDict:
-        config = default_config("test")
+        config = default_config(server_name="test")
 
         config.update(
             {

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -244,7 +244,7 @@ class StateTestCase(unittest.TestCase):
             ]
         )
         reactor, clock = get_clock()
-        hs.config = default_config("tesths", True)
+        hs.config = default_config(server_name="tesths", parse=True)
         hs.get_datastores.return_value = Mock(
             main=self.dummy_store,
             state_deletion=dummy_deletion_store,

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -545,7 +545,7 @@ class HomeserverTestCase(TestCase):
         """
         Get a default HomeServer config dict.
         """
-        config = default_config("test")
+        config = default_config(server_name="test")
 
         # apply any additional config which was specified via the override_config
         # decorator.

--- a/tests/util/test_ratelimitutils.py
+++ b/tests/util/test_ratelimitutils.py
@@ -139,7 +139,7 @@ def _await_resolution(reactor: ThreadedMemoryReactorClock, d: Deferred) -> float
 
 
 def build_rc_config(settings: dict | None = None) -> FederationRatelimitSettings:
-    config_dict = default_config("test")
+    config_dict = default_config(server_name="test")
     config_dict.update(settings or {})
     config = HomeServerConfig()
     config.parse_config_dict(config_dict, "", "")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -129,16 +129,16 @@ def setupdb() -> None:
 
 @overload
 def default_config(
-    server_name: str, parse: Literal[False] = ...
+    *, server_name: str, parse: Literal[False] = ...
 ) -> dict[str, object]: ...
 
 
 @overload
-def default_config(server_name: str, parse: Literal[True]) -> HomeServerConfig: ...
+def default_config(*, server_name: str, parse: Literal[True]) -> HomeServerConfig: ...
 
 
 def default_config(
-    server_name: str, parse: bool = False
+    *, server_name: str, parse: bool = False
 ) -> dict[str, object] | HomeServerConfig:
     """
     Create a reasonable test config.


### PR DESCRIPTION
Force keyword-args for clear `default_config(server_name="test")` usage. `default_config("test")` and `default_config("test", False)` are so opaque and hard to connect the dots with.

Spawning from trying to figure out what the `server_name` is set as for our `HomeserverTestCase` in order to reference it in https://github.com/element-hq/synapse/pull/19848#discussion_r3397455309

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
