### PR TITLE
Make sure calling /context on an out-of-band membership event doesn't 500

### DIFF
--- a/changelog.d/19959.bugfix
+++ b/changelog.d/19959.bugfix
@@ -1,0 +1,1 @@
+Don't 500 when calling /context on an out-of-band membership event.

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1983,15 +1983,15 @@ class RoomContextHandler:
             # context rather than failing. Clients legitimately fetch such events,
             # e.g. to render a push notification for an invite after the room has
             # already been joined.
-            token = await StreamToken.START.to_string(self.store)
+            dummy_token = await StreamToken.START.to_string(self.store)
             return EventContext(
                 events_before=[],
                 event=filtered[0],
                 events_after=[],
                 state=[],
                 aggregations={},
-                start=token,
-                end=token,
+                start=dummy_token,
+                end=dummy_token,
             )
 
         results = await self.store.get_events_around(

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1975,6 +1975,25 @@ class RoomContextHandler:
         if not filtered:
             raise AuthError(403, "You don't have permission to access that event.")
 
+        if event.internal_metadata.outlier:
+            # The only outliers that pass the visibility filter are the user's own
+            # out-of-band membership events (e.g. an invite or knock received over
+            # federation). They have no stream position or state group, so we cannot
+            # compute surrounding events or state — return the event with an empty
+            # context rather than failing. Clients legitimately fetch such events,
+            # e.g. to render a push notification for an invite after the room has
+            # already been joined.
+            token = await StreamToken.START.to_string(self.store)
+            return EventContext(
+                events_before=[],
+                event=filtered[0],
+                events_after=[],
+                state=[],
+                aggregations={},
+                start=token,
+                end=token,
+            )
+
         results = await self.store.get_events_around(
             room_id, event_id, before_limit, after_limit, event_filter
         )

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -359,6 +359,59 @@ class FederationTestCase(unittest.FederatingHomeserverTestCase):
             exc=LimitExceededError,
         )
 
+    def test_context_on_out_of_band_invite(self) -> None:
+        """/context on the user's own out-of-band invite returns the event with an
+        empty context instead of a 500: the outlier has no stream position or state
+        group, so surrounding events and state cannot be computed. Clients fetch such
+        events e.g. to render a push notification for an invite after the server has
+        already joined the user (auto-accepted knock)."""
+        other_server = "otherserver"
+        other_user = "@otheruser:" + other_server
+
+        user_id = self.register_user("kermit", "test")
+        tok = self.login("kermit", "test")
+        room_id = self.helper.create_room_as(room_creator=user_id, tok=tok)
+        room_version = self.get_success(self.store.get_room_version(room_id))
+
+        invited_user = self.register_user("invitee", "test")
+        invited_tok = self.login("invitee", "test")
+
+        invite = make_test_pdu_event(
+            {
+                "type": EventTypes.Member,
+                "content": {"membership": "invite"},
+                "room_id": room_id,
+                "sender": other_user,
+                "state_key": invited_user,
+                "depth": 32,
+                "prev_events": [],
+                "auth_events": [],
+                "origin_server_ts": self.clock.time_msec(),
+            },
+            room_version,
+        )
+        self.get_success(
+            self.handler.on_invite_request(other_server, invite, invite.room_version)
+        )
+
+        channel = self.make_request(
+            "GET",
+            f"/rooms/{room_id}/context/{invite.event_id}",
+            access_token=invited_tok,
+        )
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertEqual(channel.json_body["event"]["event_id"], invite.event_id)
+        self.assertEqual(channel.json_body["events_before"], [])
+        self.assertEqual(channel.json_body["events_after"], [])
+
+        # Another user must NOT be able to fetch it.
+        channel = self.make_request(
+            "GET",
+            f"/rooms/{room_id}/context/{invite.event_id}",
+            access_token=tok,
+        )
+        self.assertEqual(channel.code, 403, channel.result)
+
     def _build_and_send_join_event(
         self, other_server: str, other_user: str, room_id: str
     ) -> EventBase:


### PR DESCRIPTION
An out-of-band membership event (e.g. an invite or knock received over federation) is an outlier with no stream position or state group, so computing surrounding events or state for it fails with 'No state group for unknown or outlier event'.

Visibility already permits the user to see their own out-of-band membership events, and clients legitimately fetch them, e.g. to render a push notification for an invite after the server has already joined the user (auto-accepted knock). Return the event with an empty context instead of erroring.

This is helpful for clients trying to reason about knocks where they might call /context on a state event ID - for instance, Element X iOS's push extension (NSE) calls /context on every event ID it gets, so if you send a state event for autojoining a room you've knocked in, this would have 500'd.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
