### PR TITLE
Add `golangci-lint` to CI.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
       integration: ${{ !startsWith(github.ref, 'refs/pull/') || steps.filter.outputs.integration }}
       linting: ${{ !startsWith(github.ref, 'refs/pull/') || steps.filter.outputs.linting }}
       linting_readme: ${{ !startsWith(github.ref, 'refs/pull/') || steps.filter.outputs.linting_readme }}
+      golangci: ${{ !startsWith(github.ref, 'refs/pull/') || steps.filter.outputs.golangci }}
     steps:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
@@ -77,6 +78,13 @@ jobs:
               - 'mypy.ini'
               - 'pyproject.toml'
               - 'poetry.lock'
+              - '.github/workflows/tests.yml'
+
+            golangci:
+              - 'complement/**/*.go'
+              - 'complement/.golangci.yml'
+              - 'complement/go.mod'
+              - 'complement/go.sum'
               - '.github/workflows/tests.yml'
 
             linting_readme:
@@ -302,6 +310,23 @@ jobs:
 
       - run: cargo fmt --check
 
+  lint-golangci:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.golangci == 'true' }}
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          cache-dependency-path: complement/go.sum
+          go-version-file: complement/go.mod
+
+      - name: Run golangci-lint
+        working-directory: ./complement
+        run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.1 run ./... --max-issues-per-linter=0
+
   # This is to detect issues with the rst file, which can otherwise cause issues
   # when uploading packages to PyPi.
   lint-readme:
@@ -331,6 +356,7 @@ jobs:
       - lint-clippy-nightly
       - lint-rust
       - lint-rustfmt
+      - lint-golangci
       - lint-readme
     runs-on: ubuntu-latest
     steps:
@@ -349,6 +375,7 @@ jobs:
             lint-clippy-nightly
             lint-rust
             lint-rustfmt
+            lint-golangci
             lint-readme
 
   calculate-test-jobs:

--- a/changelog.d/19888.misc
+++ b/changelog.d/19888.misc
@@ -1,0 +1,1 @@
+Add `golangci-lint` to CI.


### PR DESCRIPTION
Fixes: #19857
