### PR TITLE
Silencing alerts is no longer necessary during a deploy (release script instructions)

### DIFF
--- a/changelog.d/19968.misc
+++ b/changelog.d/19968.misc
@@ -1,0 +1,1 @@
+Remove alert silencing deploy step from release script instructions as it's no longer necessary.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -806,7 +806,6 @@ def full(gh_token: str) -> None:
     _prepare()
 
     click.echo("Deploy to matrix.org and ensure that it hasn't fallen over.")
-    click.echo("Remember to silence the alerts to prevent alert spam.")
     click.confirm("Deployed?", abort=True)
 
     click.echo("\n*** tag ***")


### PR DESCRIPTION
Silencing alerts is no longer necessary during a deploy (release script instructions)

As discussed in [`#element-backend-internal:matrix.org`](https://matrix.to/#/!SGNQGPGUwtcPBUotTL:matrix.org/$29ZzRe7gg62UZmT0bgeseMs320Kb-Ub6DyaQE20-3ng?via=jki.re&via=element.io&via=matrix.org)

Our assumptions on why this was done previously: in the olden days you'd get paged doing the redeploy even if everything was actually fine (probably before we started doing rolling restarts?)

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
