### PR TITLE
MSC4140: support getting a single delayed event 

### DIFF
--- a/changelog.d/19926.feature
+++ b/changelog.d/19926.feature
@@ -1,0 +1,1 @@
+[MSC4140: Cancellable delayed events](https://github.com/matrix-org/matrix-spec-proposals/pull/4140): Add an endpoint for getting a single delayed event.

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -530,6 +530,19 @@ class DelayedEventsHandler:
         else:
             self._next_delayed_event_call.reset(delay_duration.as_secs())
 
+    async def get_for_user(self, requester: Requester, delay_id: str) -> JsonDict:
+        """
+        Return the specified pending delayed event requested by the given user.
+
+        Raises:
+            NotFoundError: if no matching delayed event could be found.
+        """
+        await self._delayed_event_mgmt_ratelimiter.ratelimit(requester)
+        return await self._store.get_delayed_event_for_user(
+            delay_id,
+            requester.user.localpart,
+        )
+
     async def get_all_for_user(self, requester: Requester) -> list[JsonDict]:
         """Return all pending delayed events requested by the given user."""
         await self._delayed_event_mgmt_ratelimiter.ratelimit(requester)

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -30,6 +30,7 @@ from synapse.replication.http.delayed_events import (
 )
 from synapse.storage.databases.main.delayed_events import (
     DelayedEventDetails,
+    DelayedEventResponse,
     EventType,
     StateKey,
     Timestamp,
@@ -530,7 +531,9 @@ class DelayedEventsHandler:
         else:
             self._next_delayed_event_call.reset(delay_duration.as_secs())
 
-    async def get_for_user(self, requester: Requester, delay_id: str) -> JsonDict:
+    async def get_for_user(
+        self, requester: Requester, delay_id: str
+    ) -> DelayedEventResponse:
         """
         Return the specified pending delayed event requested by the given user.
 
@@ -543,7 +546,9 @@ class DelayedEventsHandler:
             requester.user.localpart,
         )
 
-    async def get_all_for_user(self, requester: Requester) -> list[JsonDict]:
+    async def get_all_for_user(
+        self, requester: Requester
+    ) -> list[DelayedEventResponse]:
         """Return all pending delayed events requested by the given user."""
         await self._delayed_event_mgmt_ratelimiter.ratelimit(requester)
         return await self._store.get_all_delayed_events_for_user(

--- a/synapse/handlers/delayed_events.py
+++ b/synapse/handlers/delayed_events.py
@@ -31,6 +31,7 @@ from synapse.replication.http.delayed_events import (
 from synapse.storage.databases.main.delayed_events import (
     DelayedEventDetails,
     DelayedEventResponse,
+    DelayedEventResponseLegacyCompat,
     EventType,
     StateKey,
     Timestamp,
@@ -548,8 +549,13 @@ class DelayedEventsHandler:
 
     async def get_all_for_user(
         self, requester: Requester
-    ) -> list[DelayedEventResponse]:
-        """Return all pending delayed events requested by the given user."""
+    ) -> list[DelayedEventResponseLegacyCompat]:
+        """
+        Return all pending delayed events owned by the given user.
+        Includes fields from earlier revisions of MSC4140 for
+        compatibility with clients that still expect them.
+        """
+        # TODO: Remove legacy fields once stable
         await self._delayed_event_mgmt_ratelimiter.ratelimit(requester)
         return await self._store.get_all_delayed_events_for_user(
             requester.user.localpart

--- a/synapse/rest/client/delayed_events.py
+++ b/synapse/rest/client/delayed_events.py
@@ -134,6 +134,25 @@ class SendDelayedEventServlet(RestServlet):
         return 200, {}
 
 
+class DelayedEventServlet(RestServlet):
+    PATTERNS = client_patterns(
+        r"/org\.matrix\.msc4140/delayed_events/(?P<delay_id>[^/]+)$",
+        releases=(),
+    )
+    CATEGORY = "Delayed event management requests"
+
+    def __init__(self, hs: "HomeServer"):
+        super().__init__()
+        self.auth = hs.get_auth()
+        self.delayed_events_handler = hs.get_delayed_events_handler()
+
+    async def on_GET(
+        self, request: SynapseRequest, delay_id: str
+    ) -> tuple[int, JsonDict]:
+        requester = await self.auth.get_user_by_req(request)
+        return 200, await self.delayed_events_handler.get_for_user(requester, delay_id)
+
+
 class DelayedEventsServlet(RestServlet):
     PATTERNS = client_patterns(
         r"/org\.matrix\.msc4140/delayed_events$",
@@ -162,4 +181,5 @@ def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:
         CancelDelayedEventServlet(hs).register(http_server)
         SendDelayedEventServlet(hs).register(http_server)
     RestartDelayedEventServlet(hs).register(http_server)
+    DelayedEventServlet(hs).register(http_server)
     DelayedEventsServlet(hs).register(http_server)

--- a/synapse/rest/client/delayed_events.py
+++ b/synapse/rest/client/delayed_events.py
@@ -150,7 +150,10 @@ class DelayedEventServlet(RestServlet):
         self, request: SynapseRequest, delay_id: str
     ) -> tuple[int, JsonDict]:
         requester = await self.auth.get_user_by_req(request)
-        return 200, await self.delayed_events_handler.get_for_user(requester, delay_id)
+        delayed_event = await self.delayed_events_handler.get_for_user(
+            requester, delay_id
+        )
+        return 200, delayed_event.asdict()
 
 
 class DelayedEventsServlet(RestServlet):
@@ -169,9 +172,11 @@ class DelayedEventsServlet(RestServlet):
         requester = await self.auth.get_user_by_req(request)
         # TODO: Support Pagination stream API ("from" query parameter)
         delayed_events = await self.delayed_events_handler.get_all_for_user(requester)
-
-        ret = {"delayed_events": delayed_events}
-        return 200, ret
+        return 200, {
+            "delayed_events": [
+                delayed_event.asdict() for delayed_event in delayed_events
+            ]
+        }
 
 
 def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:

--- a/synapse/storage/databases/main/delayed_events.py
+++ b/synapse/storage/databases/main/delayed_events.py
@@ -225,6 +225,39 @@ class DelayedEventsStore(SQLBaseStore):
             _get_count_of_delayed_events,
         )
 
+    async def get_delayed_event_for_user(
+        self,
+        delay_id: str,
+        user_localpart: str,
+    ) -> JsonDict:
+        """
+        Returns the specified pending delayed event owned by the given user.
+
+        Raises:
+            NotFoundError: if there is no matching delayed event.
+        """
+        row = await self.db_pool.simple_select_one(
+            table="delayed_events",
+            keyvalues={
+                "delay_id": delay_id,
+                "user_localpart": user_localpart,
+                "is_processed": False,
+            },
+            retcols=(
+                "room_id",
+                "event_type",
+                "state_key",
+                "delay",
+                "send_ts",
+                "content",
+            ),
+            allow_none=True,
+            desc="get_delayed_event_for_user",
+        )
+        if row is None:
+            raise NotFoundError("Delayed event not found")
+        return _row_to_delayed_event_dict((delay_id, *row))
+
     async def get_all_delayed_events_for_user(
         self,
         user_localpart: str,
@@ -248,18 +281,7 @@ class DelayedEventsStore(SQLBaseStore):
             """,
             user_localpart,
         )
-        return [
-            {
-                "delay_id": DelayID(row[0]),
-                "room_id": str(RoomID.from_string(row[1])),
-                "type": EventType(row[2]),
-                **({"state_key": StateKey(row[3])} if row[3] is not None else {}),
-                "delay": Delay(row[4]),
-                "running_since": Timestamp(row[5] - row[4]),
-                "content": db_to_json(row[6]),
-            }
-            for row in rows
-        ]
+        return [_row_to_delayed_event_dict(row) for row in rows]
 
     async def process_timeout_delayed_events(
         self, current_ts: Timestamp, reprocess_events: bool = False
@@ -571,6 +593,18 @@ class DelayedEventsStore(SQLBaseStore):
             allow_none=True,
         )
         return Timestamp(result) if result is not None else None
+
+
+def _row_to_delayed_event_dict(row: tuple) -> JsonDict:
+    return {
+        "delay_id": DelayID(row[0]),
+        "room_id": str(RoomID.from_string(row[1])),
+        "type": EventType(row[2]),
+        **({"state_key": StateKey(row[3])} if row[3] is not None else {}),
+        "delay": Delay(row[4]),
+        "running_since": Timestamp(row[5] - row[4]),
+        "content": db_to_json(row[6]),
+    }
 
 
 def _generate_delay_id() -> DelayID:

--- a/synapse/storage/databases/main/delayed_events.py
+++ b/synapse/storage/databases/main/delayed_events.py
@@ -67,13 +67,12 @@ class DelayedEventDetails(EventDetails):
 class DelayedEventResponse:
     """The representation of a delayed event in API format."""
 
-    # Implementation detail: use converters to normalize untyped values read from the database
-    delay_id: str = attr.ib(converter=str)
-    room_id: str = attr.ib(converter=str)
-    type: str = attr.ib(converter=str)
-    state_key: str | None = attr.ib(converter=attr.converters.optional(str))
-    delay_ms: int = attr.ib(converter=int)
-    delayed_since_ts: int = attr.ib(converter=int)
+    delay_id: str
+    room_id: str
+    type: str
+    state_key: str | None
+    delay_ms: int
+    delayed_since_ts: int
     content: JsonDict = attr.ib(converter=db_to_json)
 
     def asdict(self) -> JsonDict:

--- a/synapse/storage/databases/main/delayed_events.py
+++ b/synapse/storage/databases/main/delayed_events.py
@@ -63,6 +63,23 @@ class DelayedEventDetails(EventDetails):
     user_localpart: UserLocalpart
 
 
+@attr.s(slots=True, frozen=True, auto_attribs=True)
+class DelayedEventResponse:
+    """The representation of a delayed event in API format."""
+
+    # Implementation detail: use converters to normalize untyped values read from the database
+    delay_id: str = attr.ib(converter=str)
+    room_id: str = attr.ib(converter=str)
+    type: str = attr.ib(converter=str)
+    state_key: str | None = attr.ib(converter=attr.converters.optional(str))
+    delay: int = attr.ib(converter=int)
+    running_since: int = attr.ib(converter=int)
+    content: JsonDict = attr.ib(converter=db_to_json)
+
+    def asdict(self) -> JsonDict:
+        return attr.asdict(self, filter=lambda _attr, v: v is not None)
+
+
 class DelayedEventsStore(SQLBaseStore):
     def __init__(
         self,
@@ -229,7 +246,7 @@ class DelayedEventsStore(SQLBaseStore):
         self,
         delay_id: str,
         user_localpart: str,
-    ) -> JsonDict:
+    ) -> DelayedEventResponse:
         """
         Returns the specified pending delayed event owned by the given user.
 
@@ -248,7 +265,7 @@ class DelayedEventsStore(SQLBaseStore):
                 "event_type",
                 "state_key",
                 "delay",
-                "send_ts",
+                "send_ts - delay",
                 "content",
             ),
             allow_none=True,
@@ -256,12 +273,12 @@ class DelayedEventsStore(SQLBaseStore):
         )
         if row is None:
             raise NotFoundError("Delayed event not found")
-        return _row_to_delayed_event_dict((delay_id, *row))
+        return DelayedEventResponse(delay_id, *row)
 
     async def get_all_delayed_events_for_user(
         self,
         user_localpart: str,
-    ) -> list[JsonDict]:
+    ) -> list[DelayedEventResponse]:
         """Returns all pending delayed events owned by the given user."""
         # TODO: Support Pagination stream API ("next_batch" field)
         rows = await self.db_pool.execute(
@@ -273,7 +290,7 @@ class DelayedEventsStore(SQLBaseStore):
                 event_type,
                 state_key,
                 delay,
-                send_ts,
+                send_ts - delay,
                 content
             FROM delayed_events
             WHERE user_localpart = ? AND NOT is_processed
@@ -281,7 +298,7 @@ class DelayedEventsStore(SQLBaseStore):
             """,
             user_localpart,
         )
