### PR TITLE
Experimental support for MSC4507: Return additional room state from `/hierarchy`

### DIFF
--- a/changelog.d/19991.feature
+++ b/changelog.d/19991.feature
@@ -1,0 +1,1 @@
+Implement experimental MSC4507 support for requesting public additional state from the federation room hierarchy endpoint, gated behind `experimental_features.msc4507_enabled`.

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -187,6 +187,8 @@ class EventTypes:
 
     RoomPolicy: Final = "m.room.policy"
 
+    MSC4507PublicState: Final = "org.matrix.msc4507.public_state"
+
 
 class ToDeviceEventTypes:
     RoomKeyRequest: Final = "m.room_key_request"

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -309,3 +309,6 @@ class ExperimentalConfig(Config):
 
         # MSC4491: Invite reasons in room creation
         self.msc4491_enabled: bool = experimental.get("msc4491_enabled", False)
+
+        # MSC4507: Return additional room state from the federation hierarchy endpoint.
+        self.msc4507_enabled: bool = experimental.get("msc4507_enabled", False)

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -71,6 +71,7 @@ from synapse.http.types import QueryParams
 from synapse.logging.opentracing import SynapseTags, log_kv, set_tag, tag_args, trace
 from synapse.metrics import SERVER_NAME_LABEL
 from synapse.types import JsonDict, StrCollection, UserID, get_domain_from_id
+from synapse.types.state import StateEventQuery
 from synapse.util.async_helpers import concurrently_execute
 from synapse.util.caches.expiringcache import ExpiringCache
 from synapse.util.duration import Duration
@@ -134,6 +135,7 @@ class FederationClient(FederationBase):
         self._clock.looping_call(self._clear_tried_cache, Duration(minutes=1))
         self.state = hs.get_state_handler()
         self.transport_layer = hs.get_federation_transport_client()
+        self._msc4507_enabled = hs.config.experimental.msc4507_enabled
 
         self.server_name = hs.hostname
         self.signing_key = hs.signing_key
@@ -155,10 +157,10 @@ class FederationClient(FederationBase):
         # Some stale data over federation is OK, but must be refreshed
         # periodically since the local server is in the room.
         #
-        # It is a map of (room ID, suggested-only) -> the response of
+        # It is a map of (room ID, suggested-only, additional-state) -> the response of
         # get_room_hierarchy.
         self._get_room_hierarchy_cache: ExpiringCache[
-            tuple[str, bool],
+            tuple[str, bool, tuple[StateEventQuery, ...]],
             tuple[JsonDict, Sequence[JsonDict], Sequence[JsonDict], Sequence[str]],
         ] = ExpiringCache(
             cache_name="get_room_hierarchy_cache",
@@ -1653,6 +1655,7 @@ class FederationClient(FederationBase):
         destinations: Iterable[str],
         room_id: str,
         suggested_only: bool,
+        additional_state: Iterable[StateEventQuery] = (),
     ) -> tuple[JsonDict, Sequence[JsonDict], Sequence[JsonDict], Sequence[str]]:
         """
         Call other servers to get a hierarchy of the given room.
@@ -1665,6 +1668,9 @@ class FederationClient(FederationBase):
             room_id: ID of the space to be queried
             suggested_only:  If true, ask the remote server to only return children
                 with the "suggested" flag set
+            additional_state: Additional state events to ask for (under
+                MSC4507). May not be returned if they are not specifically marked as
+                public in the room state.
 
         Returns:
             A tuple of:
@@ -1678,7 +1684,15 @@ class FederationClient(FederationBase):
                remote servers
         """
 
-        cached_result = self._get_room_hierarchy_cache.get((room_id, suggested_only))
+        additional_state = (
+            _canonicalize_additional_state(additional_state)
+            if self._msc4507_enabled
+            else ()
+        )
+
+        cached_result = self._get_room_hierarchy_cache.get(
+            (room_id, suggested_only, additional_state)
+        )
         if cached_result:
             return cached_result
 
@@ -1690,6 +1704,7 @@ class FederationClient(FederationBase):
                     destination=destination,
                     room_id=room_id,
                     suggested_only=suggested_only,
+                    additional_state=additional_state,
                 )
             except HttpResponseException as e:
                 # If an error is received that is due to an unrecognised endpoint,
@@ -1706,6 +1721,7 @@ class FederationClient(FederationBase):
                     destination=destination,
                     room_id=room_id,
                     suggested_only=suggested_only,
+                    additional_state=additional_state,
                 )
 
             room = res.get("room")
@@ -1713,6 +1729,13 @@ class FederationClient(FederationBase):
                 raise InvalidResponseError("'room' must be a dict")
             if room.get("room_id") != room_id:
                 raise InvalidResponseError("wrong room returned in hierarchy response")
+            filtered_additional_parent_state = (
+                _validate_and_filter_hierarchy_additional_state(room, additional_state)
+            )
+            if filtered_additional_parent_state:
+                room["org.matrix.msc4507.additional_state"] = (
+                    filtered_additional_parent_state
+                )
 
             # Validate children_state of the room.
             children_state = room.pop("children_state", [])
@@ -1732,6 +1755,16 @@ class FederationClient(FederationBase):
                 raise InvalidResponseError("'children' must be a list")
             if any(not isinstance(r, dict) for r in children):
                 raise InvalidResponseError("Invalid room in 'children' list")
+            for child in children:
+                filtered_additional_child_state = (
+                    _validate_and_filter_hierarchy_additional_state(
+                        child, additional_state
+                    )
+                )
+                if filtered_additional_child_state:
+                    child["org.matrix.msc4507.additional_state"] = (
+                        filtered_additional_child_state
+                    )
 
             # Validate the inaccessible children.
             inaccessible_children = res.get("inaccessible_children", [])
@@ -1752,7 +1785,9 @@ class FederationClient(FederationBase):
         )
 
         # Cache the result to avoid fetching data over federation every time.
