### PR TITLE
Ignore ruff cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ __pycache__/
 !/.coveragerc
 /.coverage*
 /.mypy_cache/
+/.ruff_cache/
 /.tox
 /.tox-pg-container
 /build/

--- a/changelog.d/19854.misc
+++ b/changelog.d/19854.misc
@@ -1,0 +1,1 @@
+Add `.ruff_cache/` directory to `.gitignore`.


### PR DESCRIPTION
When I run `ruff` locally, either `ruff` or one of the linting scripts adds `.ruff_cache` to the `.gitignore` file.  This PR adds that line so that running linters doesn't result in a dirty git working tree (and to ignore ruff's cache, of course).

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