-        return [_row_to_delayed_event_dict(row) for row in rows]
+        return [DelayedEventResponse(*row) for row in rows]
 
     async def process_timeout_delayed_events(
         self, current_ts: Timestamp, reprocess_events: bool = False
@@ -593,18 +610,6 @@ class DelayedEventsStore(SQLBaseStore):
             allow_none=True,
         )
         return Timestamp(result) if result is not None else None
-
-
-def _row_to_delayed_event_dict(row: tuple) -> JsonDict:
-    return {
-        "delay_id": DelayID(row[0]),
-        "room_id": str(RoomID.from_string(row[1])),
-        "type": EventType(row[2]),
-        **({"state_key": StateKey(row[3])} if row[3] is not None else {}),
-        "delay": Delay(row[4]),
-        "running_since": Timestamp(row[5] - row[4]),
-        "content": db_to_json(row[6]),
-    }
 
 
 def _generate_delay_id() -> DelayID:

--- a/synapse/storage/databases/main/delayed_events.py
+++ b/synapse/storage/databases/main/delayed_events.py
@@ -72,12 +72,23 @@ class DelayedEventResponse:
     room_id: str = attr.ib(converter=str)
     type: str = attr.ib(converter=str)
     state_key: str | None = attr.ib(converter=attr.converters.optional(str))
