### PR TITLE
Add index to `sliding_sync_connection_lazy_members` on `connection_position`

### DIFF
--- a/changelog.d/19923.misc
+++ b/changelog.d/19923.misc
@@ -1,0 +1,1 @@
+Add an index to `sliding_sync_connection_lazy_members` to speed up deleting old sliding sync connection positions.

--- a/synapse/storage/databases/main/sliding_sync.py
+++ b/synapse/storage/databases/main/sliding_sync.py
@@ -104,6 +104,14 @@ class SlidingSyncStore(SQLBaseStore):
             where_clause="last_used_ts IS NOT NULL",
         )
 
+        self.db_pool.updates.register_background_index_update(
+            update_name="sliding_sync_connection_lazy_members_conn_pos_idx",
+            index_name="sliding_sync_connection_lazy_members_conn_pos_idx",
+            table="sliding_sync_connection_lazy_members",
+            columns=("connection_position",),
+            where_clause="connection_position IS NOT NULL",
+        )
+
         if self.hs.config.worker.run_background_tasks:
             self.clock.looping_call(
                 self.delete_old_sliding_sync_connections,

--- a/synapse/storage/schema/main/delta/94/07_sliding_sync_lazy_members_position_index.sql
+++ b/synapse/storage/schema/main/delta/94/07_sliding_sync_lazy_members_position_index.sql
@@ -1,0 +1,24 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2026 Element Creations Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+
+-- Add an index on `sliding_sync_connection_lazy_members(connection_position)`
+-- so that deleting from `sliding_sync_connection_positions` is efficient. This
+-- is needed because `connection_position` has an `ON DELETE CASCADE` foreign key
+-- constraint, and without this index Postgres has to sequentially scan the whole
+-- table for each deleted position.
+--
+-- This is a partial index as we only ever need to find rows with a non-NULL
+-- `connection_position`.
+INSERT INTO background_updates (ordering, update_name, progress_json) VALUES
+    (9407, 'sliding_sync_connection_lazy_members_conn_pos_idx', '{}');


### PR DESCRIPTION
This speeds up the cascading delete from `sliding_sync_connection_positions`, which without an index on `connection_position` requires a sequential scan of the whole table for each deleted position.