### PR TITLE
Change the MSC3814 dehydrated device `/events` endpoint paging to match spec conventions

### DIFF
--- a/changelog.d/19897.misc
+++ b/changelog.d/19897.misc
@@ -1,1 +1,1 @@
-Change the [MSC3814](https://github.com/matrix-org/matrix-spec-proposals/pull/3814) dehydrated device `/events` endpoint to support `from` as per spec conventions.
+Change the [MSC3814](https://github.com/matrix-org/matrix-spec-proposals/pull/3814) dehydrated device `/events` endpoint paging to match spec conventions.

--- a/changelog.d/19897.misc
+++ b/changelog.d/19897.misc
@@ -1,0 +1,1 @@
+Change the [MSC3814](https://github.com/matrix-org/matrix-spec-proposals/pull/3814) dehydrated device `/events` endpoint to support `from` as per spec conventions.

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -23,8 +23,8 @@ import logging
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
+import attr
 from canonicaljson import encode_canonical_json
-from pydantic import StrictStr
 
 from synapse.api.constants import (
     MAX_TO_DEVICE_CONTENT_SIZE,
@@ -54,9 +54,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@attr.s(slots=True, frozen=True, auto_attribs=True)
 class DehydratedEvents:
     events: list[JsonDict]
-    stream_id: StrictStr
+    stream_id: str
     limited: bool
 
 
@@ -434,12 +435,11 @@ class DeviceMessageHandler:
             user_id,
         )
 
-        ret = DehydratedEvents()
-        ret.events = messages
-        ret.stream_id = f"d{stream_id}"
-        ret.limited = stream_id != to_token
-
-        return ret
+        return DehydratedEvents(
+            events=messages,
+            stream_id=f"d{stream_id}",
+            limited=(stream_id != to_token),
+        )
 
 
 def split_device_messages_into_edus(

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -24,6 +24,7 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
 from canonicaljson import encode_canonical_json
+from pydantic import StrictStr
 
 from synapse.api.constants import (
     MAX_TO_DEVICE_CONTENT_SIZE,
@@ -51,6 +52,12 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+class DehydratedEvents:
+    events: list[JsonDict]
+    stream_id: StrictStr
+    limited: bool
 
 
 class DeviceMessageHandler:
@@ -350,7 +357,7 @@ class DeviceMessageHandler:
         device_id: str,
         since_token: str | None,
         limit: int,
-    ) -> JsonDict:
+    ) -> DehydratedEvents:
         """Fetches up to `limit` events sent to `device_id` starting from `since_token`
         and returns the new since token. If there are no more messages, returns an empty
         array.
@@ -361,9 +368,9 @@ class DeviceMessageHandler:
             since_token: stream id to start from when fetching messages
             limit: the number of messages to fetch
         Returns:
-            A dict containing the to-device `messages`, as well as a `next_batch` token that the
-            client can provide in the next call to fetch the next batch of messages. If `next_batch`
-            is missing, there are no more messages to fetch.
+            A DehydratedEvents containing the to-device `events` and `stream_id` token that the
+            client can provide in the next call to fetch the next batch of messages. If there are
+            more messages which will arrive in the next batch, `limited` is True, otherwise False.
         """
 
         user_id = requester.user.to_string()
@@ -427,15 +434,10 @@ class DeviceMessageHandler:
             user_id,
         )
 
-        ret: JsonDict = {
-            "events": messages,
-        }
-
-        # If the stream_id returned from get_messages_for_device equals the to_token we
-        # provided, we've fetched all the available messages. Otherwise, return a
-        # 'next_batch' for the caller to use to request more.
-        if stream_id != to_token:
-            ret["next_batch"] = f"d{stream_id}"
+        ret = DehydratedEvents()
+        ret.events = messages
+        ret.stream_id = f"d{stream_id}"
+        ret.limited = stream_id != to_token
 
         return ret
 

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -431,7 +431,10 @@ class DeviceMessageHandler:
             "events": messages,
         }
 
-        if len(messages) > 0:
+        # If the stream_id returned from get_messages_for_device equals the to_token we
+        # provided, we've fetched all the available messages. Otherwise, return a
+        # 'next_batch' for the caller to use to request more.
+        if stream_id != to_token > 0:
             ret["next_batch"] = f"d{stream_id}"
 
         return ret

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -361,8 +361,9 @@ class DeviceMessageHandler:
             since_token: stream id to start from when fetching messages
             limit: the number of messages to fetch
         Returns:
-            A dict containing the to-device messages, as well as a token that the client
-            can provide in the next call to fetch the next batch of messages
+            A dict containing the to-device `messages`, as well as a `next_batch` token that the
+            client can provide in the next call to fetch the next batch of messages. If `next_batch`
+            is missing, there are no more messages to fetch.
         """
 
         user_id = requester.user.to_string()
@@ -426,10 +427,14 @@ class DeviceMessageHandler:
             user_id,
         )
 
-        return {
+        ret: JsonDict = {
             "events": messages,
-            "next_batch": f"d{stream_id}",
         }
+
+        if len(messages) > 0:
+            ret["next_batch"] = f"d{stream_id}"
+
+        return ret
 
 
 def split_device_messages_into_edus(

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -434,7 +434,7 @@ class DeviceMessageHandler:
         # If the stream_id returned from get_messages_for_device equals the to_token we
         # provided, we've fetched all the available messages. Otherwise, return a
         # 'next_batch' for the caller to use to request more.
-        if stream_id != to_token > 0:
+        if stream_id != to_token:
             ret["next_batch"] = f"d{stream_id}"
 
         return ret

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -265,7 +265,17 @@ class DehydratedDeviceEventsServlet(RestServlet):
             limit=limit,
         )
 
-        return 200, msgs
+        if msgs.limited:
+            msgs_json = {
+                "events": msgs.events,
+                "next_batch": msgs.stream_id,
+            }
+        else:
+            msgs_json = {
+                "events": msgs.events,
+            }
+
+        return 200, msgs_json
 
     class PostBody(RequestBodyModel):
         """
@@ -302,16 +312,14 @@ class DehydratedDeviceEventsServlet(RestServlet):
             limit=limit,
         )
 
