### PR TITLE
Update release script JSON schema find/replace to be compatible with macOS

### DIFF
--- a/changelog.d/19962.misc
+++ b/changelog.d/19962.misc
@@ -1,0 +1,1 @@
+Update release script JSON schema find/replace task to be compatible with macOS.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -31,6 +31,7 @@ import sys
 import time
 import urllib.request
 from os import path
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
@@ -257,21 +258,16 @@ def _prepare() -> None:
     subprocess.check_output(["poetry", "version", new_version])
 
     # Update config schema $id.
-    schema_file = "schema/synapse-config.schema.yaml"
+    schema_file_path = Path("schema/synapse-config.schema.yaml")
     major_minor_version = ".".join(new_version.split(".")[:2])
     url = f"https://element-hq.github.io/synapse/schema/synapse/v{major_minor_version}/synapse-config.schema.json"
     # Find/replace the `$id: ...` line in `schema/synapse-config.schema.yaml` with a new
     # unique identifier for this release
-    #
-    # We use two `open(...)` blocks as it's easier to read/write then figure out the
-    # seek/truncate dance with one.
-    with open(schema_file) as f:
-        schema_file_content = f.read()
+    schema_file_content = schema_file_path.read_text()
     new_schema_file_content = re.sub(
         r"^\$id: .*", f"$id: {url}", schema_file_content, count=1, flags=re.MULTILINE
     )
-    with open(schema_file, "w") as f:
-        f.write(new_schema_file_content)
+    schema_file_path.write_text(new_schema_file_content)
 
     # Generate changelogs.
     generate_and_write_changelog(synapse_repo, current_version, new_version)

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -266,12 +266,12 @@ def _prepare() -> None:
     # We use two `open(...)` blocks as it's easier to read/write then figure out the
     # seek/truncate dance with one.
     with open(schema_file) as f:
-        contents = f.read()
-    contents = re.sub(
-        r"^\$id: .*", f"$id: {url}", contents, count=1, flags=re.MULTILINE
+        schema_file_content = f.read()
+    new_schema_file_content = re.sub(
+        r"^\$id: .*", f"$id: {url}", schema_file_content, count=1, flags=re.MULTILINE
     )
     with open(schema_file, "w") as f:
-        f.write(contents)
+        f.write(new_schema_file_content)
 
     # Generate changelogs.
     generate_and_write_changelog(synapse_repo, current_version, new_version)

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -260,7 +260,18 @@ def _prepare() -> None:
     schema_file = "schema/synapse-config.schema.yaml"
     major_minor_version = ".".join(new_version.split(".")[:2])
     url = f"https://element-hq.github.io/synapse/schema/synapse/v{major_minor_version}/synapse-config.schema.json"
-    subprocess.check_output(["sed", "-i", f"0,/^\\$id: .*/s||$id: {url}|", schema_file])
+    # Find/replace the `$id: ...` line in `schema/synapse-config.schema.yaml` with a new
+    # unique identifier for this release
+    #
+    # We use two `open(...)` blocks as it's easier to read/write then figure out the
+    # seek/truncate dance with one.
+    with open(schema_file) as f:
+        contents = f.read()
+    contents = re.sub(
+        r"^\$id: .*", f"$id: {url}", contents, count=1, flags=re.MULTILINE
+    )
+    with open(schema_file, "w") as f:
+        f.write(contents)
 
     # Generate changelogs.
     generate_and_write_changelog(synapse_repo, current_version, new_version)


### PR DESCRIPTION
Update release script JSON schema find/replace to be compatible with macOS

BSD vs GNU `sed` problems:
```shell
$ sed -i '0,/^\$id: .*/s||$id: https://element-hq.github.io/synapse/schema/synapse/v1.157/synapse-config.schema.json|' schema/synapse-config.schema.yaml
sed: 1: "schema/synapse-config.s ...": bad flag in substitute command: 'h'
```

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
