### PR TITLE
Implement unstable support for MSC4491

### DIFF
--- a/changelog.d/19874.feature
+++ b/changelog.d/19874.feature
@@ -1,0 +1,1 @@
+Add experimental support for [MSC4491: Invite reasons in room creation](https://github.com/matrix-org/matrix-spec-proposals/pull/4491).

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -617,3 +617,6 @@ class ExperimentalConfig(Config):
         # MSC4455: Preview URL capability
         # Tracked in: https://github.com/element-hq/synapse/issues/19719
         self.msc4452_enabled: bool = experimental.get("msc4452_enabled", False)
+
+        # MSC4491: Invite reasons in room creation
+        self.msc4491_enabled: bool = experimental.get("msc4491_enabled", False)

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1345,6 +1345,11 @@ class RoomCreationHandler:
             if is_direct:
                 content["is_direct"] = is_direct
 
+            if self.config.experimental.msc4491_enabled:
+                reason = config.get("uk.timedout.msc4491.invite_reason")
+                if reason and isinstance(reason, str):
+                    content["reason"] = reason
+
             for invitee in invite_list:
                 (
                     member_event_id,

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -208,6 +208,7 @@ class VersionsRestServlet(RestServlet):
                     "org.matrix.msc4380.stable": True,
                     # MSC4445: Sync timeline order
                     "org.matrix.msc4445.initial_sync_timeline_topological_ordering": True,
+                    "uk.timedout.msc4491.create_room_invite_reasons": self.config.experimental.msc4491_enabled,
                 },
             },
         )


### PR DESCRIPTION
Implements unstable support for MSC4491.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
