### PR TITLE
Revert "Fix flaky 3PID inhibit error unit tests"

### DIFF
--- a/changelog.d/19913.misc
+++ b/changelog.d/19913.misc
@@ -1,1 +1,0 @@
-Fix a flake in 3PID inhibit error unit tests, causing occasional failures in CI.

--- a/changelog.d/19916.misc
+++ b/changelog.d/19916.misc
@@ -1,0 +1,1 @@
+Add note to 3PID email token request unit tests that the endpoint being tested can have an expected, artificial delay of up to 1s.

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -325,13 +325,7 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
         email = "test@example.com"
 
         client_secret = "foobar"
-        session_id = self._request_token(
-            email,
-            client_secret,
-            # The endpoint intentionally adds up to 1000ms of jitter to avoid
-            # leaking whether the email address is bound to an account.
-            timeout_ms=3000,
-        )
+        session_id = self._request_token(email, client_secret)
 
         self.assertIsNotNone(session_id)
 
@@ -370,7 +364,6 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
         client_secret: str,
         ip: str = "127.0.0.1",
         next_link: str | None = None,
-        timeout_ms: int = 1000,
     ) -> str:
         body = {"client_secret": client_secret, "email": email, "send_attempt": 1}
         if next_link is not None:
@@ -380,7 +373,6 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
             b"account/password/email/requestToken",
             body,
             client_ip=ip,
-            timeout_ms=timeout_ms,
         )
 
         if channel.code != 200:

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -325,6 +325,12 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
         email = "test@example.com"
 
         client_secret = "foobar"
+
+        # Note: The endpoint intentionally adds up to 1000ms of jitter to avoid
+        # leaking whether the email address is bound to an account.
+        #
+        # This should be handled by `await_result` underneath, which has a
+        # 1000ms timeout.
         session_id = self._request_token(email, client_secret)
 
         self.assertIsNotNone(session_id)

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -326,11 +326,6 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
 
         client_secret = "foobar"
 
-        # Note: The endpoint intentionally adds up to 1000ms of jitter to avoid
-        # leaking whether the email address is bound to an account.
-        #
-        # This should be handled by `await_result` underneath, which has a
-        # 1000ms timeout.
         session_id = self._request_token(email, client_secret)
 
         self.assertIsNotNone(session_id)
@@ -374,12 +369,17 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
         body = {"client_secret": client_secret, "email": email, "send_attempt": 1}
         if next_link is not None:
             body["next_link"] = next_link
+
         channel = self.make_request(
             "POST",
             b"account/password/email/requestToken",
             body,
             client_ip=ip,
+            await_result=False,
         )
+        # Note: The endpoint intentionally adds up to 1000ms of jitter to avoid
+        # leaking whether the email address is bound to an account.
+        channel.await_result(timeout_ms=1000)
 
         if channel.code != 200:
             raise HttpResponseException(

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -749,16 +749,15 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        # Note: The endpoint intentionally adds up to 1000ms of jitter to avoid
-        # leaking whether the email address is bound to an account.
-        #
-        # This should be handled by `await_result` underneath, which has a
-        # 1000ms timeout.
         channel = self.make_request(
             "POST",
             b"register/email/requestToken",
             {"client_secret": "foobar", "email": email, "send_attempt": 1},
+            await_result=False,
         )
+        # Note: The endpoint intentionally adds up to 1000ms of jitter to avoid
+        # leaking whether the email address is bound to an account.
+        channel.await_result(timeout_ms=1000)
         self.assertEqual(200, channel.code, channel.result)
 
         self.assertIsNotNone(channel.json_body.get("sid"))

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -749,6 +749,11 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             )
         )
 
+        # Note: The endpoint intentionally adds up to 1000ms of jitter to avoid
+        # leaking whether the email address is bound to an account.
+        #
+        # This should be handled by `await_result` underneath, which has a
+        # 1000ms timeout.
         channel = self.make_request(
             "POST",
             b"register/email/requestToken",

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -753,9 +753,6 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             "POST",
             b"register/email/requestToken",
             {"client_secret": "foobar", "email": email, "send_attempt": 1},
-            # The endpoint intentionally adds up to 1000ms of jitter to avoid
-            # leaking whether the email address is already bound to an account.
-            timeout_ms=3000,
         )
         self.assertEqual(200, channel.code, channel.result)
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -459,7 +459,6 @@ def make_request(
     await_result: bool = True,
     custom_headers: Iterable[CustomHeaderType] | None = None,
     client_ip: str = "127.0.0.1",
-    timeout_ms: int = 1000,
 ) -> FakeChannel:
     """
     Make a web request using the given method, path and content, and render it
@@ -488,8 +487,6 @@ def make_request(
         custom_headers: (name, value) pairs to add as request headers
         client_ip: The IP to use as the requesting IP. Useful for testing
             ratelimiting.
-        timeout_ms: if `await_result` is `True`, the amount of time to wait on
-            the request before timing out. Ignored otherwise.
 
     Returns:
         channel
@@ -574,7 +571,7 @@ def make_request(
     req.requestReceived(method, path, b"1.1")
 
     if await_result:
-        channel.await_result(timeout_ms=timeout_ms)
+        channel.await_result()
 
     return channel
 

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -571,7 +571,6 @@ class HomeserverTestCase(TestCase):
         await_result: bool = True,
         custom_headers: Iterable[CustomHeaderType] | None = None,
         client_ip: str = "127.0.0.1",
-        timeout_ms: int = 1000,
     ) -> FakeChannel:
         """
         Create a SynapseRequest at the path using the method and containing the
@@ -600,8 +599,6 @@ class HomeserverTestCase(TestCase):
 
             client_ip: The IP to use as the requesting IP. Useful for testing
                 ratelimiting.
-            timeout_ms: if `await_result` is `True`, the amount of time to wait on
-                the request before timing out. Ignored otherwise.
 
         Returns:
             The FakeChannel object which stores the result of the request.
@@ -621,7 +618,6 @@ class HomeserverTestCase(TestCase):
             await_result,
             custom_headers,
             client_ip,
-            timeout_ms,
         )
 
     def setup_test_homeserver(


### PR DESCRIPTION
This PR reverts element-hq/synapse#19913, but leaves behind the comments in the tests noting that the endpoints have jitter.

See https://github.com/element-hq/synapse/pull/19913#discussion_r3532415025 as for why. Kudos to @MadLittleMods for digging into the issue properly and providing an elegant fix in https://github.com/element-hq/synapse/pull/19879!

---

https://github.com/element-hq/synapse/pull/19916/changes/928716e76af4887d8e66ad645d2f4bc6bf672e29 is the only new code here.