-        # For backwards compatibility, the POST API always contains a
-        # next_batch, which points at the latest token if we are finished.
-        # Older clients will hit this API again and stop when we return an
-        # empty list of events.
-        if "next_batch" not in msgs:
-            msgs["next_batch"] = (
-                self.message_handler.event_sources.get_current_token().to_device_key
-            )
+        # For backwards compatibility, we always provide next_batch from the
+        # POST API.
+        msgs_json = {
+            "events": msgs.events,
+            "next_batch": msgs.stream_id,
+        }
 
-        return 200, msgs
+        return 200, msgs_json
 
 
 class DehydratedDeviceV2Servlet(RestServlet):

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -255,13 +255,13 @@ class DehydratedDeviceEventsServlet(RestServlet):
     ) -> tuple[int, JsonDict]:
         requester = await self.auth.get_user_by_req(request)
 
-        next_batch = parse_string(request, "next_batch")
+        since_token = parse_string(request, "from")
         limit = parse_integer(request, "limit", 100)
 
         msgs = await self.message_handler.get_events_for_dehydrated_device(
             requester=requester,
             device_id=device_id,
-            since_token=next_batch,
+            since_token=since_token,
             limit=limit,
         )
 

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -302,6 +302,13 @@ class DehydratedDeviceEventsServlet(RestServlet):
             limit=limit,
         )
 
