### PR TITLE
Link to changelog instead of duplicating content in the tag/release

### DIFF
--- a/changelog.d/19984.misc
+++ b/changelog.d/19984.misc
@@ -1,0 +1,1 @@
+Link to changelog instead of duplicating content in the tag/release.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -373,19 +373,9 @@ def _tag(gh_token: str | None) -> None:
         )
         click.get_current_context().abort()
 
-    # Get the appropriate changelogs and tag.
-    changes = get_changes_for_version(current_version)
+    tag_message = f"Changelog: https://github.com/element-hq/synapse/blob/{repo.active_branch.name}/CHANGES.md"
 
-    click.echo_via_pager(changes)
-    if click.confirm("Edit text?", default=False):
-        edited_changes = click.edit(changes, require_save=False)
-        # This assert is for mypy's benefit. click's docs are a little unclear, but
-        # when `require_save=False`, not saving the temp file in the editor returns
-        # the original string.
-        assert edited_changes is not None
-        changes = edited_changes
-
-    repo.create_tag(tag_name, message=changes, sign=True)
+    repo.create_tag(tag_name, message=tag_message, sign=True)
 
     if not click.confirm("Push tag to GitHub?", default=True):
         print("")

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -736,6 +736,7 @@ def announce(_gh_token: str | None) -> None:
 def _announce() -> None:
     """Generate markdown to announce the release."""
 
+    synapse_repo = get_repo_and_check_clean_checkout()
     current_version = get_package_version()
     tag_name = f"v{current_version}"
     is_rc = "rc" in tag_name
@@ -755,7 +756,7 @@ Hi everyone. Synapse {current_version} has just been released.
         )
 
     release_text += f"""
-[notes](https://github.com/element-hq/synapse/releases/tag/{tag_name}) | \
+[notes](https://github.com/element-hq/synapse/blob/{synapse_repo.active_branch.name}/CHANGES.md) | \
 [docker](https://hub.docker.com/r/matrixdotorg/synapse/tags?name={tag_name}) | \
 [debs](https://packages.matrix.org/debian/) | \
 [pypi](https://pypi.org/project/matrix-synapse/{current_version}/)"""

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -373,6 +373,7 @@ def _tag(gh_token: str | None) -> None:
         )
         click.get_current_context().abort()
 
+    # We simply point to the changelog instead of duplicating the content into the git tag/release
     tag_message = f"Changelog: https://github.com/element-hq/synapse/blob/{repo.active_branch.name}/CHANGES.md"
 
     repo.create_tag(tag_name, message=tag_message, sign=True)
@@ -410,7 +411,7 @@ def _tag(gh_token: str | None) -> None:
     release = gh_repo.create_git_release(
         tag=tag_name,
         name=tag_name,
-        message=changes,
+        message=tag_message,
         draft=True,
         prerelease=current_version.is_prerelease,
     )


### PR DESCRIPTION
Link to changelog instead of duplicating content in the tag/release

This means we can point to a single source of truth instead of duplicating the content to the tag and GitHub release. Less to manage and worry about when you make some updates to the changelog (maintenance burden). We also get to avoid the content sitting in the vendor lock-in GitHub releases.

We point to `https://github.com/element-hq/synapse/blob/{repo.active_branch.name}/CHANGES.md` as it will have the relevant changelog entry at the top and won't change as we archive releases on `develop`. Even for RC releases after the main release goes out, the entry will still be towards the top. We could try to get the heading anchor for the specific section but I thought that it wasn't necessary (nice but more complex).


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
