### PR TITLE
Disable Postgres crash-safety features in CI for speed.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -383,13 +383,21 @@ jobs:
         if: ${{ matrix.job.postgres-version }}
         # 1. Mount postgres data files onto a tmpfs in-memory filesystem to reduce overhead of docker's overlayfs layer.
         # 2. Expose the unix socket for postgres. This removes latency of using docker-proxy for connections.
+        # 3. We disable crash-safety features for speed: fsync, synchronous commits, full-page writes.
+        #    Note: synchronous commits are enabled/disabled at runtime by Synapse, so there is also
+        #    code in `tests/server.py` to configure this as off.
         run: |
           docker run -d -p 5432:5432 \
-            --tmpfs /var/lib/postgres:rw,size=6144m \
+            --tmpfs /var/lib/postgresql:rw,size=6144m \
             --mount 'type=bind,src=/var/run/postgresql,dst=/var/run/postgresql' \
             -e POSTGRES_PASSWORD=postgres \
             -e POSTGRES_INITDB_ARGS="--lc-collate C --lc-ctype C --encoding UTF8" \
-            postgres:${{ matrix.job.postgres-version }}
+            postgres:${{ matrix.job.postgres-version }} \
+              -c fsync=off \
+              -c synchronous_commit=off \
+              -c full_page_writes=off \
+              -c wal_level=minimal \
+              -c max_wal_senders=0
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -382,14 +382,17 @@ jobs:
       - name: Set up PostgreSQL ${{ matrix.job.postgres-version }}
         if: ${{ matrix.job.postgres-version }}
         # 1. Mount postgres data files onto a tmpfs in-memory filesystem to reduce overhead of docker's overlayfs layer.
+        #    Use a custom path to ensure stability (it will change across versions,
+        #    see https://github.com/docker-library/postgres/blob/be0b7ac960bb393b00a31938b6d878397f482759/Dockerfile-debian.template#L188)
         # 2. Expose the unix socket for postgres. This removes latency of using docker-proxy for connections.
         # 3. We disable crash-safety features for speed: fsync, synchronous commits, full-page writes.
         #    Note: synchronous commits are enabled/disabled at runtime by Synapse, so there is also
         #    code in `tests/server.py` to configure this as off.
         run: |
           docker run -d -p 5432:5432 \
-            --tmpfs /var/lib/postgresql:rw,size=6144m \
+            --tmpfs /pgdata:rw,size=6144m \
             --mount 'type=bind,src=/var/run/postgresql,dst=/var/run/postgresql' \
+            -e PGDATA=/pgdata \
             -e POSTGRES_PASSWORD=postgres \
             -e POSTGRES_INITDB_ARGS="--lc-collate C --lc-ctype C --encoding UTF8" \
             postgres:${{ matrix.job.postgres-version }} \

--- a/changelog.d/19880.misc
+++ b/changelog.d/19880.misc
@@ -1,0 +1,1 @@
+Disable Postgres crash-safety features in CI for speed.

--- a/docker/complement/conf/postgres.supervisord.conf
+++ b/docker/complement/conf/postgres.supervisord.conf
@@ -1,5 +1,7 @@
 [program:postgres]
 # Disable crash-safety features for speed: fsync, synchronous commit, full page writes
+# Note: synchronous commits are enabled/disabled at runtime by Synapse, so there is also
+# an env set in `start_for_complement.sh` to configure this as off.
 command=/usr/local/bin/prefix-log gosu postgres postgres
     -c fsync=off
     -c synchronous_commit=off

--- a/docker/complement/conf/postgres.supervisord.conf
+++ b/docker/complement/conf/postgres.supervisord.conf
@@ -1,5 +1,11 @@
 [program:postgres]
+# Disable crash-safety features for speed: fsync, synchronous commit, full page writes
 command=/usr/local/bin/prefix-log gosu postgres postgres
+    -c fsync=off
+    -c synchronous_commit=off
+    -c full_page_writes=off
+    -c wal_level=minimal
+    -c max_wal_senders=0
 
 # Only start if START_POSTGRES=true
 autostart=%(ENV_START_POSTGRES)s

--- a/docker/complement/conf/start_for_complement.sh
+++ b/docker/complement/conf/start_for_complement.sh
@@ -27,6 +27,9 @@ case "$SYNAPSE_COMPLEMENT_DATABASE" in
     export POSTGRES_USER=postgres
     export POSTGRES_HOST=localhost
 
+    # Disable synchronous commit for potential performance gains
+    export __PRIVATE_SYNAPSE_DISABLE_SYNCHRONOUS_COMMIT=1
+
     # configure supervisord to start postgres
     export START_POSTGRES=true
     ;;

--- a/docker/conf/homeserver.yaml
+++ b/docker/conf/homeserver.yaml
@@ -71,6 +71,10 @@ database:
     user: "{{ POSTGRES_USER or "synapse" }}"
     password: "{{ POSTGRES_PASSWORD }}"
     database: "{{ POSTGRES_DB or "synapse" }}"
+{# Used by Complement. Not documented as a stable option. CAUSES RISK OF DATA LOSS. #}
+{% if __PRIVATE_SYNAPSE_DISABLE_SYNCHRONOUS_COMMIT %}
+    synchronous_commit: false
+{% endif %}
 {% if not SYNAPSE_USE_UNIX_SOCKET %}
 {# Synapse will use a default unix socket for Postgres when host/port is not specified (behavior from `psycopg2`). #}
     host: "{{ POSTGRES_HOST or "db" }}"

--- a/tests/server.py
+++ b/tests/server.py
@@ -1134,6 +1134,11 @@ def setup_test_homeserver(
                 "port": POSTGRES_PORT,
                 "cp_min": 1,
                 "cp_max": 5,
+                # Tolerate data loss for testing speedup.
+                # https://postgresqlco.nf/doc/en/param/synchronous_commit/
+                # (Mechanically: means we ask Postgres not to wait to flush data to disk before
+                # telling us transactions are committed.)
+                "synchronous_commit": False,
             },
         }
     else:


### PR DESCRIPTION
Also correct the tmpfs mount that the trial test suite had; see https://github.com/docker-library/postgres/blob/be0b7ac960bb393b00a31938b6d878397f482759/Dockerfile-debian.template#L188