+        # For backwards compatibility, the POST API always contains a
+        # next_batch, which points at the latest token if we are finished.
+        # Older clients will hit this API again and stop when we return an
+        # empty list of events.
+        if "next_batch" not in msgs:
+            msgs["next_batch"] = self.message_handler.event_sources.get_current_token().to_device_key
+
         return 200, msgs
 
 

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -307,7 +307,9 @@ class DehydratedDeviceEventsServlet(RestServlet):
         # Older clients will hit this API again and stop when we return an
         # empty list of events.
         if "next_batch" not in msgs:
-            msgs["next_batch"] = self.message_handler.event_sources.get_current_token().to_device_key
+            msgs["next_batch"] = (
+                self.message_handler.event_sources.get_current_token().to_device_key
+            )
 
         return 200, msgs
 

--- a/tests/handlers/test_device.py
+++ b/tests/handlers/test_device.py
@@ -572,7 +572,9 @@ class DehydrationTestCase(unittest.HomeserverTestCase):
                 self.message_handler.send_device_message(
                     requester=requester,
                     message_type="test.message",
-                    messages={user_id: {stored_dehydrated_device_id: {"body": f"foo_{i}"}}},
+                    messages={
+                        user_id: {stored_dehydrated_device_id: {"body": f"foo_{i}"}}
+                    },
                 )
             )
         self.pump()

--- a/tests/handlers/test_device.py
+++ b/tests/handlers/test_device.py
@@ -566,17 +566,18 @@ class DehydrationTestCase(unittest.HomeserverTestCase):
             SynapseError,
         )
 
-        # Send a message to the dehydrated device
-        ensureDeferred(
-            self.message_handler.send_device_message(
-                requester=requester,
-                message_type="test.message",
-                messages={user_id: {stored_dehydrated_device_id: {"body": "foo"}}},
+        # Send some messages to the dehydrated device
+        for i in range(12):
+            ensureDeferred(
+                self.message_handler.send_device_message(
+                    requester=requester,
+                    message_type="test.message",
+                    messages={user_id: {stored_dehydrated_device_id: {"body": f"foo_{i}"}}},
+                )
             )
-        )
         self.pump()
 
-        # Fetch the message of the dehydrated device
+        # Fetch the first batch of messages from the dehydrated device
         res = self.get_success(
             self.message_handler.get_events_for_dehydrated_device(
                 requester=requester,
@@ -587,11 +588,13 @@ class DehydrationTestCase(unittest.HomeserverTestCase):
         )
 
         self.assertTrue(len(res["next_batch"]) > 1)
-        self.assertEqual(len(res["events"]), 1)
-        self.assertEqual(res["events"][0]["content"]["body"], "foo")
+        # This batch contains the first 10 events
+        self.assertEqual(len(res["events"]), 10)
+        self.assertEqual(res["events"][0]["content"]["body"], "foo_0")
+        self.assertEqual(res["events"][1]["content"]["body"], "foo_1")
 
-        # Fetch the message of the dehydrated device again, which should return
-        # the same message as it has not been deleted
+        # Fetch the first batch again, which should return the same messages as they
+        # have not been deleted
         res = self.get_success(
             self.message_handler.get_events_for_dehydrated_device(
                 requester=requester,
@@ -601,8 +604,25 @@ class DehydrationTestCase(unittest.HomeserverTestCase):
             )
         )
         self.assertTrue(len(res["next_batch"]) > 1)
-        self.assertEqual(len(res["events"]), 1)
-        self.assertEqual(res["events"][0]["content"]["body"], "foo")
+        self.assertEqual(len(res["events"]), 10)
+        self.assertEqual(res["events"][0]["content"]["body"], "foo_0")
+        self.assertEqual(res["events"][7]["content"]["body"], "foo_7")
+
+        # Fetch the next batch
+        res = self.get_success(
+            self.message_handler.get_events_for_dehydrated_device(
+                requester=requester,
+                device_id=stored_dehydrated_device_id,
+                since_token=res["next_batch"],
+                limit=10,
+            )
+        )
+        # This is the last batch, so there is no "next_batch"
+        self.assertTrue("next_batch" not in res)
+        # This batch contains the last 2 events
+        self.assertEqual(len(res["events"]), 2)
+        self.assertEqual(res["events"][0]["content"]["body"], "foo_10")
+        self.assertEqual(res["events"][1]["content"]["body"], "foo_11")
 
 
 @patch("synapse.crypto.keyring.Keyring.process_request", AsyncMock(return_value=None))

--- a/tests/handlers/test_device.py
+++ b/tests/handlers/test_device.py
@@ -589,11 +589,11 @@ class DehydrationTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        self.assertTrue(len(res["next_batch"]) > 1)
+        self.assertTrue(res.limited)
         # This batch contains the first 10 events
-        self.assertEqual(len(res["events"]), 10)
-        self.assertEqual(res["events"][0]["content"]["body"], "foo_0")
-        self.assertEqual(res["events"][1]["content"]["body"], "foo_1")
+        self.assertEqual(len(res.events), 10)
+        self.assertEqual(res.events[0]["content"]["body"], "foo_0")
+        self.assertEqual(res.events[1]["content"]["body"], "foo_1")
 
         # Fetch the first batch again, which should return the same messages as they
         # have not been deleted
@@ -605,26 +605,26 @@ class DehydrationTestCase(unittest.HomeserverTestCase):
                 limit=10,
             )
         )
