### PR TITLE
Fix `PostgresSequenceGenerator.check_consistency(...)` using stale value after auto-repair

### DIFF
--- a/changelog.d/19973.bugfix
+++ b/changelog.d/19973.bugfix
@@ -1,0 +1,1 @@
+Fix bug where Synapse could refuse to start with an `IncorrectDatabaseSetup` error about `stream_positions` being inconsistent with a stream sequence, even though the sequence had just been automatically repaired.

--- a/synapse/storage/util/sequence.py
+++ b/synapse/storage/util/sequence.py
@@ -184,6 +184,16 @@ class PostgresSequenceGenerator(SequenceGenerator):
             """
             txn.execute(sql)
 
+            # Since we just auto-repaired, update `last_value` with the new value
+            # (otherwise we'd make stale comparisons below)
+            #
+            # `setval` returns the value the sequence was set to, and marks the sequence
+            # as `is_called` (i.e. the next `nextval` will return a value strictly
+            # greater than it), so this is now the true "last value".
+            row = txn.fetchone()
+            assert row is not None
+            (last_value,) = row
+
         txn.close()
 
         # If we have values in the stream positions table then they have to be


### PR DESCRIPTION
Fix `PostgresSequenceGenerator.check_consistency(...)` using stale value after auto-repair

Spawning from a problem that @gaelgatelement ran into [`#element-backend-internal:matrix.org`](https://matrix.to/#/!SGNQGPGUwtcPBUotTL:matrix.org/$eEyNXZ1Hwe_x9L4gRB0NQQiOJVvk_pvRCTo_2fnUWtY?via=jki.re&via=element.io&via=matrix.org) but I don't think this PR necessarily fixes that problem.

<details>
<summary><code>IncorrectDatabaseSetup</code>: 
<code>Postgres sequence 'device_lists_sequence' is inconsistent with associated stream position of 'device_lists_stream' in the 'stream_positions' table.</code></summary>

```
2026-07-16 16:30:12,335 - synapse.config.logger - 377 - WARNING - main - ***** STARTING SERVER *****
2026-07-16 16:30:12,336 - synapse.config.logger - 378 - WARNING - main - Server /usr/local/lib/python3.13/site-packages/synapse/app/homeserver.py version 1.156.0+pro.1
2026-07-16 16:30:12,336 - synapse.config.logger - 383 - WARNING - main - Copyright (c) 2023 New Vector, Inc
2026-07-16 16:30:12,336 - synapse.config.logger - 384 - WARNING - main - Licensed under the AGPL 3.0 license. Website: https://github.com/element-hq/synapse
2026-07-16 16:30:12,336 - synapse.config.logger - 387 - INFO - main - Server hostname: goldstar.element.dev
2026-07-16 16:30:12,336 - synapse.config.logger - 388 - INFO - main - Public Base URL: https://matrix.goldstar.element.dev/
2026-07-16 16:30:12,336 - synapse.config.logger - 389 - INFO - main - Instance name: master
2026-07-16 16:30:12,336 - synapse.config.logger - 390 - INFO - main - Twisted reactor: EPollReactor
2026-07-16 16:30:12,336 - synapse.app.homeserver - 417 - INFO - main - Setting up server
2026-07-16 16:30:12,336 - synapse.server - 635 - INFO - main - Setting up.
2026-07-16 16:30:12,351 - synapse.storage.databases - 92 - INFO - main - [database config 'master']: Checking database server
2026-07-16 16:30:12,352 - synapse.storage.databases - 95 - INFO - main - [database config 'master']: Preparing for databases ['main', 'state']
2026-07-16 16:30:12,352 - synapse.storage.prepare_database - 132 - INFO - main - ['main', 'state']: Checking existing schema version
2026-07-16 16:30:12,354 - synapse.storage.prepare_database - 136 - INFO - main - ['main', 'state']: Existing schema is 94 (+7 deltas)
2026-07-16 16:30:12,354 - synapse.storage.databases.main - 401 - INFO - main - Checking database for consistency with configuration...
2026-07-16 16:30:12,354 - synapse.storage.prepare_database - 430 - INFO - main - Applying schema deltas for v94
2026-07-16 16:30:12,355 - synapse.storage.prepare_database - 565 - INFO - main - Schema now up to date
2026-07-16 16:30:12,356 - synapse.storage.databases - 110 - INFO - main - [database config 'master']: Starting 'main' database
2026-07-16 16:30:12,376 - synapse.storage.util.id_generators - 92 - INFO - main - Initialising stream generator for push_rules(id): 1
2026-07-16 16:30:12,376 - synapse.storage.util.id_generators - 92 - INFO - main - Initialising stream generator for push_rules_enable(id): 1
2026-07-16 16:30:12,382 - synapse.storage.databases.main.event_push_actions - 1238 - INFO - main - Searching for stream ordering 1 month ago
2026-07-16 16:30:12,382 - synapse.storage.databases.main.event_push_actions - 1242 - INFO - main - Found stream ordering 1 month ago: it's 2
2026-07-16 16:30:12,383 - synapse.storage.databases.main.event_push_actions - 1245 - INFO - main - Searching for stream ordering 1 day ago
2026-07-16 16:30:12,383 - synapse.storage.databases.main.event_push_actions - 1249 - INFO - main - Found stream ordering 1 day ago: it's 2
2026-07-16 16:30:12,386 - synapse.storage.util.id_generators - 92 - INFO - main - Initialising stream generator for access_tokens(id): 1
2026-07-16 16:30:12,386 - synapse.storage.util.id_generators - 92 - INFO - main - Initialising stream generator for refresh_tokens(id): 1
2026-07-16 16:30:12,389 - synapse.storage.util.id_generators - 92 - INFO - main - Initialising stream generator for event_reports(id): 1
2026-07-16 16:30:12,390 - synapse.storage.util.id_generators - 92 - INFO - main - Initialising stream generator for room_reports(id): 1
2026-07-16 16:30:12,390 - synapse.storage.util.id_generators - 92 - INFO - main - Initialising stream generator for user_reports(id): 1
2026-07-16 16:30:12,391 - synapse.app._base - 251 - ERROR - main - Exception during startup
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/synapse/app/homeserver.py", line 486, in main
    setup(hs)
    ~~~~~^^^^
  File "/usr/local/lib/python3.13/site-packages/synapse/app/homeserver.py", line 422, in setup
    hs.setup()
    ~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/synapse/server.py", line 637, in setup
    self.datastores = Databases(self.DATASTORE_CLASS, self)
                      ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/synapse/storage/databases/__init__.py", line 119, in __init__
    main = main_store_class(database, db_conn, hs)
  File "/usr/local/lib/python3.13/site-packages/synapse/storage/databases/main/__init__.py", line 179, in __init__
    super().__init__(database, db_conn, hs)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/synapse/storage/databases/main/events_bg_updates.py", line 133, in __init__
    super().__init__(database, db_conn, hs)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/synapse/storage/databases/main/experimental_features.py", line 44, in __init__
    super().__init__(database, db_conn, hs)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/synapse/storage/databases/main/devices.py", line 2806, in __init__
    super().__init__(database, db_conn, hs)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/synapse/storage/databases/main/devices.py", line 110, in __init__
    self._device_list_id_gen = MultiWriterIdGenerator(
                               ~~~~~~~~~~~~~~~~~~~~~~^
        db_conn=db_conn,
        ^^^^^^^^^^^^^^^^
    ...<18 lines>...
        writers=hs.config.worker.writers.device_lists,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/synapse/storage/util/id_generators.py", line 308, in __init__
    self._sequence_gen.check_consistency(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        db_conn,
        ^^^^^^^^
    ...<3 lines>...
        positive=positive,
        ^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/synapse/storage/util/sequence.py", line 192, in check_consistency
    raise IncorrectDatabaseSetup(
    ...<2 lines>...
    )
synapse.storage.engines._base.IncorrectDatabaseSetup: 
Postgres sequence 'device_lists_sequence' is inconsistent with associated stream position
of 'device_lists_stream' in the 'stream_positions' table.

This is likely a programming error and should be reported at
https://github.com/matrix-org/synapse.

A temporary workaround to fix this error is to shut down Synapse (including
any and all workers) and run the following SQL:

    DELETE FROM stream_positions WHERE stream_name = 'device_lists_stream';

This will need to be done every time the server is restarted.

**********************************************************************************
 Error during initialisation:
     Traceback (most recent call last):
       File "/usr/local/lib/python3.13/site-packages/synapse/app/homeserver.py", line 486, in main
         setup(hs)
         ~~~~~^^^^
       File "/usr/local/lib/python3.13/site-packages/synapse/app/homeserver.py", line 422, in setup
         hs.setup()
         ~~~~~~~~^^
       File "/usr/local/lib/python3.13/site-packages/synapse/server.py", line 637, in setup
         self.datastores = Databases(self.DATASTORE_CLASS, self)
                           ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       File "/usr/local/lib/python3.13/site-packages/synapse/storage/databases/__init__.py", line 119, in __init__
         main = main_store_class(database, db_conn, hs)
       File "/usr/local/lib/python3.13/site-packages/synapse/storage/databases/main/__init__.py", line 179, in __init__
         super().__init__(database, db_conn, hs)
         ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
       File "/usr/local/lib/python3.13/site-packages/synapse/storage/databases/main/events_bg_updates.py", line 133, in __init__
         super().__init__(database, db_conn, hs)
         ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
       File "/usr/local/lib/python3.13/site-packages/synapse/storage/databases/main/experimental_features.py", line 44, in __init__
         super().__init__(database, db_conn, hs)
         ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
       File "/usr/local/lib/python3.13/site-packages/synapse/storage/databases/main/devices.py", line 2806, in __init__
         super().__init__(database, db_conn, hs)
         ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
       File "/usr/local/lib/python3.13/site-packages/synapse/storage/databases/main/devices.py", line 110, in __init__
         self._device_list_id_gen = MultiWriterIdGenerator(
                                    ~~~~~~~~~~~~~~~~~~~~~~^
             db_conn=db_conn,
             ^^^^^^^^^^^^^^^^
         ...<18 lines>...
             writers=hs.config.worker.writers.device_lists,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         )
         ^
       File "/usr/local/lib/python3.13/site-packages/synapse/storage/util/id_generators.py", line 308, in __init__
         self._sequence_gen.check_consistency(
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
             db_conn,
             ^^^^^^^^
         ...<3 lines>...
             positive=positive,
             ^^^^^^^^^^^^^^^^^^
         )
         ^
       File "/usr/local/lib/python3.13/site-packages/synapse/storage/util/sequence.py", line 192, in check_consistency
         raise IncorrectDatabaseSetup(
         ...<2 lines>...
         )
     synapse.storage.engines._base.IncorrectDatabaseSetup:
     Postgres sequence 'device_lists_sequence' is inconsistent with associated stream position
     of 'device_lists_stream' in the 'stream_positions' table.
 
     This is likely a programming error and should be reported at
     https://github.com/matrix-org/synapse.
 
     A temporary workaround to fix this error is to shut down Synapse (including
     any and all workers) and run the following SQL:
 
         DELETE FROM stream_positions WHERE stream_name = 'device_lists_stream';
 
     This will need to be done every time the server is restarted.
 
 
 There may be more information in the logs.
**********************************************************************************
```

</details>


Related to https://github.com/element-hq/synapse/issues/18544


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