-    delay: int = attr.ib(converter=int)
-    running_since: int = attr.ib(converter=int)
+    delay_ms: int = attr.ib(converter=int)
+    delayed_since_ts: int = attr.ib(converter=int)
     content: JsonDict = attr.ib(converter=db_to_json)
 
     def asdict(self) -> JsonDict:
         return attr.asdict(self, filter=lambda _attr, v: v is not None)
+
+
+# TODO: Remove this class once the response format is stable
+class DelayedEventResponseLegacyCompat(DelayedEventResponse):
+    """For backwards compatibility with field names from earlier revisions of MSC4140."""
+
+    def asdict(self) -> JsonDict:
+        return super().asdict() | {
+            "delay": self.delay_ms,
+            "running_since": self.delayed_since_ts,
+        }
 
 
 class DelayedEventsStore(SQLBaseStore):
@@ -278,8 +289,13 @@ class DelayedEventsStore(SQLBaseStore):
     async def get_all_delayed_events_for_user(
         self,
         user_localpart: str,
-    ) -> list[DelayedEventResponse]:
-        """Returns all pending delayed events owned by the given user."""
+    ) -> list[DelayedEventResponseLegacyCompat]:
+        """
+        Return all pending delayed events owned by the given user.
+        Includes fields from earlier revisions of MSC4140 for
+        compatibility with clients that still expect them.
+        """
+        # TODO: Remove legacy fields once stable
         # TODO: Support Pagination stream API ("next_batch" field)
         rows = await self.db_pool.execute(
             "get_all_delayed_events_for_user",
@@ -298,7 +314,7 @@ class DelayedEventsStore(SQLBaseStore):
             """,
             user_localpart,
         )
-        return [DelayedEventResponse(*row) for row in rows]
+        return [DelayedEventResponseLegacyCompat(*row) for row in rows]
 
     async def process_timeout_delayed_events(
         self, current_ts: Timestamp, reprocess_events: bool = False

--- a/tests/rest/client/test_delayed_events.py
+++ b/tests/rest/client/test_delayed_events.py
@@ -127,6 +127,48 @@ class DelayedEventsTestCase(HomeserverTestCase):
     def test_delayed_events_empty_on_startup(self) -> None:
         self.assertListEqual([], self._get_delayed_events())
 
+    def test_delayed_event_lookup(self) -> None:
+        channel = self.make_request(
+            "POST",
+            _get_path_for_delayed_send(self.room_id, _EVENT_TYPE, 100000),
+            {},
+            self.user1_access_token,
+        )
+        self.assertEqual(HTTPStatus.OK, channel.code, channel.result)
+        delay_id = channel.json_body["delay_id"]
+
+        # Test that the scheduled delayed event can be retrieved
+        channel = self.make_request(
+            "GET",
+            f"{PATH_PREFIX}/{delay_id}",
+            access_token=self.user1_access_token,
+        )
+        self.assertEqual(HTTPStatus.OK, channel.code, channel.result)
+
+        event = channel.json_body
+        self.assertEqual(delay_id, event["delay_id"])
+
+        # Test that the list lookup retrieves the same item
+        events = self._get_delayed_events()
+        self.assertEqual(1, len(events), events)
+        self.assertDictEqual(events[0], event)
+
+        # Test that a non-existent delayed event cannot be found
+        channel = self.make_request(
+            "GET",
+            f"{PATH_PREFIX}/{delay_id}-fake",
+            access_token=self.user1_access_token,
+        )
+        self.assertEqual(HTTPStatus.NOT_FOUND, channel.code, channel.result)
+
+        # Test that other users cannot access this delayed event
+        channel = self.make_request(
+            "GET",
+            f"{PATH_PREFIX}/{delay_id}",
+            access_token=self.user2_access_token,
+        )
+        self.assertEqual(HTTPStatus.NOT_FOUND, channel.code, channel.result)
+
     def test_delayed_state_events_are_sent_on_timeout(self) -> None:
         state_key = "to_send_on_timeout"
 

--- a/tests/rest/client/test_delayed_events.py
+++ b/tests/rest/client/test_delayed_events.py
@@ -137,7 +137,7 @@ class DelayedEventsTestCase(HomeserverTestCase):
             content,
             self.user1_access_token,
         )
-        self.assertEqual(HTTPStatus.OK, channel.code, channel.result)
+        self.assertEqual(channel.code, HTTPStatus.OK, channel.result)
         delay_id = channel.json_body["delay_id"]
 
         # Test that the scheduled delayed event can be retrieved
@@ -146,7 +146,7 @@ class DelayedEventsTestCase(HomeserverTestCase):
             f"{PATH_PREFIX}/{delay_id}",
             access_token=self.user1_access_token,
         )
-        self.assertEqual(HTTPStatus.OK, channel.code, channel.result)
+        self.assertEqual(channel.code, HTTPStatus.OK, channel.result)
 
         event = channel.json_body
         self.assertDictEqual(
@@ -170,7 +170,7 @@ class DelayedEventsTestCase(HomeserverTestCase):
             f"{PATH_PREFIX}/{delay_id}-fake",
             access_token=self.user1_access_token,
         )
-        self.assertEqual(HTTPStatus.NOT_FOUND, channel.code, channel.result)
+        self.assertEqual(channel.code, HTTPStatus.NOT_FOUND, channel.result)
 
         # Test that other users cannot access this delayed event
         channel = self.make_request(
@@ -178,7 +178,7 @@ class DelayedEventsTestCase(HomeserverTestCase):
             f"{PATH_PREFIX}/{delay_id}",
             access_token=self.user2_access_token,
         )
-        self.assertEqual(HTTPStatus.NOT_FOUND, channel.code, channel.result)
+        self.assertEqual(channel.code, HTTPStatus.NOT_FOUND, channel.result)
 
     def test_delayed_state_events_are_sent_on_timeout(self) -> None:
         state_key = "to_send_on_timeout"

--- a/tests/rest/client/test_delayed_events.py
+++ b/tests/rest/client/test_delayed_events.py
@@ -150,8 +150,7 @@ class DelayedEventsTestCase(HomeserverTestCase):
 
         # Test that the list lookup retrieves the same item
         events = self._get_delayed_events()
-        self.assertEqual(1, len(events), events)
-        self.assertDictEqual(events[0], event)
+        self.assertEqual(self._get_delayed_events(), [event])
 
         # Test that a non-existent delayed event cannot be found
         channel = self.make_request(

--- a/tests/rest/client/test_delayed_events.py
+++ b/tests/rest/client/test_delayed_events.py
@@ -128,8 +128,9 @@ class DelayedEventsTestCase(HomeserverTestCase):
         self.assertListEqual([], self._get_delayed_events())
 
     def test_delayed_event_lookup(self) -> None:
+        # Schedule a message event
         delay = 100000
-        content: JsonDict = {}
+        content: JsonDict = {"message": "hello"}
         request_time_msec = self.hs.get_clock().time_msec()
         channel = self.make_request(
             "POST",
@@ -148,6 +149,7 @@ class DelayedEventsTestCase(HomeserverTestCase):
         )
         self.assertEqual(channel.code, HTTPStatus.OK, channel.result)
 
+        # Assert the stored properties of the delayed event
         event = channel.json_body
         self.assertDictEqual(
             event,
@@ -179,6 +181,48 @@ class DelayedEventsTestCase(HomeserverTestCase):
             access_token=self.user2_access_token,
         )
         self.assertEqual(channel.code, HTTPStatus.NOT_FOUND, channel.result)
+
+        # Now schedule a state event.
+        # Do it in this test, as opposed to a new one, to confirm that the correct delayed event
+        # is retrieved when multiple delayed events have been scheduled.
+        delay += 2000
+        state_key = ""
+        state_event_type = _EVENT_TYPE + "_state"
+        content = {"state_message": "greetings"}
+        request_time_msec = self.hs.get_clock().time_msec()
+        channel = self.make_request(
+            "PUT",
+            _get_path_for_delayed_state(self.room_id, state_event_type, state_key, delay),
+            content,
+            self.user1_access_token,
+        )
+        self.assertEqual(channel.code, HTTPStatus.OK, channel.result)
+        delay_id_2 = channel.json_body["delay_id"]
+
+        # Test that the new delayed event has a different ID from the previous one
+        self.assertNotEqual(delay_id, delay_id_2)
+
+        # Test that the scheduled delayed event can be retrieved
+        channel = self.make_request(
+            "GET",
+            f"{PATH_PREFIX}/{delay_id_2}",
+            access_token=self.user1_access_token,
+        )
+        self.assertEqual(channel.code, HTTPStatus.OK, channel.result)
+
+        # Assert the stored properties of the delayed event
+        self.assertDictEqual(
+            channel.json_body,
+            {
+                "delay_id": delay_id_2,
+                "room_id": self.room_id,
+                "type": state_event_type,
+                "state_key": state_key,
+                "delay": delay,
+                "running_since": request_time_msec,
+                "content": content,
+            },
+        )
 
     def test_delayed_state_events_are_sent_on_timeout(self) -> None:
         state_key = "to_send_on_timeout"

--- a/tests/rest/client/test_delayed_events.py
+++ b/tests/rest/client/test_delayed_events.py
@@ -192,7 +192,9 @@ class DelayedEventsTestCase(HomeserverTestCase):
         request_time_msec = self.hs.get_clock().time_msec()
         channel = self.make_request(
             "PUT",
-            _get_path_for_delayed_state(self.room_id, state_event_type, state_key, delay),
+            _get_path_for_delayed_state(
+                self.room_id, state_event_type, state_key, delay
+            ),
             content,
             self.user1_access_token,
         )

--- a/tests/rest/client/test_delayed_events.py
+++ b/tests/rest/client/test_delayed_events.py
@@ -129,12 +129,12 @@ class DelayedEventsTestCase(HomeserverTestCase):
 
     def test_delayed_event_lookup(self) -> None:
         # Schedule a message event
-        delay = 100000
+        delay_ms = 100000
         content: JsonDict = {"message": "hello"}
-        request_time_msec = self.hs.get_clock().time_msec()
+        delayed_since_ts = self.hs.get_clock().time_msec()
         channel = self.make_request(
             "POST",
-            _get_path_for_delayed_send(self.room_id, _EVENT_TYPE, delay),
+            _get_path_for_delayed_send(self.room_id, _EVENT_TYPE, delay_ms),
             content,
             self.user1_access_token,
         )
@@ -157,14 +157,11 @@ class DelayedEventsTestCase(HomeserverTestCase):
                 "delay_id": delay_id,
                 "room_id": self.room_id,
                 "type": _EVENT_TYPE,
-                "delay": delay,
-                "running_since": request_time_msec,
+                "delay_ms": delay_ms,
+                "delayed_since_ts": delayed_since_ts,
                 "content": content,
             },
         )
-
-        # Test that the list lookup retrieves the same item
-        self.assertEqual(self._get_delayed_events(), [event])
 
         # Test that a non-existent delayed event cannot be found
         channel = self.make_request(
@@ -185,15 +182,15 @@ class DelayedEventsTestCase(HomeserverTestCase):
         # Now schedule a state event.
         # Do it in this test, as opposed to a new one, to confirm that the correct delayed event
         # is retrieved when multiple delayed events have been scheduled.
-        delay += 2000
+        delay_ms += 2000
         state_key = ""
         state_event_type = _EVENT_TYPE + "_state"
         content = {"state_message": "greetings"}
-        request_time_msec = self.hs.get_clock().time_msec()
+        delayed_since_ts = self.hs.get_clock().time_msec()
         channel = self.make_request(
             "PUT",
             _get_path_for_delayed_state(
-                self.room_id, state_event_type, state_key, delay
+                self.room_id, state_event_type, state_key, delay_ms
             ),
             content,
             self.user1_access_token,
@@ -213,17 +210,35 @@ class DelayedEventsTestCase(HomeserverTestCase):
         self.assertEqual(channel.code, HTTPStatus.OK, channel.result)
 
         # Assert the stored properties of the delayed event
+        state_event = channel.json_body
         self.assertDictEqual(
-            channel.json_body,
+            state_event,
             {
                 "delay_id": delay_id_2,
                 "room_id": self.room_id,
                 "type": state_event_type,
                 "state_key": state_key,
-                "delay": delay,
-                "running_since": request_time_msec,
+                "delay_ms": delay_ms,
+                "delayed_since_ts": delayed_since_ts,
                 "content": content,
             },
+        )
+
+        # Test that the list lookup retrieves the same items (with legacy fields included)
+        self.assertEqual(
+            self._get_delayed_events(),
+            [
+                event
+                | {
+                    "delay": event["delay_ms"],
+                    "running_since": event["delayed_since_ts"],
+                },
+                state_event
+                | {
+                    "delay": state_event["delay_ms"],
+                    "running_since": state_event["delayed_since_ts"],
+                },
+            ],
         )
 
     def test_delayed_state_events_are_sent_on_timeout(self) -> None:

--- a/tests/rest/client/test_delayed_events.py
+++ b/tests/rest/client/test_delayed_events.py
@@ -149,7 +149,6 @@ class DelayedEventsTestCase(HomeserverTestCase):
         self.assertEqual(delay_id, event["delay_id"])
 
         # Test that the list lookup retrieves the same item
-        events = self._get_delayed_events()
         self.assertEqual(self._get_delayed_events(), [event])
 
         # Test that a non-existent delayed event cannot be found

--- a/tests/rest/client/test_delayed_events.py
+++ b/tests/rest/client/test_delayed_events.py
@@ -128,10 +128,13 @@ class DelayedEventsTestCase(HomeserverTestCase):
         self.assertListEqual([], self._get_delayed_events())
 
     def test_delayed_event_lookup(self) -> None:
+        delay = 100000
+        content: JsonDict = {}
+        request_time_msec = self.hs.get_clock().time_msec()
         channel = self.make_request(
             "POST",
-            _get_path_for_delayed_send(self.room_id, _EVENT_TYPE, 100000),
-            {},
+            _get_path_for_delayed_send(self.room_id, _EVENT_TYPE, delay),
+            content,
             self.user1_access_token,
         )
         self.assertEqual(HTTPStatus.OK, channel.code, channel.result)
@@ -146,7 +149,17 @@ class DelayedEventsTestCase(HomeserverTestCase):
         self.assertEqual(HTTPStatus.OK, channel.code, channel.result)
 
         event = channel.json_body
-        self.assertEqual(delay_id, event["delay_id"])
+        self.assertDictEqual(
+            event,
+            {
+                "delay_id": delay_id,
+                "room_id": self.room_id,
+                "type": _EVENT_TYPE,
+                "delay": delay,
+                "running_since": request_time_msec,
+                "content": content,
+            },
+        )
 
         # Test that the list lookup retrieves the same item
         self.assertEqual(self._get_delayed_events(), [event])


### PR DESCRIPTION
See https://github.com/matrix-org/matrix-spec-proposals/blob/toger5/expiring-events-keep-alive/proposals/4140-delayed-events-futures.md#getting-a-single-delayed-event

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