-        self.assertTrue(len(res["next_batch"]) > 1)
-        self.assertEqual(len(res["events"]), 10)
-        self.assertEqual(res["events"][0]["content"]["body"], "foo_0")
-        self.assertEqual(res["events"][7]["content"]["body"], "foo_7")
+        self.assertTrue(res.limited)
+        self.assertEqual(len(res.events), 10)
+        self.assertEqual(res.events[0]["content"]["body"], "foo_0")
+        self.assertEqual(res.events[7]["content"]["body"], "foo_7")
 
         # Fetch the next batch
         res = self.get_success(
             self.message_handler.get_events_for_dehydrated_device(
                 requester=requester,
                 device_id=stored_dehydrated_device_id,
-                since_token=res["next_batch"],
+                since_token=res.stream_id,
                 limit=10,
             )
         )
-        # This is the last batch, so there is no "next_batch"
-        self.assertTrue("next_batch" not in res)
+        # This is the last batch
+        self.assertFalse(res.limited)
         # This batch contains the last 2 events
-        self.assertEqual(len(res["events"]), 2)
-        self.assertEqual(res["events"][0]["content"]["body"], "foo_10")
-        self.assertEqual(res["events"][1]["content"]["body"], "foo_11")
+        self.assertEqual(len(res.events), 2)
+        self.assertEqual(res.events[0]["content"]["body"], "foo_10")
+        self.assertEqual(res.events[1]["content"]["body"], "foo_11")
 
 
 @patch("synapse.crypto.keyring.Keyring.process_request", AsyncMock(return_value=None))

--- a/tests/rest/client/test_devices.py
+++ b/tests/rest/client/test_devices.py
@@ -213,7 +213,7 @@ class DehydratedDeviceTestCase(unittest.HomeserverTestCase):
         requester = create_requester(user, device_id=new_device_id)
 
         # Send enough messages to the dehydrated device that we need 2 batches
