### PR TITLE
Move `JsonDict` import to type-checking path only

### DIFF
--- a/changelog.d/19876.misc
+++ b/changelog.d/19876.misc
@@ -1,0 +1,1 @@
+Prevent an obtuse error masking a more user-friendly error when trying to run Synapse with an outdated rust module in certain cases.

--- a/synapse/util/__init__.py
+++ b/synapse/util/__init__.py
@@ -38,10 +38,8 @@ from matrix_common.versionstring import get_distribution_version_string
 from twisted.internet import defer
 from twisted.python.failure import Failure
 
-from synapse.types import JsonDict
-
 if typing.TYPE_CHECKING:
-    pass
+    from synapse.types import JsonDict
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +187,7 @@ def split_dict_to_fit_to_size(
     *,
     soft_max_size: int,
     wrapping_object_size: int = 2,
-) -> Iterator[tuple[dict[str, JsonDict], int]]:
+) -> Iterator[tuple[dict[str, "JsonDict"], int]]:
     """Splits a dict up into a list of dicts, each of which is small enough to
     fit into the given size when encoded as JSON. Every entry in the original
     dict is in exactly one of the resulting dicts.


### PR DESCRIPTION
I ran into the usual case where my `synapse_rust` module was outdated and needed to rebuild them before running the Complement tests.

However, instead of getting the typical error of `Rust module outdated. Please rebuild using `poetry install`, I instead got the following:

```
COMPLEMENT_DIR="../complement" ./scripts-dev/complement.sh -run
  "TestMSC4429ProfileUpdates"
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/home/work/code/synapse/synapse/util/__init__.py", line 41, in <module>
      from synapse.types import JsonDict
    File "/home/work/code/synapse/synapse/types/__init__.py", line 70, in <module>
      from synapse.synapse_rust.types import Requester
  ModuleNotFoundError: No module named 'synapse.synapse_rust.types'; 'synapse.synapse_rust' is not a package.
```

which is much more confusing for a irregular contributor to diagnose than the one that tells you to run `poetry install`.

The cause was an edge case: I did not yet have the `synapse.synapse_rust.types` module, which was added only recently in https://github.com/element-hq/synapse/pull/19828. So you could argue this is a one-time hurdle.

However, the need to import `synapse.synapse_rust.types` solely comes from needing to import `JsonDict`, which is only used for typechecking!

Hence moving the import under `if typing.TYPE_CHECKING`. With this, I would have received the more noob-friendly error message instead of one about a `synapse_rust.types` module not existing.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
