### PR TITLE
Fix the `cargo-test` and `cargo-bench` CI jobs not running

### DIFF
--- a/.github/workflows/fix_lint.yaml
+++ b/.github/workflows/fix_lint.yaml
@@ -9,7 +9,9 @@ on:
 env:
   # We use nightly so that `fmt` correctly groups together imports, and
   # clippy correctly fixes up the benchmarks.
-  RUST_VERSION: nightly-2025-06-24
+  #
+  # Note: This should match the nightly rust version in `tests.yml`.
+  RUST_VERSION: nightly-2025-03-27
 
 jobs:
   fixup:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -677,7 +677,12 @@ jobs:
       - changes
 
   cargo-test:
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    # We need to explicitly specify `!cancelled() && !failure()` as otherwise
+    # GitHub will implicitly add `success()`, which will be `false` when any job
+    # in `needs`, or its dependents, is skipped. Most notably, jobs like
+    # `lint-readme`, a dependency of `linting-done`, are unlikely to run very
+    # often - and would result in this job being skipped.
+    if: ${{ !cancelled() && !failure() && needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     needs:
       - linting-done
@@ -697,7 +702,8 @@ jobs:
   # We want to ensure that the cargo benchmarks still compile, which requires a
   # nightly compiler.
   cargo-bench:
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    # See `cargo-test` above for why we need to specify `!cancelled() && !failure()`.
+    if: ${{ !cancelled() && !failure() && needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     needs:
       - linting-done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,16 @@ concurrency:
 
 env:
   RUST_VERSION: 1.87.0
+  # This nightly is roughly the last to be branded 1.87.0.
+  #
+  # We know this, as 1.87.0 was branched from master on 2025-03-28. Shortly
+  # afterwards, nightlies were then branded as 1.88.0. See
+  # https://releases.rs/docs/1.87.0/ for where we get the dates.
+  #
+  # Technically the last 1.87.0 nightly was 2025-03-29, but that all depends on
+  # at which time of day they cut the release and when the nightly is built.
+  # It's safer for future releases to just do the day before.
+  RUST_NIGHTLY_VERSION: nightly-2025-03-27 # last nightly before 1.88.0
 
 jobs:
   # Job to detect what has changed so we don't run e.g. Rust checks on PRs that
@@ -240,7 +250,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          toolchain: nightly-2026-02-01
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
@@ -296,7 +306,7 @@ jobs:
         with:
           # We use nightly so that we can use some unstable options that we use in
           # `.rustfmt.toml`.
-          toolchain: nightly-2025-04-23
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
           components: rustfmt
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
@@ -715,7 +725,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          toolchain: nightly-2022-12-01
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - run: cargo bench --no-run

--- a/changelog.d/19883.misc
+++ b/changelog.d/19883.misc
@@ -1,0 +1,1 @@
+Prevent the `cargo-deny` and `cargo-bench` CI jobs from being skipped, even on PRs that have Rust changes.

--- a/rust/src/events/formats/v4.rs
+++ b/rust/src/events/formats/v4.rs
@@ -37,7 +37,7 @@ use crate::{
     json::AllowMissing,
 };
 
-/// Version-specific fields for room version 11.
+/// Version-specific fields for room version 12+.
 #[derive(Serialize, Deserialize)]
 pub struct EventFormatV4 {
     #[serde(
@@ -56,6 +56,8 @@ impl EventFormatV4 {
         if common_fields.other_fields.contains_key("event_id") {
             bail!("v4 events must not have an explicit event_id");
         }
+
+        validate_optional_room_id(self.room_id.as_ref_opt(), common_fields)?;
 
         Ok(())
     }

--- a/rust/src/events/formats/vmsc4242.rs
+++ b/rust/src/events/formats/vmsc4242.rs
@@ -33,7 +33,7 @@ use pyo3::PyResult;
 use serde::{Deserialize, Serialize};
 
 use crate::events::constants::event_type::M_ROOM_CREATE;
-use crate::events::formats::v4::get_room_id_for_optional_room_id;
+use crate::events::formats::v4::{get_room_id_for_optional_room_id, validate_optional_room_id};
 use crate::events::formats::EventCommonFields;
 use crate::events::Event;
 use crate::json::AllowMissing;
@@ -62,6 +62,8 @@ impl EventFormatVMSC4242 {
         if common_fields.other_fields.contains_key("event_id") {
             bail!("MSC4242 events must not have an explicit event_id");
         }
+
+        validate_optional_room_id(self.room_id.as_ref_opt(), common_fields)?;
 
         Ok(())
     }

--- a/rust/src/events/formats/vmsc4242.rs
+++ b/rust/src/events/formats/vmsc4242.rs
@@ -38,7 +38,6 @@ use crate::events::formats::EventCommonFields;
 use crate::events::Event;
 use crate::json::AllowMissing;
 
-// A change to the rust code.
 /// Version-specific fields for the MSC4242 event format.
 #[derive(Serialize, Deserialize)]
 pub struct EventFormatVMSC4242 {

--- a/rust/src/events/formats/vmsc4242.rs
+++ b/rust/src/events/formats/vmsc4242.rs
@@ -38,6 +38,7 @@ use crate::events::formats::EventCommonFields;
 use crate::events::Event;
 use crate::json::AllowMissing;
 
+// A change to the rust code.
 /// Version-specific fields for the MSC4242 event format.
 #[derive(Serialize, Deserialize)]
 pub struct EventFormatVMSC4242 {

--- a/rust/src/events/utils.rs
+++ b/rust/src/events/utils.rs
@@ -367,9 +367,14 @@ mod tests {
     }
 
     #[test]
-    /// Tests to ensure events with overly large values for `depth` are handled appropriately.
-    /// This was added in room version 6 <https://spec.matrix.org/v1.16/rooms/v6/#event-format>.
-    fn test_calculate_event_id_big_int_old_rooms() {
+    /// This is a bit funky, but we test that relaxed `depth` rules are in
+    /// place, even in room versions that enforce strict canonical JSON, as we
+    /// still need to load invalid events from the database even in newer room
+    /// versions. See https://github.com/element-hq/synapse/pull/19816.
+    ///
+    /// We still enforce canonicaljson when creating *new* events (see
+    /// `EventValidator` on the python side).
+    fn test_calculate_event_id_big_int_is_relaxed() {
         let original = json!(
             {
                 "auth_events":[
@@ -407,12 +412,10 @@ mod tests {
         );
 
         // These should succeed.
-        let _event_id = calculate_event_id(&original, &RoomVersion::V3).unwrap();
-        let _event_id = calculate_event_id(&original, &RoomVersion::V4).unwrap();
-        let _event_id = calculate_event_id(&original, &RoomVersion::V5).unwrap();
-
-        // These should not succeed.
         let versions = [
+            RoomVersion::V3,
+            RoomVersion::V4,
+            RoomVersion::V5,
             RoomVersion::V6,
             RoomVersion::V7,
             RoomVersion::V8,
@@ -422,7 +425,7 @@ mod tests {
             RoomVersion::V12,
         ];
         for version in versions {
-            let _event_id = calculate_event_id(&original, &version).unwrap_err();
+            let _event_id = calculate_event_id(&original, &version).unwrap();
         }
     }
 

--- a/rust/src/json.rs
+++ b/rust/src/json.rs
@@ -105,8 +105,6 @@ pub mod allow_missing {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches;
-
     use serde::{Deserialize, Serialize};
 
     use super::*;
@@ -126,12 +124,12 @@ mod tests {
         let json = r#"{"value":42}"#;
         let deserialized: TestStruct = serde_json::from_str(json).unwrap();
         assert!(deserialized.value.is_some());
-        assert_matches!(deserialized.value, AllowMissing::Some(42));
+        assert!(matches!(deserialized.value, AllowMissing::Some(42)));
 
         let json = r#"{}"#;
         let deserialized: TestStruct = serde_json::from_str(json).unwrap();
         assert!(deserialized.value.is_absent());
-        assert_matches!(deserialized.value, AllowMissing::Absent);
+        assert!(matches!(deserialized.value, AllowMissing::Absent));
     }
 
     #[test]
@@ -203,16 +201,16 @@ mod tests {
         let json = r#"{"value":42}"#;
         let deserialized: TestStructOption = serde_json::from_str(json).unwrap();
         assert!(deserialized.value.is_some());
-        assert_matches!(deserialized.value, AllowMissing::Some(Some(42)));
+        assert!(matches!(deserialized.value, AllowMissing::Some(Some(42))));
 
         let json = r#"{"value":null}"#;
         let deserialized: TestStructOption = serde_json::from_str(json).unwrap();
         assert!(deserialized.value.is_some());
-        assert_matches!(deserialized.value, AllowMissing::Some(None));
+        assert!(matches!(deserialized.value, AllowMissing::Some(None)));
 
         let json = r#"{}"#;
         let deserialized: TestStructOption = serde_json::from_str(json).unwrap();
         assert!(deserialized.value.is_absent());
-        assert_matches!(deserialized.value, AllowMissing::Absent);
+        assert!(matches!(deserialized.value, AllowMissing::Absent));
     }
 }

--- a/tests/events/test_validator.py
+++ b/tests/events/test_validator.py
@@ -11,7 +11,12 @@
 # See the GNU Affero General Public License for more details:
 # <https://www.gnu.org/licenses/agpl-3.0.html>.
 #
-from synapse.api.room_versions import RoomVersions
+from synapse.api.errors import Codes, SynapseError
+from synapse.api.room_versions import (
+    KNOWN_ROOM_VERSIONS,
+    EventFormatVersions,
+    RoomVersions,
+)
 from synapse.events import make_event_from_dict
 from synapse.events.validator import EventValidator
 
@@ -45,3 +50,46 @@ class EventValidatorTestCase(HomeserverTestCase):
         )
 
         EventValidator().validate_new(event, self.hs.config)
+
+    def test_validate_new_rejects_big_depth_for_strict_canonicaljson_rooms(
+        self,
+    ) -> None:
+        """
+        Test that `EventValidator.validate_new` rejects events with integers outside the
+        canonical JSON range, in room versions which enforce it (v6+).
+        """
+        for room_version in KNOWN_ROOM_VERSIONS.values():
+            with self.subTest(room_version=room_version.identifier):
+                event_dict = {
+                    "room_id": "!room:test",
+                    "type": "m.room.message",
+                    "sender": "@alice:example.com",
+                    "content": {
+                        "msgtype": "m.text",
+                        "body": "hello",
+                    },
+                    "auth_events": [],
+                    "prev_events": [],
+                    "hashes": {"sha256": "aGVsbG8="},
+                    "signatures": {},
+                    "depth": 2**53,
+                    "origin_server_ts": 1000,
+                }
+
+                if room_version.event_format == EventFormatVersions.ROOM_V1_V2:
+                    event_dict["event_id"] = "$event:test"
+
+                event = make_event_from_dict(
+                    event_dict,
+                    room_version=room_version,
+                )
+
+                # Check if this room version enforces strict canonical json.
+                if room_version.strict_canonicaljson:
+                    with self.assertRaises(SynapseError) as cm:
+                        EventValidator().validate_new(event, self.hs.config)
+
+                    self.assertEqual(cm.exception.errcode, Codes.BAD_JSON)
+                    self.assertEqual(cm.exception.msg, "JSON integer out of range")
+                else:
+                    EventValidator().validate_new(event, self.hs.config)


### PR DESCRIPTION
Originally reported by @jason-famedly [in #synapse-dev](https://matrix.to/#/!i5D5LLct_DYG-4hQprLzrxdbZ580U9UB6AEgFnk6rZQ/$S9iHS4QHHGtT8aC9cLTbvAecYd-FvUK_lEUQvu5n_4I?via=element.io&via=matrix.org&via=beeper.com).

Previously the `cargo-test` and `cargo-bench` GitHub action jobs weren't running unless Synapse's README was also updated (due to workflow job dependency trees; see the code for an explanation).

After fixing that, there were several test failures that went uncaught in recent PRs. Those are fixed by the final commits.

Commits overview:

- The [REVERT commit](https://github.com/element-hq/synapse/pull/19883/commits/164ebd19d609892c473e81aa3cbdf7d6d7c6571c) shows that the `cargo-test` / `cargo-bench` jobs were skipped, despite rust changes: https://github.com/element-hq/synapse/actions/runs/28236457883/job/83652600210?pr=19883
- The ["Allow `cargo-test`, `cargo-bench` to run ..." commit](https://github.com/element-hq/synapse/pull/19883/commits/42695767be8ebb26978b24fa8de52919f4f86b37) shows that those tests now run: https://github.com/element-hq/synapse/actions/runs/28387764452/job/84107137867?pr=19883
- The remaining commits fix the rust tests, and require some extra review (ideally from @erikjohnston as they apply to his past PRs).
- Finally, we revert the original rust change.
- (finally finally) We bump the nightly rust version to get `cargo-bench` tests to pass. Otherwise we'd get:

    ```
	package `anyhow v1.0.102` cannot be built because it requires rustc 1.68 or newer, while the currently active rustc version is 1.67.0-nightly
	```

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
