### PR TITLE
Log table name in "No row found" error

### DIFF
--- a/changelog.d/19869.bugfix
+++ b/changelog.d/19869.bugfix
@@ -1,0 +1,1 @@
+Make simple_select_one_onecol_txn() more helpful by naming the table of the select - as all other query wrapper functions already did.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1879,7 +1879,7 @@ class DatabasePool:
             if allow_none:
                 return None
             else:
-                raise StoreError(404, "No row found")
+                raise StoreError(404, "No row found (%s)" % (table,))
 
     @staticmethod
     def simple_select_onecol_txn(

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1879,7 +1879,7 @@ class DatabasePool:
             if allow_none:
                 return None
             else:
-                raise StoreError(404, "No row found (%s)" % (table,))
+                raise StoreError(404, f"No row found ({table})")
 
     @staticmethod
     def simple_select_onecol_txn(


### PR DESCRIPTION
bringing it up to parity with the other 404 StoreErrors naming the table name already.

More helpful response when debugging issues with incomplete relations. Concretly: a user that got partly removed and then reinstated, missing an entry in 'profiles' table.

This should also contribute to a better understanding of #2807 and #2173

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). 
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