-        for _ in range(0, 110):
+        for _ in range(110):
             ensureDeferred(
                 self.message_handler.send_device_message(
                     requester=requester,

--- a/tests/rest/client/test_devices.py
+++ b/tests/rest/client/test_devices.py
@@ -248,7 +248,7 @@ class DehydratedDeviceTestCase(unittest.HomeserverTestCase):
         # messages so we should receive an empty array
         channel = self.make_request(
             "GET",
-            f"_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/{device_id}/events?next_batch={next_batch_token}",
+            f"_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/{device_id}/events?from={next_batch_token}",
             access_token=token,
             shorthand=False,
         )

--- a/tests/rest/client/test_devices.py
+++ b/tests/rest/client/test_devices.py
@@ -283,6 +283,207 @@ class DehydratedDeviceTestCase(unittest.HomeserverTestCase):
         self.assertEqual(channel.code, 401)
 
     @unittest.override_config({"experimental_features": {"msc3814_enabled": True}})
+    def test_dehydrate_msc3814_legacy_post(self) -> None:
+        """
+        This tests the legacy POST API that was originally used in MSC3814.
+        """
+
+        user = self.register_user("mikey", "pass")
+        token = self.login(user, "pass", device_id="device1")
+        content: JsonDict = {
+            "device_data": {
+                "algorithm": "m.dehydration.v1.olm",
+            },
+            "device_id": "device1",
+            "initial_device_display_name": "foo bar",
+            "device_keys": {
+                "user_id": "@mikey:test",
+                "device_id": "device1",
+                "valid_until_ts": "80",
+                "algorithms": [
+                    "m.olm.curve25519-aes-sha2",
+                ],
+                "keys": {
+                    "<algorithm>:<device_id>": "<key_base64>",
+                },
+                "signatures": {
+                    "<user_id>": {"<algorithm>:<device_id>": "<signature_base64>"}
+                },
+            },
+            "fallback_keys": {
+                "alg1:device1": "f4llb4ckk3y",
+                "signed_<algorithm>:<device_id>": {
+                    "fallback": "true",
+                    "key": "f4llb4ckk3y",
+                    "signatures": {
+                        "<user_id>": {"<algorithm>:<device_id>": "<key_base64>"}
+                    },
+                },
+            },
+            "one_time_keys": {"alg1:k1": "0net1m3k3y"},
+        }
+        channel = self.make_request(
+            "PUT",
+            "_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device",
+            content=content,
+            access_token=token,
+            shorthand=False,
+        )
+        self.assertEqual(channel.code, 200)
+        device_id = channel.json_body.get("device_id")
+        assert device_id is not None
+        self.assertIsInstance(device_id, str)
+        self.assertEqual("device1", device_id)
+
+        # test that we can now GET the dehydrated device info
+        channel = self.make_request(
+            "GET",
+            "_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device",
+            access_token=token,
+            shorthand=False,
+        )
+        self.assertEqual(channel.code, 200)
+        returned_device_id = channel.json_body.get("device_id")
+        self.assertEqual(returned_device_id, device_id)
+        device_data = channel.json_body.get("device_data")
+        expected_device_data = {
+            "algorithm": "m.dehydration.v1.olm",
+        }
+        self.assertEqual(device_data, expected_device_data)
+
+        # test that the keys are correctly uploaded
+        channel = self.make_request(
+            "POST",
+            "/_matrix/client/r0/keys/query",
+            {
+                "device_keys": {
+                    user: ["device1"],
+                },
+            },
+            token,
+        )
+        self.assertEqual(channel.code, 200)
+        self.assertEqual(
+            channel.json_body["device_keys"][user][device_id]["keys"],
+            content["device_keys"]["keys"],
+        )
+        # first claim should return the onetime key we uploaded
+        res = self.get_success(
+            self.hs.get_e2e_keys_handler().claim_one_time_keys(
+                {user: {device_id: {"alg1": 1}}},
+                UserID.from_string(user),
+                timeout=None,
+                always_include_fallback_keys=False,
+            )
+        )
+        self.assertEqual(
+            res,
+            {
+                "failures": {},
+                "one_time_keys": {user: {device_id: {"alg1:k1": "0net1m3k3y"}}},
+            },
+        )
+        # second claim should return fallback key
+        res2 = self.get_success(
+            self.hs.get_e2e_keys_handler().claim_one_time_keys(
+                {user: {device_id: {"alg1": 1}}},
+                UserID.from_string(user),
+                timeout=None,
+                always_include_fallback_keys=False,
+            )
+        )
+        self.assertEqual(
+            res2,
+            {
+                "failures": {},
+                "one_time_keys": {user: {device_id: {"alg1:device1": "f4llb4ckk3y"}}},
+            },
+        )
+
+        # create another device for the user
+        (
+            new_device_id,
+            _,
+            _,
+            _,
+        ) = self.get_success(
+            self.registration.register_device(
+                user_id=user,
+                device_id=None,
+                initial_display_name="new device",
+            )
+        )
+        requester = create_requester(user, device_id=new_device_id)
+
+        # Send enough messages to the dehydrated device that we need 2 batches
+        for _ in range(110):
+            ensureDeferred(
+                self.message_handler.send_device_message(
+                    requester=requester,
+                    message_type="test.message",
+                    messages={user: {device_id: {"body": "test_message"}}},
+                )
+            )
+        self.pump()
+
+        # make sure we can fetch the first batch with our dehydrated device id
+        channel = self.make_request(
+            "POST",
+            f"_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/{device_id}/events",
+            content={},
+            access_token=token,
+            shorthand=False,
+        )
+        self.assertEqual(channel.code, 200)
+        expected_content = {"body": "test_message"}
+        self.assertEqual(channel.json_body["events"][0]["content"], expected_content)
+        self.assertEqual(len(channel.json_body["events"]), 100)
+
+        # fetch the same messages again to prove that the messages were not deleted
+        channel = self.make_request(
+            "POST",
+            f"_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/{device_id}/events",
+            content={},
+            access_token=token,
+            shorthand=False,
+        )
+        self.assertEqual(channel.code, 200)
+        self.assertEqual(channel.json_body["events"][0]["content"], expected_content)
+        self.assertEqual(len(channel.json_body["events"]), 100)
+        next_batch_token = channel.json_body.get("next_batch")
+
+        # There is a next_batch token
+        self.assertNotEqual(next_batch_token, None)
+
+        # make sure fetching messages with next batch token works
+        channel = self.make_request(
+            "POST",
+            f"_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/{device_id}/events",
+            content={"next_batch": next_batch_token},
+            access_token=token,
+            shorthand=False,
+        )
+        self.assertEqual(channel.code, 200)
+        self.assertEqual(channel.json_body["events"][0]["content"], expected_content)
+        self.assertEqual(len(channel.json_body["events"]), 10)
+        next_batch_token = channel.json_body.get("next_batch")
+
+        # There is a next_batch token (even though there are no more messages - this is
+        # the way the legacy API works)
+        self.assertNotEqual(next_batch_token, None)
+
+        # Fetch the next batch - it should be empty, indicating we should stop polling
+        channel = self.make_request(
+            "POST",
+            f"_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/{device_id}/events",
+            content={"next_batch": next_batch_token},
+            access_token=token,
+            shorthand=False,
+        )
+        self.assertEqual(channel.code, 200)
+        self.assertEqual(len(channel.json_body["events"]), 0)
+
+    @unittest.override_config({"experimental_features": {"msc3814_enabled": True}})
     def test_msc3814_dehydrated_device_delete_works(self) -> None:
         user = self.register_user("mikey", "pass")
         token = self.login(user, "pass", device_id="device1")

--- a/tests/rest/client/test_devices.py
+++ b/tests/rest/client/test_devices.py
@@ -212,17 +212,18 @@ class DehydratedDeviceTestCase(unittest.HomeserverTestCase):
         )
         requester = create_requester(user, device_id=new_device_id)
 
-        # Send a message to the dehydrated device
-        ensureDeferred(
-            self.message_handler.send_device_message(
-                requester=requester,
-                message_type="test.message",
-                messages={user: {device_id: {"body": "test_message"}}},
+        # Send enough messages to the dehydrated device that we need 2 batches
+        for _ in range(0, 110):
+            ensureDeferred(
+                self.message_handler.send_device_message(
+                    requester=requester,
+                    message_type="test.message",
+                    messages={user: {device_id: {"body": "test_message"}}},
+                )
             )
-        )
         self.pump()
 
-        # make sure we can fetch the message with our dehydrated device id
+        # make sure we can fetch the first batch with our dehydrated device id
         channel = self.make_request(
             "GET",
             f"_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/{device_id}/events",
@@ -232,8 +233,9 @@ class DehydratedDeviceTestCase(unittest.HomeserverTestCase):
         self.assertEqual(channel.code, 200)
         expected_content = {"body": "test_message"}
         self.assertEqual(channel.json_body["events"][0]["content"], expected_content)
+        self.assertEqual(len(channel.json_body["events"]), 100)
 
-        # fetch messages again and make sure that the message was not deleted
+        # fetch the same messages again to prove that the messages were not deleted
         channel = self.make_request(
             "GET",
             f"_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/{device_id}/events",
@@ -242,10 +244,13 @@ class DehydratedDeviceTestCase(unittest.HomeserverTestCase):
         )
         self.assertEqual(channel.code, 200)
         self.assertEqual(channel.json_body["events"][0]["content"], expected_content)
+        self.assertEqual(len(channel.json_body["events"]), 100)
         next_batch_token = channel.json_body.get("next_batch")
 
-        # make sure fetching messages with next batch token works - there are no unfetched
-        # messages so we should receive an empty array, and there should be no `next_batch` in the response.
+        # There are more messages to come
+        self.assertNotEqual(next_batch_token, None)
+
+        # make sure fetching messages with next batch token works
         channel = self.make_request(
             "GET",
             f"_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/{device_id}/events?from={next_batch_token}",
@@ -253,7 +258,10 @@ class DehydratedDeviceTestCase(unittest.HomeserverTestCase):
             shorthand=False,
         )
         self.assertEqual(channel.code, 200)
-        self.assertEqual(channel.json_body["events"], [])
+        self.assertEqual(channel.json_body["events"][0]["content"], expected_content)
+        self.assertEqual(len(channel.json_body["events"]), 10)
+
+        # Now, there are no more messages
         self.assertNotIn("next_batch", channel.json_body)
 
         # make sure we can delete the dehydrated device

--- a/tests/rest/client/test_devices.py
+++ b/tests/rest/client/test_devices.py
@@ -254,6 +254,7 @@ class DehydratedDeviceTestCase(unittest.HomeserverTestCase):
         )
         self.assertEqual(channel.code, 200)
         self.assertEqual(channel.json_body["events"], [])
+        self.assertNotIn("next_batch", channel.json_body)
 
         # make sure we can delete the dehydrated device
         channel = self.make_request(

--- a/tests/rest/client/test_devices.py
+++ b/tests/rest/client/test_devices.py
@@ -245,7 +245,7 @@ class DehydratedDeviceTestCase(unittest.HomeserverTestCase):
         next_batch_token = channel.json_body.get("next_batch")
 
         # make sure fetching messages with next batch token works - there are no unfetched
-        # messages so we should receive an empty array
+        # messages so we should receive an empty array, and there should be no `next_batch` in the response.
         channel = self.make_request(
             "GET",
             f"_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/{device_id}/events?from={next_batch_token}",


### PR DESCRIPTION
To match [the spec requirements for pagination](https://spec.matrix.org/v1.9/appendices/#pagination):

* rename the query parameter of `/org.matrix.msc3814.v1/dehydrated_device/[device_id]/events` to `from`, and
* omit `next_batch` from the response content if there are no more events to fetch

This matches [the changes that are coming in MSC3814](https://github.com/matrix-org/matrix-spec-proposals/pull/3814/files#r1540896531).

The previous change https://github.com/element-hq/synapse/pull/19896 kept the old POST API to support old clients. This preserves that compatibility, so the POST API still works how it used to.

Depends on https://github.com/element-hq/synapse/pull/19896
Part of https://github.com/element-hq/element-meta/issues/2799


### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
