### PR TITLE
Make sure room avatars in sliding sync responses are strings

### DIFF
--- a/changelog.d/19882.bugfix
+++ b/changelog.d/19882.bugfix
@@ -1,0 +1,4 @@
+Make sure room avatars in sliding sync responses are strings: don't blindly trust the contents of the room avatar
+state event and assign it to sliding sync rooms, instead check it's a string like
+[the MSC](https://github.com/matrix-org/matrix-spec-proposals/blob/erikj/sss/proposals/4186-simplified-sliding-sync.md)
+expects. Contributed by @jmartinesp.

--- a/synapse/handlers/sliding_sync/__init__.py
+++ b/synapse/handlers/sliding_sync/__init__.py
@@ -1356,7 +1356,9 @@ class SlidingSyncHandler:
         room_avatar: str | None = None
         avatar_event = room_state.get((EventTypes.RoomAvatar, ""))
         if avatar_event is not None:
-            room_avatar = avatar_event.content.get("url")
+            avatar_content = avatar_event.content.get("url")
+            if isinstance(avatar_content, str):
+                room_avatar = avatar_content
 
         # Assemble heroes: extract the info from the state we just fetched
         heroes: list[SlidingSyncResult.RoomResult.StrippedHero] = []


### PR DESCRIPTION
We had an issue reported on Element X Android where a room's avatar in the sliding sync response had this format:

```json
"avatar": {
  "content_url": "mxc://..."
}
```

Which crashed the sliding sync service of the SDK in a loop, since Rust is strongly typed and failed to deserialize the response.

I guess this is caused by the room's avatar state event being incorrectly formatted, but since [the sliding sync MSC](https://github.com/matrix-org/matrix-spec-proposals/blob/erikj/sss/proposals/4186-simplified-sliding-sync.md) states a string type and the synapse code gives a hint of `str | None`, it looks like we shouldn't blindly assign any value of the state event there.

If this is accepted, I wonder if it should also be done for other fields which are just extracted from their state event contents.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
