### PR TITLE
Explain natural behavior of events lost in the `/make_join`/`/send_join` gap

### DIFF
--- a/changelog.d/19856.bugfix
+++ b/changelog.d/19856.bugfix
@@ -1,0 +1,1 @@
+Provide remote servers a way to find out about an event created during the remote join handshake. Contributed by @FrenchGithubUser and @jason-famedly @ Famedly.

--- a/complement/tests/federation_room_join_test.go
+++ b/complement/tests/federation_room_join_test.go
@@ -32,7 +32,13 @@ import (
 //
 // This test lives as a in-repo Synapse Complement test because the spec doesn't mandate
 // which events should be resolvable after the `/make_join`/`/send_join` dance (or that
-// a homeserver should send `m.dummy` events to tie things together)
+// a homeserver should send `m.dummy` events to tie things together).
+//
+// To be clear, resolving the events in the `/make_join`/`/send_join` gap would happen
+// naturally as soon as someone else sends an event who is on a homeserver aware of the
+// events in the gap (tie it into the DAG). The goal of the dummy events is to make this
+// happen automatically by sending a `m.dummy` event that ties things in instead of
+// waiting for another event to be sent naturally.
 func TestEventBetweenMakeJoinAndSendJoinIsNotLost(t *testing.T) {
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)

--- a/complement/tests/federation_room_join_test.go
+++ b/complement/tests/federation_room_join_test.go
@@ -36,9 +36,9 @@ import (
 //
 // To be clear, resolving the events in the `/make_join`/`/send_join` gap would happen
 // naturally as soon as someone else sends an event who is on a homeserver aware of the
-// events in the gap (tie it into the DAG). The goal of the dummy events is to make this
-// happen automatically by sending a `m.dummy` event that ties things in instead of
-// waiting for another event to be sent naturally.
+// events in the gap (tie it into the DAG). The goal of the automatic dummy events is to
+// make this happen more immediately by sending a `m.dummy` event that ties things in
+// instead of waiting for another event to be sent naturally.
 func TestEventBetweenMakeJoinAndSendJoinIsNotLost(t *testing.T) {
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)


### PR DESCRIPTION
Explain natural behavior of events lost in the `/make_join`/`/send_join` gap. To better explain that this new thing we're doing in https://github.com/element-hq/synapse/pull/19390 is a good citizen thing, not a requirement. 

Follow-up to https://github.com/element-hq/synapse/pull/19390

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
