### PR TITLE
Fix flaky 3PID inhibit error unit tests

### DIFF
--- a/changelog.d/19913.misc
+++ b/changelog.d/19913.misc
@@ -1,0 +1,1 @@
+Fix a flake in 3PID inhibit error unit tests, causing occasional failures in CI.

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -325,7 +325,13 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
         email = "test@example.com"
 
         client_secret = "foobar"
-        session_id = self._request_token(email, client_secret)
+        session_id = self._request_token(
+            email,
+            client_secret,
+            # The endpoint intentionally adds up to 1000ms of jitter to avoid
+            # leaking whether the email address is bound to an account.
+            timeout_ms=3000,
+        )
 
         self.assertIsNotNone(session_id)
 
@@ -364,6 +370,7 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
         client_secret: str,
         ip: str = "127.0.0.1",
         next_link: str | None = None,
+        timeout_ms: int = 1000,
     ) -> str:
         body = {"client_secret": client_secret, "email": email, "send_attempt": 1}
         if next_link is not None:
@@ -373,6 +380,7 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
             b"account/password/email/requestToken",
             body,
             client_ip=ip,
+            timeout_ms=timeout_ms,
         )
 
         if channel.code != 200:

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -753,6 +753,9 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             "POST",
             b"register/email/requestToken",
             {"client_secret": "foobar", "email": email, "send_attempt": 1},
+            # The endpoint intentionally adds up to 1000ms of jitter to avoid
+            # leaking whether the email address is already bound to an account.
+            timeout_ms=3000,
         )
         self.assertEqual(200, channel.code, channel.result)
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -371,6 +371,7 @@ def make_request(
     await_result: bool = True,
     custom_headers: Iterable[CustomHeaderType] | None = None,
     client_ip: str = "127.0.0.1",
+    timeout_ms: int = 1000,
 ) -> FakeChannel:
     """
     Make a web request using the given method, path and content, and render it
@@ -399,6 +400,8 @@ def make_request(
         custom_headers: (name, value) pairs to add as request headers
         client_ip: The IP to use as the requesting IP. Useful for testing
             ratelimiting.
+        timeout_ms: if `await_result` is `True`, the amount of time to wait on
+            the request before timing out. Ignored otherwise.
 
     Returns:
         channel
@@ -483,7 +486,7 @@ def make_request(
     req.requestReceived(method, path, b"1.1")
 
     if await_result:
-        channel.await_result()
+        channel.await_result(timeout_ms=timeout_ms)
 
     return channel
 

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -571,6 +571,7 @@ class HomeserverTestCase(TestCase):
         await_result: bool = True,
         custom_headers: Iterable[CustomHeaderType] | None = None,
         client_ip: str = "127.0.0.1",
+        timeout_ms: int = 1000,
     ) -> FakeChannel:
         """
         Create a SynapseRequest at the path using the method and containing the
@@ -599,6 +600,8 @@ class HomeserverTestCase(TestCase):
 
             client_ip: The IP to use as the requesting IP. Useful for testing
                 ratelimiting.
+            timeout_ms: if `await_result` is `True`, the amount of time to wait on
+                the request before timing out. Ignored otherwise.
 
         Returns:
             The FakeChannel object which stores the result of the request.
@@ -618,6 +621,7 @@ class HomeserverTestCase(TestCase):
             await_result,
             custom_headers,
             client_ip,
+            timeout_ms,
         )
 
     def setup_test_homeserver(


### PR DESCRIPTION
Fixes flakes in the following unit tests:

- `tests.rest.client.test_account.PasswordResetTestCase.test_password_reset_bad_email_inhibit_error`
- `tests.rest.client.test_register.RegisterRestServletTestCase.test_request_token_existing_email_inhibit_error`

These tests could flake as the endpoints would intentionally wait for 100-1000ms in order to prevent a timing attack allowing one to deduce whether an email was already registered.

The tests were only waiting 1000ms for the endpoint to return, so a randomly-chosen jitter any higher than ~900ms would cause the test to fail.

---

I'm unsure why this started failing recently, as the jitter has been in place for years. There was [a recent change](https://github.com/element-hq/synapse/pull/19229) with the `Duration` work - we used `randrandom.randint(1, 10) / 10` and now `Duration(milliseconds=random.randint(100, 1000))`, but the math is technically equivalent.


### Dev notes

There are multiple places we add jitter in both `synapse/rest/client/account.py` and `synapse/rest/client/register.py`

https://github.com/element-hq/synapse/blob/963e486a70fa841f89dc7c84d551e29e3335937d/synapse/rest/client/account.py#L125-L131

https://github.com/element-hq/synapse/blob/963e486a70fa841f89dc7c84d551e29e3335937d/synapse/rest/client/register.py#L157-L165

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
