### PR TITLE
Fix config regression around falsy `experimental_features` (`None`)

### DIFF
--- a/changelog.d/19987.bugfix
+++ b/changelog.d/19987.bugfix
@@ -1,1 +1,1 @@
-Stub changelog: Merge with #19539.
+Fix config regression around falsy `experimental_features` no longer being accepted.

--- a/changelog.d/19987.bugfix
+++ b/changelog.d/19987.bugfix
@@ -1,0 +1,1 @@
+Stub changelog: Merge with #19539.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -966,9 +966,10 @@ class ServerConfig(Config):
 
         # The maximum number of delayed events a user may have scheduled at a time.
         # (Defined here despite being experimental to be near the other MSC4140 config)
-        self.max_delayed_events_per_user: int = config.get(
-            "experimental_features", {}
-        ).get("msc4140_max_delayed_events_per_user", 100)
+        experimental = config.get("experimental_features") or {}
+        self.max_delayed_events_per_user: int = experimental.get(
+            "msc4140_max_delayed_events_per_user", 100
+        )
         if (
             not isinstance(self.max_delayed_events_per_user, int)
             or self.max_delayed_events_per_user < 0

--- a/tests/config/test_experimental.py
+++ b/tests/config/test_experimental.py
@@ -1,0 +1,71 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 Element Creations Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+
+import yaml
+from parameterized import parameterized
+
+from synapse.config._base import RootConfig
+from synapse.config.experimental import ExperimentalConfig
+from synapse.config.homeserver import HomeServerConfig
+from synapse.types import JsonDict
+
+from tests import unittest
+
+
+class ExperimentalConfigTestCase(unittest.TestCase):
+    @parameterized.expand(
+        [
+            [
+                "single",
+                {
+                    "experimental_features": {
+                        "msc3575_enabled": True,
+                    }
+                },
+            ],
+            [
+                "multi",
+                {
+                    "experimental_features": {
+                        "msc3575_enabled": True,
+                        "msc3030_enabled": True,
+                    }
+                },
+            ],
+            # This has historically worked and this is being added as a regression test
+            ["none", {"experimental_features": None}],
+        ]
+    )
+    def test_experimental_features_parsing(
+        self, test_description: str, config_values: JsonDict
+    ) -> None:
+        """
+        Test the that `experimental_features` parses with these values
+        """
+
+        _read_config(config_values)
+
+
+def _read_config(config_values: JsonDict) -> None:
+    ExperimentalConfig(RootConfig()).read_config(
+        yaml.safe_load(
+            HomeServerConfig().generate_config(
+                config_dir_path="CONFDIR",
+                data_dir_path="/data_dir_path",
+                server_name="che.org",
+            )
+        )
+        | config_values,
+        allow_secrets_in_config=False,
+    )

--- a/tests/config/test_server.py
+++ b/tests/config/test_server.py
@@ -22,6 +22,7 @@
 from typing import Any
 
 import yaml
+from parameterized import parameterized
 
 from synapse.config._base import ConfigError, RootConfig
 from synapse.config.homeserver import HomeServerConfig
@@ -227,6 +228,29 @@ class ServerConfigTestCase(unittest.TestCase):
         for disallowed_value in (-1, 0.5):
             with self.assertRaises(ConfigError):
                 _read_config(generate_config(disallowed_value))
+
+    @parameterized.expand(
+        [
+            [
+                "single",
+                {
+                    "experimental_features": {
+                        "msc4140_max_delayed_events_per_user": 3,
+                    }
+                },
+            ],
+            # This has historically worked and this is being added as a regression test
+            ["none", {"experimental_features": None}],
+        ]
+    )
+    def test_experimental_features_parsing(
+        self, test_description: str, config_values: JsonDict
+    ) -> None:
+        """
+        Test the that `experimental_features` parses with these values
+        """
+
+        _read_config(config_values)
 
 
 def _read_config(config_values: JsonDict) -> None:


### PR DESCRIPTION
Fix config regression around falsy `experimental_features` (`None`)

Examples:

```yaml
experimental_features:
```

```yaml
experimental_features: null
```

```yaml
experimental_features: ~
```

Fix https://github.com/element-hq/synapse/issues/19986

Regressed in https://github.com/element-hq/synapse/pull/19539

The plan is to create a patch release and ship this in `v1.157.1`

### Dev notes

```
SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.config.test_experimental
```

```
SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.config.test_server
```


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