-        self._get_room_hierarchy_cache[(room_id, suggested_only)] = result
+        self._get_room_hierarchy_cache[(room_id, suggested_only, additional_state)] = (
+            result
+        )
         return result
 
     async def timestamp_to_event(
@@ -2070,3 +2105,187 @@ def _validate_hierarchy_event(d: JsonDict) -> None:
         raise ValueError("Invalid event: 'via' must be a list")
     if any(not isinstance(v, str) for v in via):
         raise ValueError("Invalid event: 'via' must be a list of strings")
+
+
+def _canonicalize_additional_state(
+    additional_state: Iterable[StateEventQuery],
+) -> tuple[StateEventQuery, ...]:
+    """
+    Convert any iterable of `StateEventQuery` to a (hashable) tuple, which can
+    be used as a cache key. Additionally, optimise the query by combining
+    semantically identical requests with:
+
+    * duplicate entries
+    * collapsed wildcards
+      (i.e. (type="x", state_key=None) (all state keys)
+      dominates (type="x", state_key="a") )
+
+    Keys are also ordered to ensure otherwise identical `StateEventQuery`s are
+    cached.
+    """
+    type_to_state_keys: dict[str, set[str] | None] = {}
+
+    for state_query in additional_state:
+        existing_state_keys = type_to_state_keys.get(state_query.event_type)
+
+        if state_query.state_key is None:
+            type_to_state_keys[state_query.event_type] = None
+        elif (
+            existing_state_keys is None and state_query.event_type in type_to_state_keys
+        ):
+            continue
+        elif existing_state_keys is None:
+            type_to_state_keys[state_query.event_type] = {state_query.state_key}
+        else:
+            existing_state_keys.add(state_query.state_key)
+
+    result: list[StateEventQuery] = []
+    for event_type in sorted(type_to_state_keys):
+        state_keys = type_to_state_keys[event_type]
+        if state_keys is None:
+            result.append(StateEventQuery(event_type))
+        else:
+            result.extend(
+                StateEventQuery(event_type, state_key)
+                for state_key in sorted(state_keys)
+            )
+
+    return tuple(result)
+
+
+def _validate_and_filter_hierarchy_additional_state(
+    room: JsonDict, requested_state: Sequence[StateEventQuery]
+) -> list[JsonDict]:
+    """
+    Given the `room` field in a response to a `/hierarchy` request over
+    federation, and the `requested_state` that the homeserver desired:
+
+    - filter the response to only what we asked for
+    - ignore invalid events that were returned, rather than passing it to callers.
+
+    Results are loaded into the `org.matrix.msc4507.additional_state` field of
+    the passed `room` dict.
+
+    Args:
+        room: The contents of the `room` or one of the `children` fields in a
+            `GET /_matrix/federation/v1/hierarchy/{roomId}` response.
+        requested_state: The state events that the caller desires.
+    """
+    if len(requested_state) == 0:
+        # No state was requested. Don't return any to the client.
+        return []
+
+    additional_state = room.get("org.matrix.msc4507.additional_state")
+    if not additional_state:
+        # The field was not present or `None`.
+        return []
+
+    if not isinstance(additional_state, list):
+        logger.debug(
+            "Invalid 'org.matrix.msc4507.additional_state' field in hierarchy response for room "
+            "'%s': expected a list, got %s",
+            room.get("room_id"),
+            type(additional_state).__name__,
+        )
+        raise InvalidResponseError(
+            "'org.matrix.msc4507.additional_state' must be a list"
+        )
+
+    filtered_state: list[JsonDict] = []
+    for index, state_event in enumerate(additional_state):
+        if not isinstance(state_event, dict):
+            logger.debug(
+                "Invalid 'org.matrix.msc4507.additional_state' entry %d in hierarchy response for "
+                "room '%s': expected an object, got %s",
+                index,
+                room.get("room_id"),
+                type(state_event).__name__,
+            )
+            raise InvalidResponseError("Invalid event in 'additional_state' list")
+
+        # Check that the returned state event has valid form.
+        try:
+            _validate_hierarchy_additional_state_event(state_event)
+        except ValueError as e:
+            raise InvalidResponseError(str(e))
+
+        # Check that this is actually what we asked for.
+        if _matches_additional_state_query(state_event, requested_state):
+            filtered_state.append(state_event)
+
+    return filtered_state
+
+
+def _matches_additional_state_query(
+    state_event: JsonDict, requested_state: Sequence[StateEventQuery]
+) -> bool:
+    """
+    Validate that a given state event matches the given requested state query.
+
+    This ensures that we don't return more state than what we asked for, even if
+    the remote homeserver happens to.
+
+    Args:
+        state_event: The returned state event from the remote server.
+        requested_state: The set of locally-requested state events.
+
+    Returns:
+        True if the state_event matches the requested state, False otherwise.
+    """
+    event_type = state_event["type"]
+    state_key = state_event["state_key"]
+
+    return any(
+        requested.event_type == event_type
+        and (requested.state_key is None or requested.state_key == state_key)
+        for requested in requested_state
+    )
+
+
+def _validate_hierarchy_additional_state_event(state_event: JsonDict) -> None:
+    """
+    Validate an event within the `org.matrix.msc4507.additional_state` field
+    in a /hierarchy response.
+
+    Args:
+        state_event: The stripped state event to validate.
+
+    Raises:
+        ValueError: If the event is invalid in some way.
+    """
+
+    event_type = state_event.get("type")
+    if not isinstance(event_type, str):
+        logger.debug(
+            "Invalid event in hierarchy 'org.matrix.msc4507.additional_state': 'type' must be a "
+            "string, got %s",
+            type(event_type).__name__,
+        )
+        raise ValueError("Invalid event: 'event_type' must be a str")
+
+    state_key = state_event.get("state_key")
+    if not isinstance(state_key, str):
+        logger.debug(
+            "Invalid event in hierarchy 'org.matrix.msc4507.additional_state': 'state_key' must be "
+            "a string, got %s",
+            type(state_key).__name__,
+        )
+        raise ValueError("Invalid event: 'state_key' must be a str")
+
+    content = state_event.get("content")
+    if not isinstance(content, dict):
+        logger.debug(
+            "Invalid event in hierarchy 'org.matrix.msc4507.additional_state': 'content' must be "
+            "an object, got %s",
+            type(content).__name__,
+        )
+        raise ValueError("Invalid event: 'content' must be a dict")
+
+    sender = state_event.get("sender")
+    if not isinstance(sender, str):
+        logger.debug(
+            "Invalid event in hierarchy 'org.matrix.msc4507.additional_state': 'sender' must be a "
+            "string, got %s",
+            type(sender).__name__,
+        )
+        raise ValueError("Invalid event: 'sender' must be a str")

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -51,12 +51,39 @@ from synapse.http.client import is_unknown_endpoint
 from synapse.http.matrixfederationclient import ByteParser, LegacyJsonSendParser
 from synapse.http.types import QueryParams
 from synapse.types import JsonDict, UserID
+from synapse.types.state import StateEventQuery
 from synapse.util import ExceptionBundle
+from synapse.util.json import json_encoder
 
 if TYPE_CHECKING:
     from synapse.app.homeserver import HomeServer
 
 logger = logging.getLogger(__name__)
+
+
+def _create_room_hierarchy_args(
+    suggested_only: bool, additional_state: Iterable[StateEventQuery]
+) -> QueryParams:
+    """
+    Build HTTP query parameters for a `GET /_matrix/federation/v1/hierarchy/{roomId}`
+    request.
+    """
+    args: dict[str, str | list[str]] = {
+        "suggested_only": "true" if suggested_only else "false"
+    }
+
+    encoded_additional_state: list[str] = []
+    for state_query in additional_state:
+        value = {"type": state_query.event_type}
+        if state_query.state_key is not None:
+            value["state_key"] = state_query.state_key
+
+        encoded_additional_state.append(json_encoder.encode(value))
+
+    if encoded_additional_state:
+        args["org.matrix.msc4507.additional_state"] = encoded_additional_state
+
+    return args
 
 
 class TransportLayerClient:
@@ -65,6 +92,7 @@ class TransportLayerClient:
     def __init__(self, hs: "HomeServer"):
         self.client = hs.get_federation_http_client()
         self._is_mine_server_name = hs.is_mine_server_name
+        self._msc4507_enabled = hs.config.experimental.msc4507_enabled
 
     def shutdown(self) -> None:
         self.client.shutdown()
@@ -802,39 +830,57 @@ class TransportLayerClient:
         return await self.client.get_json(destination=destination, path=path)
 
     async def get_room_hierarchy(
-        self, destination: str, room_id: str, suggested_only: bool
+        self,
+        destination: str,
+        room_id: str,
+        suggested_only: bool,
+        additional_state: Iterable[StateEventQuery] = (),
     ) -> JsonDict:
         """
         Args:
             destination: The remote server
             room_id: The room ID to ask about.
             suggested_only: if True, only suggested rooms will be returned
+            additional_state: state events to ask for under MSC4507
         """
         path = _create_v1_path("/hierarchy/%s", room_id)
+        args = _create_room_hierarchy_args(
+            suggested_only,
+            additional_state if self._msc4507_enabled else (),
+        )
 
         return await self.client.get_json(
             destination=destination,
             path=path,
-            args={"suggested_only": "true" if suggested_only else "false"},
+            args=args,
         )
 
     async def get_room_hierarchy_unstable(
-        self, destination: str, room_id: str, suggested_only: bool
+        self,
+        destination: str,
+        room_id: str,
+        suggested_only: bool,
+        additional_state: Iterable[StateEventQuery] = (),
     ) -> JsonDict:
         """
         Args:
             destination: The remote server
             room_id: The room ID to ask about.
             suggested_only: if True, only suggested rooms will be returned
+            additional_state: state events to ask for under MSC4507
         """
         path = _create_path(
             FEDERATION_UNSTABLE_PREFIX, "/org.matrix.msc2946/hierarchy/%s", room_id
         )
+        args = _create_room_hierarchy_args(
+            suggested_only,
+            additional_state if self._msc4507_enabled else (),
+        )
 
         return await self.client.get_json(
             destination=destination,
             path=path,
-            args={"suggested_only": "true" if suggested_only else "false"},
+            args=args,
         )
 
     async def get_account_status(

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -28,6 +28,8 @@ from typing import (
     Sequence,
 )
 
+from pydantic import BaseModel, StrictStr, ValidationError
+
 from synapse.api.constants import Direction, EduTypes
 from synapse.api.errors import Codes, SynapseError
 from synapse.api.room_versions import RoomVersions
@@ -48,7 +50,8 @@ from synapse.http.servlet import (
 from synapse.http.site import SynapseRequest
 from synapse.media._base import DEFAULT_MAX_TIMEOUT_MS, MAXIMUM_ALLOWED_MAX_TIMEOUT_MS
 from synapse.media.thumbnailer import ANIMATED_THUMBNAIL_TYPE, ThumbnailProvider
-from synapse.types import JsonDict
+from synapse.types import Absent, AbsentType, JsonDict
+from synapse.types.state import StateEventQuery
 from synapse.util import SYNAPSE_VERSION
 from synapse.util.ratelimitutils import FederationRateLimiter
 
@@ -720,6 +723,7 @@ class FederationRoomHierarchyServlet(BaseFederationServlet):
     ):
         super().__init__(hs, authenticator, ratelimiter, server_name)
         self.handler = hs.get_room_summary_handler()
+        self._msc4507_enabled = hs.config.experimental.msc4507_enabled
 
     async def on_GET(
         self,
@@ -729,9 +733,78 @@ class FederationRoomHierarchyServlet(BaseFederationServlet):
         room_id: str,
     ) -> tuple[int, JsonDict]:
         suggested_only = parse_boolean_from_args(query, "suggested_only", default=False)
-        return 200, await self.handler.get_federation_hierarchy(
-            origin, room_id, suggested_only
+        additional_state = (
+            _parse_msc4507_additional_state_from_args(query)
+            if self._msc4507_enabled
+            else None
         )
+        return 200, await self.handler.get_federation_hierarchy(
+            origin, room_id, suggested_only, additional_state
+        )
+
+
+class _MSC4507AdditionalStateQuery(BaseModel):
+    """
+    The expected shape of a single `org.matrix.msc4507.additional_state` query
+    parameter once decoded as JSON.
+
+    Note that multiple may be provided in a single `/hierarchy` request.
+    """
+
+    # A state event type.
+    type: StrictStr
+    # A specific state_key to query for. If absent, the query is for a state
+    # event of the `type` type with ANY state key.
+    state_key: StrictStr | AbsentType = Absent
+
+
+def _parse_msc4507_additional_state_from_args(
+    query: Mapping[bytes, Sequence[bytes]],
+) -> tuple[StateEventQuery, ...] | None:
+    """
+    Parse zero or more instances of the `org.matrix.msc4507.additional_state`
+    query parameter in a `/hierarchy` request.
+
+    Args:
+        query: A map of the request's query parameters to their values,
+            provided by twisted.
+
+    Returns:
+        A tuple containing parsed parameters for additional state, or `None` if
+        the query parameter was not present.
+    """
+    raw_values = parse_strings_from_args(
+        query, "org.matrix.msc4507.additional_state", encoding="utf-8"
+    )
+    if raw_values is None:
+        return None
+
+    additional_state: list[StateEventQuery] = []
+    for raw_value in raw_values:
+        try:
+            value = _MSC4507AdditionalStateQuery.model_validate_json(raw_value)
+        except ValidationError as e:
+            validation_errors = e.errors(include_input=False)
+            logger.debug(
+                "Failed to parse org.matrix.msc4507.additional_state query "
+                "parameter: %s",
+                validation_errors,
+            )
+            err_type = validation_errors[0]["type"]
+            errcode = (
+                Codes.NOT_JSON if err_type == "json_invalid" else Codes.INVALID_PARAM
+            )
+            raise SynapseError(
+                400,
+                "Query parameter org.matrix.msc4507.additional_state must be a valid "
+                "JSON object with a string 'type' and optional string 'state_key'",
+                errcode,
+            )
+
+        state_key = None if value.state_key is Absent else value.state_key
+        additional_state.append(StateEventQuery(value.type, state_key))
+
+    return tuple(additional_state)
 
 
 class RoomComplexityServlet(BaseFederationServlet):

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -103,6 +103,7 @@ class RoomSummaryHandler:
         self._event_serializer = hs.get_event_client_serializer()
         self._server_name = hs.hostname
         self._federation_client = hs.get_federation_client()
+        self._msc4507_enabled = hs.config.experimental.msc4507_enabled
         self._ratelimiter = Ratelimiter(
             store=self._store,
             clock=hs.get_clock(),
@@ -439,8 +440,11 @@ class RoomSummaryHandler:
         Returns:
             The JSON hierarchy dictionary.
         """
+        if not self._msc4507_enabled:
+            additional_state = None
+
         root_room_entry = await self._summarize_local_room(
-            None, origin, requested_room_id, suggested_only
+            None, origin, requested_room_id, suggested_only, additional_state
         )
         if root_room_entry is None:
             # Room is inaccessible to the requesting server.
@@ -461,7 +465,12 @@ class RoomSummaryHandler:
                 continue
 
             room_entry = await self._summarize_local_room(
-                None, origin, room_id, suggested_only, include_children=False
+                None,
+                origin,
+                room_id,
+                suggested_only,
+                additional_state,
+                include_children=False,
             )
             # If the room is accessible, include it in the results.
             #
@@ -487,6 +496,7 @@ class RoomSummaryHandler:
         origin: str | None,
         room_id: str,
         suggested_only: bool,
+        additional_state: Sequence[StateEventQuery] | None = None,
         include_children: bool = True,
         admin_skip_room_visibility_check: bool = False,
     ) -> Optional["_RoomEntry"]:
@@ -503,6 +513,9 @@ class RoomSummaryHandler:
             room_id: The room ID to summarize.
             suggested_only: True if only suggested children should be returned.
                 Otherwise, all children are returned.
+            additional_state: State events to include in the response if the room's
+                public state declaration allows them. Should be `None` if the
+                query parameter was not present.
             include_children:
                 Whether to include the events of any children.
             admin_skip_room_visibility_check: Whether to skip checking if the room
@@ -518,6 +531,11 @@ class RoomSummaryHandler:
             return None
 
         room_entry = await self._build_room_entry(room_id)
+
+        if additional_state is not None:
+            room_entry[
+                "org.matrix.msc4507.additional_state"
+            ] = await self._get_public_room_state(room_id, additional_state)
 
         # If the room is not a space return just the room information.
         if room_entry.get("room_type") != RoomTypes.SPACE or not include_children:
@@ -837,6 +855,79 @@ class RoomSummaryHandler:
 
         return room_entry
 
+    async def _get_public_room_state(
+        self, room_id: str, requested_state: Sequence[StateEventQuery]
+    ) -> list[JsonDict]:
+        """Get requested room state that is declared public.
+
+        The room must contain an `org.matrix.msc4507.public_state` state event.
+        Invalid event shapes are ignored.
+
+        Args:
+            room_id: The room to fetch state from.
+            requested_state: A set of state event descriptions that someone is
+                asking for.
+
+        Returns:
+            A list of stripped state events that match the query, if any.
+        """
+
+        # See which state events the room has marked as "public".
+        public_state_ids = await self._storage_controllers.state.get_current_state_ids(
+            room_id,
+            state_filter=StateFilter.from_types([(EventTypes.MSC4507PublicState, "")]),
+        )
+        public_state_event_id = public_state_ids.get(
+            (EventTypes.MSC4507PublicState, "")
+        )
+        if public_state_event_id is None:
+            return []
+
+        public_state_event = await self._store.get_event(public_state_event_id)
+        raw_public_state = public_state_event.content.get("public_state")
+        if not isinstance(raw_public_state, dict):
+            logger.debug(
+                "'%s' state event in room '%s' had an invalid type for "
+                "its 'public_state' field: %s",
+                EventTypes.MSC4507PublicState,
+                room_id,
+                type(raw_public_state),
+            )
+            return []
+
+        public_state = _parse_public_state(raw_public_state)
+
+        # Fetch public room state, given the list of what's public, and a query
+        # for it.
+        permitted_state = _get_permitted_public_state(requested_state, public_state)
+        if not permitted_state:
+            # None of the requested state was allowed.
+            return []
+
+        # Pull the allowed state events from the room.
+        state_ids = await self._storage_controllers.state.get_current_state_ids(
+            room_id, state_filter=permitted_state
+        )
+        if not state_ids:
+            return []
+        events = await self._store.get_events_as_list(state_ids.values())
+
+        # Return the stripped state versions of each state event.
+        # TODO: Whether we should return stripped state is currently an open question on the MSC:
+        # https://github.com/matrix-org/matrix-spec-proposals/pull/4507/changes#r3589665252
+        stripped_state: list[JsonDict] = []
+        for event in sorted(events, key=lambda e: (e.type, e.state_key)):
+            stripped_state.append(
+                {
+                    "type": event.type,
+                    "state_key": event.state_key,
+                    "content": event.content,
+                    "sender": event.sender,
+                }
+            )
+
+        return stripped_state
+
     async def _get_child_events(self, room_id: str) -> Iterable[EventBase]:
         """
         Get the child events for a given room.
@@ -1003,6 +1094,111 @@ class _RoomEntry:
 
         result["children_state"] = self.children_state_events
         return result
+
+
+def _parse_public_state(public_state: dict) -> StateFilter:
+    """Parse an MSC4507 public state declaration into a state filter.
+
+    Invalid rules for individual event types are ignored.
+
+    Args:
+        The content of a `org.matrix.msc4507.public_state` state event.
+
+    Returns:
+        A `StateFilter` built from the parsed public state event.
+    """
+    public_types: list[tuple[str, str | None]] = []
+    for event_type, public_rule in public_state.items():
+        if not isinstance(event_type, str):
+            logger.debug(
+                "Ignoring an entry in the MSC4507 public state declaration: "
+                "event type must be a string, got %s",
+                type(event_type).__name__,
+            )
+            continue
+
+        if not isinstance(public_rule, dict):
+            logger.debug(
+                "Ignoring MSC4507 public state rule for event type '%s': "
+                "rule must be an object, got %s",
+                event_type,
+                type(public_rule).__name__,
+            )
+            continue
+
+        if "state_keys" not in public_rule:
+            public_types.append((event_type, None))
+            continue
+
+        state_keys = public_rule["state_keys"]
+        if not isinstance(state_keys, list):
+            logger.debug(
+                "Ignoring MSC4507 public state rule for event type '%s': "
+                "'state_keys' must be a list, got %s",
+                event_type,
+                type(state_keys).__name__,
+            )
+            continue
+
+        if not all(isinstance(state_key, str) for state_key in state_keys):
+            logger.debug(
+                "Ignoring MSC4507 public state rule for event type '%s': "
+                "'state_keys' must contain only strings",
+                event_type,
+            )
+            continue
+
+        # If multiple state_keys exist, create a filter for each one.
+        public_types.extend((event_type, state_key) for state_key in state_keys)
+
+    return StateFilter.from_types(public_types)
+
+
+def _get_permitted_public_state(
+    requested_state: Sequence[StateEventQuery], public_state: StateFilter
+) -> StateFilter:
+    """
+    Given a request for certain state events from a room, and a definition of
+    what state events are public, return which state event types and state_keys
+    we're actually allowed to return (AKA the intersection between the query
+    and the room's public state definition).
+
+    Args:
+        requested_state: A request for certain state event types and state_keys
+            from a room.
+        public_state: The parsed state event types and state_keys that a room has
+            explicitly marked as public.
+
+    Returns:
+        A frozen `StateFilter` representing the intersection of the requested
+        state and the room's public state declaration. May be used to pull state
+        events from the room.
+    """
+    requested_filter = StateFilter.from_types(
+        (requested.event_type, requested.state_key) for requested in requested_state
+    )
+    permitted_state: dict[str, frozenset[str] | None] = {}
+
+    # For each requested state event, check whether it may be requested based on
+    # `public_state`.
+    for event_type, requested_state_keys in requested_filter.types.items():
+        if event_type not in public_state.types:
+            continue
+
+        public_state_keys = public_state.types[event_type]
+        if public_state_keys is None:
+            # Any state key may be requested. Allow all requested.
+            permitted_state[event_type] = requested_state_keys
+        elif requested_state_keys is None:
+            # Some state keys are marked as public, but ANY were requested.
+            # Return only those that are marked as public.
+            permitted_state[event_type] = public_state_keys
+        elif permitted_keys := requested_state_keys & public_state_keys:
+            # If there is an intersection between the requested state keys and
+            # those marked as public, return those.
+            permitted_state[event_type] = permitted_keys
+
+    return StateFilter.freeze(permitted_state, include_others=False)
 
 
 def _has_valid_via(e: EventBase) -> bool:

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -561,7 +561,10 @@ class RoomSummaryHandler:
         return _RoomEntry(room_id, room_entry, stripped_events)
 
     async def _summarize_remote_room_hierarchy(
-        self, room: "_RoomQueueEntry", suggested_only: bool
+        self,
+        room: "_RoomQueueEntry",
+        suggested_only: bool,
+        additional_state: Iterable[StateEventQuery] = (),
     ) -> tuple[Optional["_RoomEntry"], dict[str, JsonDict], set[str]]:
         """
         Request room entries and a list of event entries for a given room by querying a remote server.
@@ -570,6 +573,7 @@ class RoomSummaryHandler:
             room: The room to summarize.
             suggested_only: True if only suggested children should be returned.
                 Otherwise, all children are returned.
+            additional_state: state events to ask for under MSC4507.
 
         Returns:
             A tuple of:
@@ -579,6 +583,9 @@ class RoomSummaryHandler:
         """
         room_id = room.room_id
         logger.info("Requesting summary for %s via %s", room_id, room.via)
+
+        if not self._msc4507_enabled:
+            additional_state = ()
 
         via = itertools.islice(room.via, MAX_SERVERS_PER_SPACE)
         try:
@@ -591,6 +598,7 @@ class RoomSummaryHandler:
                 via,
                 room_id,
                 suggested_only=suggested_only,
+                additional_state=additional_state,
             )
         except Exception as e:
             logger.warning(

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -45,7 +45,7 @@ from synapse.api.ratelimiting import Ratelimiter
 from synapse.config.ratelimiting import RatelimitSettings
 from synapse.events import EventBase
 from synapse.types import JsonDict, Requester, StrCollection
-from synapse.types.state import StateFilter
+from synapse.types.state import StateEventQuery, StateFilter
 from synapse.util.caches.response_cache import ResponseCache
 
 if TYPE_CHECKING:
@@ -418,6 +418,7 @@ class RoomSummaryHandler:
         origin: str,
         requested_room_id: str,
         suggested_only: bool,
+        additional_state: Sequence[StateEventQuery] | None = None,
     ) -> JsonDict:
         """
         Implementation of the room hierarchy Federation API.
@@ -431,6 +432,9 @@ class RoomSummaryHandler:
             requested_room_id: The room ID to start the hierarchy at (the "root" room).
             suggested_only: whether we should only return children with the "suggested"
                 flag set.
+            additional_state: State events to include in the response if the room's
+                public state declaration allows them. None if the query parameter
+                was not present.
 
         Returns:
             The JSON hierarchy dictionary.

--- a/synapse/types/state.py
+++ b/synapse/types/state.py
@@ -47,6 +47,15 @@ T = TypeVar("T")
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
+class StateEventQuery:
+    """A query for a state event type and optional state key."""
+
+    event_type: str
+    # None means all state keys for the event type.
+    state_key: str | None = None
+
+
+@attr.s(slots=True, frozen=True, auto_attribs=True)
 class StateFilter:
     """A filter used when querying for state.
 

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -19,8 +19,9 @@
 #
 #
 import logging
+import urllib.parse
 from http import HTTPStatus
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from parameterized import parameterized
 
@@ -39,7 +40,9 @@ from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.storage.controllers.state import server_acl_evaluator_from_event
 from synapse.types import JsonDict
+from synapse.types.state import StateEventQuery
 from synapse.util.clock import Clock
+from synapse.util.json import json_encoder
 
 from tests import unittest
 from tests.test_utils.event_builders import make_test_event, make_test_pdu_event
@@ -73,6 +76,119 @@ class FederationServerTests(unittest.FederatingHomeserverTestCase):
             "/_matrix/federation/v1/get_missing_events/%s" % (room_1,),
             query_content,
         )
+        self.assertEqual(HTTPStatus.BAD_REQUEST, channel.code, channel.result)
+        self.assertEqual(channel.json_body["errcode"], "M_NOT_JSON")
+
+    @override_config({"experimental_features": {"msc4507_enabled": True}})
+    def test_hierarchy_additional_state_query_parameter(self) -> None:
+        """The federation hierarchy servlet parses repeated MSC4507 JSON params."""
+        u1 = self.register_user("u1", "pass")
+        u1_token = self.login("u1", "pass")
+
+        room_id = self.helper.create_room_as(u1, tok=u1_token)
+        event_type = "m.some_event"
+        self.helper.send_state(
+            room_id,
+            event_type=event_type,
+            body={"foo": ["bar"]},
+            tok=u1_token,
+        )
+        self.helper.send_state(
+            room_id,
+            event_type=EventTypes.MSC4507PublicState,
+            body={"public_state": {event_type: {"state_keys": [""]}}},
+            tok=u1_token,
+        )
+
+        query = urllib.parse.urlencode(
+            [
+                (
+                    "org.matrix.msc4507.additional_state",
+                    json_encoder.encode({"type": event_type, "state_key": ""}),
+                )
+            ]
+        )
+
+        channel = self.make_signed_federation_request(
+            "GET", f"/_matrix/federation/v1/hierarchy/{room_id}?{query}"
+        )
+
+        self.assertEqual(HTTPStatus.OK, channel.code, channel.result)
+        self.assertEqual(
+            channel.json_body["room"]["org.matrix.msc4507.additional_state"],
+            [
+                {
+                    "type": event_type,
+                    "state_key": "",
+                    "content": {"foo": ["bar"]},
+                    "sender": u1,
+                }
+            ],
+        )
+
+    @override_config({"experimental_features": {"msc4507_enabled": True}})
+    def test_hierarchy_additional_state_percent_encoded_state_key(self) -> None:
+        """MSC4507 query values are percent-decoded exactly once."""
+        room_id = "!unknown:test"
+        event_type = "m.some_event_type"
+        state_key = "%22"
+        room_summary_handler = self.hs.get_room_summary_handler()
+        room_summary_handler.get_federation_hierarchy = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        query = urllib.parse.urlencode(
+            [
+                (
+                    "org.matrix.msc4507.additional_state",
+                    json_encoder.encode({"type": event_type, "state_key": state_key}),
+                )
+            ]
+        )
+        self.assertIn("%2522", query)
+
+        channel = self.make_signed_federation_request(
+            "GET", f"/_matrix/federation/v1/hierarchy/{room_id}?{query}"
+        )
+
+        self.assertEqual(HTTPStatus.OK, channel.code, channel.result)
+        room_summary_handler.get_federation_hierarchy.assert_awaited_once_with(
+            self.OTHER_SERVER_NAME,
+            room_id,
+            False,
+            (StateEventQuery(event_type, state_key),),
+        )
+
+    @override_config({"experimental_features": {"msc4507_enabled": True}})
+    def test_hierarchy_additional_state_rejects_non_string_state_key(self) -> None:
+        """MSC4507 query objects must omit state_key or use a string."""
+        query = urllib.parse.urlencode(
+            [
+                (
+                    "org.matrix.msc4507.additional_state",
+                    json_encoder.encode(
+                        {"type": "m.some_event_type", "state_key": None}
+                    ),
+                )
+            ]
+        )
+
+        channel = self.make_signed_federation_request(
+            "GET", f"/_matrix/federation/v1/hierarchy/!unknown:test?{query}"
+        )
+
+        self.assertEqual(HTTPStatus.BAD_REQUEST, channel.code, channel.result)
+        self.assertEqual(channel.json_body["errcode"], "M_INVALID_PARAM")
+
+    @override_config({"experimental_features": {"msc4507_enabled": True}})
+    def test_hierarchy_additional_state_rejects_invalid_json(self) -> None:
+        """MSC4507 query objects must be valid JSON."""
+        query = urllib.parse.urlencode(
+            [("org.matrix.msc4507.additional_state", "not json")]
+        )
+
+        channel = self.make_signed_federation_request(
+            "GET", f"/_matrix/federation/v1/hierarchy/!unknown:test?{query}"
+        )
+
         self.assertEqual(HTTPStatus.BAD_REQUEST, channel.code, channel.result)
         self.assertEqual(channel.json_body["errcode"], "M_NOT_JSON")
 

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -526,37 +526,6 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
 
         self.assertNotIn("org.matrix.msc4507.additional_state", result["room"])
 
-    @override_config({"experimental_features": {"msc4507_enabled": True}})
-    def test_msc4507_public_state_default_power_level(self) -> None:
-        """New rooms require PL100 to send the MSC4507 public-state event."""
-        state_ids = self.get_success(
-            self.hs.get_storage_controllers().state.get_current_state_ids(self.space)
-        )
-        power_levels = self.get_success(
-            self.hs.get_datastores().main.get_event(
-                state_ids[(EventTypes.PowerLevels, "")]
-            )
-        )
-
-        self.assertEqual(
-            power_levels.content["events"][EventTypes.MSC4507PublicState], 100
-        )
-
-    def test_msc4507_public_state_default_power_level_disabled_by_default(
-        self,
-    ) -> None:
-        """The MSC4507 public-state PL rule is gated by experimental config."""
-        state_ids = self.get_success(
-            self.hs.get_storage_controllers().state.get_current_state_ids(self.space)
-        )
-        power_levels = self.get_success(
-            self.hs.get_datastores().main.get_event(
-                state_ids[(EventTypes.PowerLevels, "")]
-            )
-        )
-
-        self.assertNotIn(EventTypes.MSC4507PublicState, power_levels.content["events"])
-
     @override_config({"rc_room_creation": {"burst_count": 1000, "per_second": 1}})
     def test_large_space(self) -> None:
         """Test a space with a large number of rooms."""

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -36,11 +36,17 @@ from synapse.api.constants import (
 from synapse.api.errors import AuthError, NotFoundError, SynapseError
 from synapse.api.room_versions import RoomVersions
 from synapse.federation.transport.client import TransportLayerClient
-from synapse.handlers.room_summary import _child_events_comparison_key, _RoomEntry
+from synapse.handlers.room_summary import (
+    _child_events_comparison_key,
+    _get_permitted_public_state,
+    _parse_public_state,
+    _RoomEntry,
+)
 from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.types import JsonDict, UserID, create_requester
+from synapse.types.state import StateEventQuery, StateFilter
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -118,6 +124,62 @@ class TestSpaceSummarySort(unittest.TestCase):
 
         ev1 = _create_event("!abc:test", "a" * 51)
         self.assertEqual([ev2, ev1], _order(ev1, ev2))
+
+
+class PublicStateTestCase(unittest.TestCase):
+    def test_parse_public_state(self) -> None:
+        """Public state rules are validated and normalized independently."""
+        public_state = _parse_public_state(
+            {
+                "wildcard": {},
+                "limited": {"state_keys": ["one", "two", "one"]},
+                "empty": {"state_keys": []},
+                "invalid_rule": [],
+                "invalid_state_keys": {"state_keys": ["one", 2]},
+            }
+        )
+
+        self.assertEqual(
+            public_state,
+            StateFilter.from_types(
+                [("wildcard", None), ("limited", "one"), ("limited", "two")]
+            ),
+        )
+
+    def test_get_permitted_public_state(self) -> None:
+        """Requested state is intersected with normalized public state rules."""
+        public_state = StateFilter.from_types(
+            [
+                ("wildcard", None),
+                ("limited", "one"),
+                ("limited", "two"),
+                ("overlap", "one"),
+                ("overlap", "two"),
+            ]
+        )
+
+        permitted_state = _get_permitted_public_state(
+            [
+                StateEventQuery("wildcard", "requested"),
+                StateEventQuery("limited"),
+                StateEventQuery("overlap", "two"),
+                StateEventQuery("overlap", "three"),
+                StateEventQuery("private"),
+            ],
+            public_state,
+        )
+
+        self.assertEqual(
+            permitted_state,
+            StateFilter.from_types(
+                [
+                    ("wildcard", "requested"),
+                    ("limited", "one"),
+                    ("limited", "two"),
+                    ("overlap", "two"),
+                ]
+            ),
+        )
 
 
 class SpaceSummaryTestCase(unittest.HomeserverTestCase):
@@ -245,6 +307,255 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
             self.handler.get_room_hierarchy(create_requester(self.user), self.space)
         )
         self._assert_hierarchy(result, expected)
+
+    @override_config({"experimental_features": {"msc4507_enabled": True}})
+    def test_federation_hierarchy_additional_state(self) -> None:
+        """Federation hierarchy can include requested public state for each room."""
+        event_type = "m.security_labels"
+        self.helper.send_state(
+            self.space,
+            event_type=event_type,
+            body={"labels": ["space-label"]},
+            tok=self.token,
+        )
+        self.helper.send_state(
+            self.room,
+            event_type=event_type,
+            body={"labels": ["room-label"]},
+            tok=self.token,
+        )
+        for room_id in (self.space, self.room):
+            self.helper.send_state(
+                room_id,
+                event_type=EventTypes.MSC4507PublicState,
+                body={"public_state": {event_type: {"state_keys": [""]}}},
+                tok=self.token,
+            )
+
+        result = self.get_success(
+            self.handler.get_federation_hierarchy(
+                "remote.example.com",
+                self.space,
+                suggested_only=False,
+                additional_state=(StateEventQuery(event_type, ""),),
+            )
+        )
+
+        self.assertEqual(
+            result["room"]["org.matrix.msc4507.additional_state"],
+            [
+                {
+                    "type": event_type,
+                    "state_key": "",
+                    "content": {"labels": ["space-label"]},
+                    "sender": self.user,
+                }
+            ],
+        )
+        self.assertEqual(
+            result["children"][0]["org.matrix.msc4507.additional_state"],
+            [
+                {
+                    "type": event_type,
+                    "state_key": "",
+                    "content": {"labels": ["room-label"]},
+                    "sender": self.user,
+                }
+            ],
+        )
+
+    @override_config({"experimental_features": {"msc4507_enabled": True}})
+    def test_federation_hierarchy_additional_state_requires_public_state(
+        self,
+    ) -> None:
+        """Requested state is omitted if the room has not declared it public."""
+        event_type = "m.security_labels"
+        self.helper.send_state(
+            self.space,
+            event_type=event_type,
+            body={"labels": ["secret"]},
+            tok=self.token,
+        )
+
+        result = self.get_success(
+            self.handler.get_federation_hierarchy(
+                "remote.example.com",
+                self.space,
+                suggested_only=False,
+                additional_state=(StateEventQuery(event_type, ""),),
+            )
+        )
+
+        self.assertEqual(result["room"]["org.matrix.msc4507.additional_state"], [])
+
+    @override_config({"experimental_features": {"msc4507_enabled": True}})
+    def test_federation_hierarchy_additional_state_supports_state_key_wildcard(
+        self,
+    ) -> None:
+        """Omitting state_key requests all public state keys for that type."""
+        event_type = "com.example.some_state"
+        self.helper.send_state(
+            self.space,
+            event_type=event_type,
+            state_key="allowed",
+            body={"value": "allowed"},
+            tok=self.token,
+        )
+        self.helper.send_state(
+            self.space,
+            event_type=event_type,
+            state_key="private",
+            body={"value": "private"},
+            tok=self.token,
+        )
+        self.helper.send_state(
+            self.space,
+            event_type=EventTypes.MSC4507PublicState,
+            body={"public_state": {event_type: {}}},
+            tok=self.token,
+        )
+
+        result = self.get_success(
+            self.handler.get_federation_hierarchy(
+                "remote.example.com",
+                self.space,
+                suggested_only=False,
+                additional_state=(StateEventQuery(event_type),),
+            )
+        )
+
+        self.assertEqual(
+            result["room"]["org.matrix.msc4507.additional_state"],
+            [
+                {
+                    "type": event_type,
+                    "state_key": "allowed",
+                    "content": {"value": "allowed"},
+                    "sender": self.user,
+                },
+                {
+                    "type": event_type,
+                    "state_key": "private",
+                    "content": {"value": "private"},
+                    "sender": self.user,
+                },
+            ],
+        )
+
+        self.helper.send_state(
+            self.space,
+            event_type=EventTypes.MSC4507PublicState,
+            body={"public_state": {event_type: {"state_keys": ["allowed"]}}},
+            tok=self.token,
+        )
+
+        result = self.get_success(
+            self.handler.get_federation_hierarchy(
+                "remote.example.com",
+                self.space,
+                suggested_only=False,
+                additional_state=(StateEventQuery(event_type),),
+            )
+        )
+
+        self.assertEqual(
+            result["room"]["org.matrix.msc4507.additional_state"],
+            [
+                {
+                    "type": event_type,
+                    "state_key": "allowed",
+                    "content": {"value": "allowed"},
+                    "sender": self.user,
+                }
+            ],
+        )
+
+    @override_config({"experimental_features": {"msc4507_enabled": True}})
+    def test_federation_hierarchy_additional_state_omitted_without_query(
+        self,
+    ) -> None:
+        """The federation hierarchy response is unchanged without the MSC query."""
+        event_type = "m.security_labels"
+        self.helper.send_state(
+            self.space,
+            event_type=event_type,
+            body={"labels": ["public"]},
+            tok=self.token,
+        )
+        self.helper.send_state(
+            self.space,
+            event_type=EventTypes.MSC4507PublicState,
+            body={"public_state": {event_type: {"state_keys": [""]}}},
+            tok=self.token,
+        )
+
+        result = self.get_success(
+            self.handler.get_federation_hierarchy(
+                "remote.example.com", self.space, suggested_only=False
+            )
+        )
+
+        self.assertNotIn("org.matrix.msc4507.additional_state", result["room"])
+
+    def test_federation_hierarchy_additional_state_disabled_by_default(
+        self,
+    ) -> None:
+        """The MSC4507 hierarchy response field is gated by experimental config."""
+        event_type = "m.security_labels"
+        self.helper.send_state(
+            self.space,
+            event_type=event_type,
+            body={"labels": ["public"]},
+            tok=self.token,
+        )
+        self.helper.send_state(
+            self.space,
+            event_type=EventTypes.MSC4507PublicState,
+            body={"public_state": {event_type: {"state_keys": [""]}}},
+            tok=self.token,
+        )
+
+        result = self.get_success(
+            self.handler.get_federation_hierarchy(
+                "remote.example.com",
+                self.space,
+                suggested_only=False,
+                additional_state=(StateEventQuery(event_type, ""),),
+            )
+        )
+
+        self.assertNotIn("org.matrix.msc4507.additional_state", result["room"])
+
+    @override_config({"experimental_features": {"msc4507_enabled": True}})
+    def test_msc4507_public_state_default_power_level(self) -> None:
+        """New rooms require PL100 to send the MSC4507 public-state event."""
+        state_ids = self.get_success(
+            self.hs.get_storage_controllers().state.get_current_state_ids(self.space)
+        )
+        power_levels = self.get_success(
+            self.hs.get_datastores().main.get_event(
+                state_ids[(EventTypes.PowerLevels, "")]
+            )
+        )
+
+        self.assertEqual(
+            power_levels.content["events"][EventTypes.MSC4507PublicState], 100
+        )
+
+    def test_msc4507_public_state_default_power_level_disabled_by_default(
+        self,
+    ) -> None:
+        """The MSC4507 public-state PL rule is gated by experimental config."""
+        state_ids = self.get_success(
+            self.hs.get_storage_controllers().state.get_current_state_ids(self.space)
+        )
+        power_levels = self.get_success(
+            self.hs.get_datastores().main.get_event(
+                state_ids[(EventTypes.PowerLevels, "")]
+            )
+        )
+
+        self.assertNotIn(EventTypes.MSC4507PublicState, power_levels.content["events"])
 
     @override_config({"rc_room_creation": {"burst_count": 1000, "per_second": 1}})
     def test_large_space(self) -> None:
@@ -1024,6 +1335,7 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
             destination: str,
             room_id: str,
             suggested_only: bool,
+            additional_state: Iterable[StateEventQuery] = (),
         ) -> JsonDict:
             nonlocal federation_requests
             federation_requests += 1


### PR DESCRIPTION
A draft implementation of MSC4507. Implementing responding to and requesting additional state the [`GET
/_matrix/federation/v1/hierarchy/{roomId}`](https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1hierarchyroomid) endpoint.

The requesting part currently isn't too useful, as there's no client endpoint to request additional state yet (not defined by any MSC). The use case behind this is for a Synapse module to use when requesting additional state from other homeservers, hence the lack of client endpoint. That can change if this ends up being generally useful.

I envision a Synapse module being able to ask Synapse to complete an arbitrary, signed federation request. Rather than implementing a specific Module API to request room summaries.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
