### PR TITLE
Support federated third-party network lookups (MSC4517)

### DIFF
--- a/changelog.d/19994.feature
+++ b/changelog.d/19994.feature
@@ -1,0 +1,1 @@
+Add an experimental implementation of [MSC4517](https://github.com/matrix-org/matrix-spec-proposals/pull/4517): federated third-party network lookups.

--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -73,4 +73,5 @@ pub struct ExperimentalConfig {
     pub msc4491_enabled: bool,
     pub msc4143_enabled: bool,
     pub msc4446_enabled: bool,
+    pub msc4517_enabled: bool,
 }

--- a/rust/src/handlers/versions.rs
+++ b/rust/src/handlers/versions.rs
@@ -269,6 +269,9 @@ pub struct UnstableFeatureMap {
     /// MSC4446: Allow moving the fully read marker backwards.
     #[serde(rename = "com.beeper.msc4446")]
     msc4446_enabled: bool,
+    /// MSC4517: Federated third-party network lookups
+    #[serde(rename = "org.matrix.msc4517.thirdparty")]
+    msc4517_enabled: bool,
 
     // Whether new rooms will be set to encrypted or not (based on presets).
     #[serde(rename = "io.element.e2ee_forced.public")]
@@ -320,6 +323,7 @@ pub fn synapse_config_to_global_unstable_feature_map(
         msc4491_enabled: config.experimental.msc4491_enabled,
         msc4143_enabled: config.experimental.msc4143_enabled,
         msc4446_enabled: config.experimental.msc4446_enabled,
+        msc4517_enabled: config.experimental.msc4517_enabled,
         e2ee_forced_public: config
             .room
             .encryption_enabled_by_default_for_room_presets

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -309,3 +309,15 @@ class ExperimentalConfig(Config):
 
         # MSC4491: Invite reasons in room creation
         self.msc4491_enabled: bool = experimental.get("msc4491_enabled", False)
+
+        # MSC4517: Federated third-party network lookups: allow the
+        # /thirdparty client endpoints to be pointed at a remote server
+        # (?server=), proxying the query to that server's appservices over
+        # federation.
+        self.msc4517_enabled: bool = experimental.get("msc4517_enabled", False)
+
+        # How long (in ms) to wait for a remote server to answer a federated
+        # third-party lookup before giving up on it.
+        self.msc4517_lookup_timeout: int = experimental.get(
+            "msc4517_lookup_timeout", 5000
+        )

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -134,6 +134,7 @@ class FederationClient(FederationBase):
         self._clock.looping_call(self._clear_tried_cache, Duration(minutes=1))
         self.state = hs.get_state_handler()
         self.transport_layer = hs.get_federation_transport_client()
+        self._thirdparty_lookup_timeout = hs.config.experimental.msc4517_lookup_timeout
 
         self.server_name = hs.hostname
         self.signing_key = hs.signing_key
@@ -1915,6 +1916,59 @@ class FederationClient(FederationBase):
         filtered_failures = list(filter(filter_user_id, failures))
 
         return filtered_statuses, filtered_failures
+
+    async def get_thirdparty_protocols(self, destination: str) -> JsonDict:
+        """Fetch the third-party protocol metadata of a remote server.
+
+        Returns an empty dict if the remote query fails.
+        """
+        try:
+            return await self.transport_layer.get_thirdparty_protocols(
+                destination, self._thirdparty_lookup_timeout
+            )
+        except Exception:
+            logger.warning(
+                "Error fetching thirdparty protocols from %s",
+                destination,
+                exc_info=True,
+            )
+            return {}
+
+    async def get_thirdparty_entities(
+        self,
+        destination: str,
+        kind: str,
+        protocol: str,
+        fields: Mapping[str, Iterable[str]],
+    ) -> list[JsonDict]:
+        """Look up third-party users or locations on a remote server.
+
+        Args:
+            destination: The remote server.
+            kind: "user" or "location".
+            protocol: The third-party protocol to query.
+            fields: Protocol-specific query fields.
+
+        Returns an empty list if the remote query fails.
+        """
+        try:
+            response = await self.transport_layer.get_thirdparty_entities(
+                destination, kind, protocol, fields, self._thirdparty_lookup_timeout
+            )
+        except Exception:
+            logger.warning(
+                "Error looking up thirdparty %s/%s on %s",
+                kind,
+                protocol,
+                destination,
+                exc_info=True,
+            )
+            return []
+
+        results = response.get("results", [])
+        if not isinstance(results, list):
+            return []
+        return results
 
     async def federation_download_media(
         self,

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -853,6 +853,61 @@ class TransportLayerClient:
             destination=destination, path=path, data={"user_ids": user_ids}
         )
 
+    async def get_thirdparty_protocols(
+        self, destination: str, timeout: int
+    ) -> JsonDict:
+        """Fetch the third-party protocol metadata of a remote server.
+
+        Args:
+            destination: The remote server.
+            timeout: How long to wait for the remote response, in ms.
+        """
+        path = _create_path(
+            FEDERATION_UNSTABLE_PREFIX, "/org.matrix.msc4517.thirdparty/protocols"
+        )
+
+        return await self.client.get_json(
+            destination=destination,
+            path=path,
+            ignore_backoff=True,
+            timeout=timeout,
+        )
+
+    async def get_thirdparty_entities(
+        self,
+        destination: str,
+        kind: str,
+        protocol: str,
+        fields: Mapping[str, Iterable[str]],
+        timeout: int,
+    ) -> JsonDict:
+        """Look up third-party users or locations on a remote server.
+
+        Returns:
+            A dict with a "results" key holding the list of matches.
+
+        Args:
+            destination: The remote server.
+            kind: "user" or "location".
+            protocol: The third-party protocol to query.
+            fields: Protocol-specific query fields.
+            timeout: How long to wait for the remote response, in ms.
+        """
+        path = _create_path(
+            FEDERATION_UNSTABLE_PREFIX,
+            "/org.matrix.msc4517.thirdparty/%s/%s",
+            kind,
+            protocol,
+        )
+
+        return await self.client.get_json(
+            destination=destination,
+            path=path,
+            args={k: list(v) for k, v in fields.items()},
+            ignore_backoff=True,
+            timeout=timeout,
+        )
+
     async def download_media_r0(
         self,
         destination: str,

--- a/synapse/federation/transport/server/__init__.py
+++ b/synapse/federation/transport/server/__init__.py
@@ -33,6 +33,9 @@ from synapse.federation.transport.server.federation import (
     FederationAccountStatusServlet,
     FederationMediaDownloadServlet,
     FederationMediaThumbnailServlet,
+    FederationThirdPartyLocationServlet,
+    FederationThirdPartyProtocolsServlet,
+    FederationThirdPartyUserServlet,
     FederationUnstableClientKeysClaimServlet,
     FederationUnstableGetExtremitiesServlet,
 )
@@ -331,6 +334,17 @@ def register_servlets(
             if (
                 servletclass == FederationUnstableGetExtremitiesServlet
                 and not hs.config.experimental.msc4370_enabled
+            ):
+                continue
+
+            if (
+                servletclass
+                in (
+                    FederationThirdPartyProtocolsServlet,
+                    FederationThirdPartyUserServlet,
+                    FederationThirdPartyLocationServlet,
+                )
+                and not hs.config.experimental.msc4517_enabled
             ):
                 continue
 

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -28,7 +28,7 @@ from typing import (
     Sequence,
 )
 
-from synapse.api.constants import Direction, EduTypes
+from synapse.api.constants import Direction, EduTypes, ThirdPartyEntityKind
 from synapse.api.errors import Codes, SynapseError
 from synapse.api.room_versions import RoomVersions
 from synapse.api.urls import FEDERATION_UNSTABLE_PREFIX, FEDERATION_V2_PREFIX
@@ -806,6 +806,72 @@ class FederationAccountStatusServlet(BaseFederationServerServlet):
         return 200, {"account_statuses": statuses, "failures": failures}
 
 
+class BaseFederationThirdPartyServlet(BaseFederationServlet):
+    """Base for the federated third-party lookup servlets (MSC4517).
+
+    These mirror the client-server /thirdparty lookup endpoints, letting a
+    remote homeserver query this server's bridges. Only appservices registered
+    on this server are consulted; requests are never re-delegated.
+    """
+
+    PREFIX = FEDERATION_UNSTABLE_PREFIX + "/org.matrix.msc4517.thirdparty"
+
+    def __init__(
+        self,
+        hs: "HomeServer",
+        authenticator: Authenticator,
+        ratelimiter: FederationRateLimiter,
+        server_name: str,
+    ):
+        super().__init__(hs, authenticator, ratelimiter, server_name)
+        self.appservice_handler = hs.get_application_service_handler()
+
+
+class FederationThirdPartyProtocolsServlet(BaseFederationThirdPartyServlet):
+    PATH = "/protocols"
+
+    async def on_GET(
+        self,
+        origin: str,
+        content: Literal[None],
+        query: dict[bytes, list[bytes]],
+    ) -> tuple[int, JsonDict]:
+        protocols = await self.appservice_handler.get_3pe_protocols()
+        return 200, protocols
+
+
+class FederationThirdPartyUserServlet(BaseFederationThirdPartyServlet):
+    PATH = "/user/(?P<protocol>[^/]+)$"
+
+    async def on_GET(
+        self,
+        origin: str,
+        content: Literal[None],
+        query: dict[bytes, list[bytes]],
+        protocol: str,
+    ) -> tuple[int, JsonDict]:
+        results = await self.appservice_handler.query_3pe(
+            ThirdPartyEntityKind.USER, protocol, query
+        )
+        return 200, {"results": results}
+
+
+class FederationThirdPartyLocationServlet(BaseFederationThirdPartyServlet):
+    PATH = "/location/(?P<protocol>[^/]+)$"
+
+    async def on_GET(
+        self,
+        origin: str,
+        content: Literal[None],
+        query: dict[bytes, list[bytes]],
+        protocol: str,
+    ) -> tuple[int, JsonDict]:
+        results = await self.appservice_handler.query_3pe(
+            ThirdPartyEntityKind.LOCATION, protocol, query
+        )
+        return 200, {"results": results}
+
+
 class FederationMediaDownloadServlet(BaseFederationServerServlet):
     """
     Implementation of new federation media `/download` endpoint outlined in MSC3916. Returns
@@ -935,4 +1001,7 @@ FEDERATION_SERVLET_CLASSES: tuple[type[BaseFederationServlet], ...] = (
     FederationV1SendKnockServlet,
     FederationMakeKnockServlet,
     FederationAccountStatusServlet,
+    FederationThirdPartyProtocolsServlet,
+    FederationThirdPartyUserServlet,
+    FederationThirdPartyLocationServlet,
 )

--- a/synapse/rest/client/thirdparty.py
+++ b/synapse/rest/client/thirdparty.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 
 from synapse.api.constants import ThirdPartyEntityKind
 from synapse.http.server import HttpServer
-from synapse.http.servlet import RestServlet
+from synapse.http.servlet import RestServlet, parse_string
 from synapse.http.site import SynapseRequest
 from synapse.types import JsonDict
 
@@ -36,91 +36,125 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class ThirdPartyProtocolsServlet(RestServlet):
-    PATTERNS = client_patterns("/thirdparty/protocols")
-
+class ThirdPartyBaseServlet(RestServlet):
     def __init__(self, hs: "HomeServer"):
         super().__init__()
 
+        self.hs = hs
         self.auth = hs.get_auth()
         self.appservice_handler = hs.get_application_service_handler()
+        self.federation_client = hs.get_federation_client()
+        self.federated_lookup_enabled = hs.config.experimental.msc4517_enabled
+
+    def get_remote_server(self, request: SynapseRequest) -> str | None:
+        """Return the remote server this request targets (via ?server=), or
+        None when the request is for the local server's bridges.
+        """
+        if not self.federated_lookup_enabled:
+            return None
+        server = parse_string(request, "server")
+        if server is None or self.hs.is_mine_server_name(server):
+            return None
+        return server
+
+
+class ThirdPartyProtocolsServlet(ThirdPartyBaseServlet):
+    PATTERNS = client_patterns("/thirdparty/protocols")
 
     async def on_GET(self, request: SynapseRequest) -> tuple[int, JsonDict]:
         await self.auth.get_user_by_req(request, allow_guest=True)
 
-        protocols = await self.appservice_handler.get_3pe_protocols()
+        server = self.get_remote_server(request)
+        if server is not None:
+            protocols = await self.federation_client.get_thirdparty_protocols(server)
+        else:
+            protocols = await self.appservice_handler.get_3pe_protocols()
         return 200, protocols
 
 
-class ThirdPartyProtocolServlet(RestServlet):
+class ThirdPartyProtocolServlet(ThirdPartyBaseServlet):
     PATTERNS = client_patterns("/thirdparty/protocol/(?P<protocol>[^/]+)$")
-
-    def __init__(self, hs: "HomeServer"):
-        super().__init__()
-
-        self.auth = hs.get_auth()
-        self.appservice_handler = hs.get_application_service_handler()
 
     async def on_GET(
         self, request: SynapseRequest, protocol: str
     ) -> tuple[int, JsonDict]:
         await self.auth.get_user_by_req(request, allow_guest=True)
 
-        protocols = await self.appservice_handler.get_3pe_protocols(
-            only_protocol=protocol
-        )
+        server = self.get_remote_server(request)
+        if server is not None:
+            protocols = await self.federation_client.get_thirdparty_protocols(server)
+        else:
+            protocols = await self.appservice_handler.get_3pe_protocols(
+                only_protocol=protocol
+            )
         if protocol in protocols:
             return 200, protocols[protocol]
         else:
             return 404, {"error": "Unknown protocol"}
 
 
-class ThirdPartyUserServlet(RestServlet):
+class ThirdPartyUserServlet(ThirdPartyBaseServlet):
     PATTERNS = client_patterns("/thirdparty/user(/(?P<protocol>[^/]+))?$")
 
-    def __init__(self, hs: "HomeServer"):
-        super().__init__()
-
-        self.auth = hs.get_auth()
-        self.appservice_handler = hs.get_application_service_handler()
-
     async def on_GET(
         self, request: SynapseRequest, protocol: str
     ) -> tuple[int, list[JsonDict]]:
         await self.auth.get_user_by_req(request, allow_guest=True)
 
+        server = self.get_remote_server(request)
+
         fields: dict[bytes, list[bytes]] = request.args  # type: ignore[assignment]
         fields.pop(b"access_token", None)
+        fields.pop(b"server", None)
 
-        results = await self.appservice_handler.query_3pe(
-            ThirdPartyEntityKind.USER, protocol, fields
-        )
+        if server is not None:
+            results = await self.federation_client.get_thirdparty_entities(
+                server,
+                "user",
+                protocol,
+                _decode_fields(fields),
+            )
+        else:
+            results = await self.appservice_handler.query_3pe(
+                ThirdPartyEntityKind.USER, protocol, fields
+            )
 
         return 200, results
 
 
-class ThirdPartyLocationServlet(RestServlet):
+class ThirdPartyLocationServlet(ThirdPartyBaseServlet):
     PATTERNS = client_patterns("/thirdparty/location(/(?P<protocol>[^/]+))?$")
 
-    def __init__(self, hs: "HomeServer"):
-        super().__init__()
-
-        self.auth = hs.get_auth()
-        self.appservice_handler = hs.get_application_service_handler()
-
     async def on_GET(
         self, request: SynapseRequest, protocol: str
     ) -> tuple[int, list[JsonDict]]:
         await self.auth.get_user_by_req(request, allow_guest=True)
 
+        server = self.get_remote_server(request)
+
         fields: dict[bytes, list[bytes]] = request.args  # type: ignore[assignment]
         fields.pop(b"access_token", None)
+        fields.pop(b"server", None)
 
-        results = await self.appservice_handler.query_3pe(
-            ThirdPartyEntityKind.LOCATION, protocol, fields
-        )
+        if server is not None:
+            results = await self.federation_client.get_thirdparty_entities(
+                server,
+                "location",
+                protocol,
+                _decode_fields(fields),
+            )
+        else:
+            results = await self.appservice_handler.query_3pe(
+                ThirdPartyEntityKind.LOCATION, protocol, fields
+            )
 
         return 200, results
+
+
+def _decode_fields(fields: dict[bytes, list[bytes]]) -> dict[str, list[str]]:
+    return {
+        k.decode("utf-8"): [v.decode("utf-8") for v in vs] for k, vs in fields.items()
+    }
 
 
 def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -20,7 +20,7 @@
 #
 import logging
 from http import HTTPStatus
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from parameterized import parameterized
 
@@ -92,6 +92,69 @@ class FederationServerTests(unittest.FederatingHomeserverTestCase):
             {"edus": [{"edu_type": "FAIL_EDU_TYPE", "content": {}}]},
         )
         self.assertEqual(500, channel.code, channel.result)
+
+
+class FederationThirdPartyLookupTests(unittest.FederatingHomeserverTestCase):
+    """Tests for the federated third-party lookup servlets."""
+
+    PREFIX = "/_matrix/federation/unstable/org.matrix.msc4517.thirdparty"
+
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        config["experimental_features"] = {"msc4517_enabled": True}
+        return config
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        super().prepare(reactor, clock, hs)
+        self.appservice_handler = hs.get_application_service_handler()
+        self.appservice_handler.query_3pe = AsyncMock(  # type: ignore[method-assign]
+            return_value=[
+                {
+                    "userid": "@_xmpp_someone:test",
+                    "protocol": "xmpp",
+                    "fields": {"username": "someone"},
+                }
+            ]
+        )
+        self.appservice_handler.get_3pe_protocols = AsyncMock(  # type: ignore[method-assign]
+            return_value={"xmpp": {"instances": []}}
+        )
+
+    def test_user_lookup(self) -> None:
+        channel = self.make_signed_federation_request(
+            "GET", f"{self.PREFIX}/user/xmpp?username=someone"
+        )
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertEqual(
+            channel.json_body["results"][0]["userid"], "@_xmpp_someone:test"
+        )
+        call = self.appservice_handler.query_3pe.call_args
+        self.assertEqual(call.args[1], "xmpp")
+        self.assertEqual(call.args[2], {b"username": [b"someone"]})
+
+    def test_location_lookup(self) -> None:
+        channel = self.make_signed_federation_request(
+            "GET", f"{self.PREFIX}/location/xmpp?muc=room"
+        )
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertIn("results", channel.json_body)
+
+    def test_protocols(self) -> None:
+        channel = self.make_signed_federation_request("GET", f"{self.PREFIX}/protocols")
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertEqual(channel.json_body, {"xmpp": {"instances": []}})
+
+
+class FederationThirdPartyLookupDisabledTests(unittest.FederatingHomeserverTestCase):
+    """The servlets are not registered when the flag is off."""
+
+    def test_unrecognised(self) -> None:
+        channel = self.make_signed_federation_request(
+            "GET",
+            "/_matrix/federation/unstable/org.matrix.msc4517.thirdparty/user/xmpp"
+            "?username=someone",
+        )
+        self.assertEqual(channel.code, 404, channel.result)
 
 
 def _create_acl_event(content: JsonDict) -> EventBase:

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -106,8 +106,8 @@ class FederationThirdPartyLookupTests(unittest.FederatingHomeserverTestCase):
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         super().prepare(reactor, clock, hs)
-        self.appservice_handler = hs.get_application_service_handler()
-        self.appservice_handler.query_3pe = AsyncMock(  # type: ignore[method-assign]
+        appservice_handler = hs.get_application_service_handler()
+        self.query_3pe_mock = AsyncMock(
             return_value=[
                 {
                     "userid": "@_xmpp_someone:test",
@@ -116,7 +116,8 @@ class FederationThirdPartyLookupTests(unittest.FederatingHomeserverTestCase):
                 }
             ]
         )
-        self.appservice_handler.get_3pe_protocols = AsyncMock(  # type: ignore[method-assign]
+        appservice_handler.query_3pe = self.query_3pe_mock  # type: ignore[method-assign]
+        appservice_handler.get_3pe_protocols = AsyncMock(  # type: ignore[method-assign]
             return_value={"xmpp": {"instances": []}}
         )
 
@@ -128,7 +129,7 @@ class FederationThirdPartyLookupTests(unittest.FederatingHomeserverTestCase):
         self.assertEqual(
             channel.json_body["results"][0]["userid"], "@_xmpp_someone:test"
         )
-        call = self.appservice_handler.query_3pe.call_args
+        call = self.query_3pe_mock.call_args
         self.assertEqual(call.args[1], "xmpp")
         self.assertEqual(call.args[2], {b"username": [b"someone"]})
 

--- a/tests/rest/client/test_thirdparty.py
+++ b/tests/rest/client/test_thirdparty.py
@@ -1,0 +1,195 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 New Vector, Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+
+from unittest.mock import AsyncMock
+
+from twisted.internet.testing import MemoryReactor
+
+import synapse.rest.admin
+from synapse.rest.client import login, thirdparty
+from synapse.server import HomeServer
+from synapse.types import JsonDict
+from synapse.util.clock import Clock
+
+from tests import unittest
+
+REMOTE_USER_RESULT = {
+    "userid": "@_xmpp_someone:remote.example.com",
+    "protocol": "xmpp",
+    "fields": {"username": "someone", "domain": "xmpp.example.com"},
+}
+
+REMOTE_LOCATION_RESULT = {
+    "alias": "#_xmpp_room_xmpp.example.com:remote.example.com",
+    "protocol": "xmpp",
+    "fields": {"muc": "room", "domain": "xmpp.example.com"},
+}
+
+LOCAL_USER_RESULT = {
+    "userid": "@_local_bridge_user:test",
+    "protocol": "xmpp",
+    "fields": {"username": "someone", "domain": "local.example.com"},
+}
+
+
+class ThirdPartyFederatedLookupTests(unittest.HomeserverTestCase):
+    """Tests for ?server= on the client /thirdparty endpoints."""
+
+    servlets = [
+        thirdparty.register_servlets,
+        login.register_servlets,
+        synapse.rest.admin.register_servlets_for_client_rest_resource,
+    ]
+
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        config["experimental_features"] = {"msc4517_enabled": True}
+        return config
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.appservice_handler = hs.get_application_service_handler()
+        self.appservice_handler.query_3pe = AsyncMock(  # type: ignore[method-assign]
+            return_value=[LOCAL_USER_RESULT]
+        )
+        self.appservice_handler.get_3pe_protocols = AsyncMock(  # type: ignore[method-assign]
+            return_value={"xmpp": {"instances": [{"desc": "local xmpp"}]}}
+        )
+
+        self.transport = hs.get_federation_client().transport_layer
+        self.transport.get_thirdparty_entities = AsyncMock(  # type: ignore[method-assign]
+            return_value={"results": [REMOTE_USER_RESULT]}
+        )
+        self.transport.get_thirdparty_protocols = AsyncMock(  # type: ignore[method-assign]
+            return_value={"xmpp": {"instances": [{"desc": "remote xmpp"}]}}
+        )
+
+        self.user = self.register_user("user", "pass")
+        self.token = self.login(self.user, "pass")
+
+    def test_local_lookup_unchanged(self) -> None:
+        channel = self.make_request(
+            "GET",
+            "/_matrix/client/v3/thirdparty/user/xmpp?username=someone",
+            access_token=self.token,
+        )
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertEqual(channel.json_list, [LOCAL_USER_RESULT])
+        self.transport.get_thirdparty_entities.assert_not_called()
+
+    def test_remote_user_lookup(self) -> None:
+        channel = self.make_request(
+            "GET",
+            "/_matrix/client/v3/thirdparty/user/xmpp"
+            "?username=someone&server=remote.example.com",
+            access_token=self.token,
+        )
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertEqual(channel.json_list, [REMOTE_USER_RESULT])
+        self.appservice_handler.query_3pe.assert_not_called()
+
+        call = self.transport.get_thirdparty_entities.call_args
+        self.assertEqual(call.args[0], "remote.example.com")
+        self.assertEqual(call.args[1], "user")
+        self.assertEqual(call.args[2], "xmpp")
+        # The server routing param must not leak into the bridge query fields.
+        self.assertEqual(call.args[3], {"username": ["someone"]})
+
+    def test_remote_location_lookup(self) -> None:
+        self.transport.get_thirdparty_entities.return_value = {
+            "results": [REMOTE_LOCATION_RESULT]
+        }
+        channel = self.make_request(
+            "GET",
+            "/_matrix/client/v3/thirdparty/location/xmpp"
+            "?muc=room&server=remote.example.com",
+            access_token=self.token,
+        )
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertEqual(channel.json_list, [REMOTE_LOCATION_RESULT])
+        self.assertEqual(
+            self.transport.get_thirdparty_entities.call_args.args[1], "location"
+        )
+
+    def test_remote_protocols(self) -> None:
+        channel = self.make_request(
+            "GET",
+            "/_matrix/client/v3/thirdparty/protocols?server=remote.example.com",
+            access_token=self.token,
+        )
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertEqual(
+            channel.json_body, {"xmpp": {"instances": [{"desc": "remote xmpp"}]}}
+        )
+        self.appservice_handler.get_3pe_protocols.assert_not_called()
+
+    def test_own_server_name_is_local(self) -> None:
+        channel = self.make_request(
+            "GET",
+            "/_matrix/client/v3/thirdparty/user/xmpp?username=someone&server=test",
+            access_token=self.token,
+        )
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertEqual(channel.json_list, [LOCAL_USER_RESULT])
+        self.transport.get_thirdparty_entities.assert_not_called()
+        # The stripped server param must not reach the local bridges either.
+        fields = self.appservice_handler.query_3pe.call_args.args[2]
+        self.assertNotIn(b"server", fields)
+
+    def test_remote_failure_returns_empty(self) -> None:
+        self.transport.get_thirdparty_entities.side_effect = RuntimeError("boom")
+        channel = self.make_request(
+            "GET",
+            "/_matrix/client/v3/thirdparty/user/xmpp"
+            "?username=someone&server=remote.example.com",
+            access_token=self.token,
+        )
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertEqual(channel.json_list, [])
+
+
+class ThirdPartyFederatedLookupDisabledTests(unittest.HomeserverTestCase):
+    """With the flag off, ?server= is ignored and lookups stay local."""
+
+    servlets = [
+        thirdparty.register_servlets,
+        login.register_servlets,
+        synapse.rest.admin.register_servlets_for_client_rest_resource,
+    ]
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.appservice_handler = hs.get_application_service_handler()
+        self.appservice_handler.query_3pe = AsyncMock(  # type: ignore[method-assign]
+            return_value=[LOCAL_USER_RESULT]
+        )
+        self.transport = hs.get_federation_client().transport_layer
+        self.transport.get_thirdparty_entities = AsyncMock(  # type: ignore[method-assign]
+            return_value={"results": [REMOTE_USER_RESULT]}
+        )
+
+        self.user = self.register_user("user", "pass")
+        self.token = self.login(self.user, "pass")
+
+    def test_server_param_ignored(self) -> None:
+        channel = self.make_request(
+            "GET",
+            "/_matrix/client/v3/thirdparty/user/xmpp"
+            "?username=someone&server=remote.example.com",
+            access_token=self.token,
+        )
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertEqual(channel.json_list, [LOCAL_USER_RESULT])
+        self.transport.get_thirdparty_entities.assert_not_called()
+        # The server param is still stripped from the bridge query fields.
+        fields = self.appservice_handler.query_3pe.call_args.args[2]
+        self.assertNotIn(b"server", fields)

--- a/tests/rest/client/test_thirdparty.py
+++ b/tests/rest/client/test_thirdparty.py
@@ -58,21 +58,23 @@ class ThirdPartyFederatedLookupTests(unittest.HomeserverTestCase):
         return config
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
-        self.appservice_handler = hs.get_application_service_handler()
-        self.appservice_handler.query_3pe = AsyncMock(  # type: ignore[method-assign]
-            return_value=[LOCAL_USER_RESULT]
-        )
-        self.appservice_handler.get_3pe_protocols = AsyncMock(  # type: ignore[method-assign]
+        appservice_handler = hs.get_application_service_handler()
+        self.query_3pe_mock = AsyncMock(return_value=[LOCAL_USER_RESULT])
+        appservice_handler.query_3pe = self.query_3pe_mock  # type: ignore[method-assign]
+        self.get_3pe_protocols_mock = AsyncMock(
             return_value={"xmpp": {"instances": [{"desc": "local xmpp"}]}}
         )
+        appservice_handler.get_3pe_protocols = self.get_3pe_protocols_mock  # type: ignore[method-assign]
 
-        self.transport = hs.get_federation_client().transport_layer
-        self.transport.get_thirdparty_entities = AsyncMock(  # type: ignore[method-assign]
+        transport = hs.get_federation_client().transport_layer
+        self.get_thirdparty_entities_mock = AsyncMock(
             return_value={"results": [REMOTE_USER_RESULT]}
         )
-        self.transport.get_thirdparty_protocols = AsyncMock(  # type: ignore[method-assign]
+        transport.get_thirdparty_entities = self.get_thirdparty_entities_mock  # type: ignore[method-assign]
+        self.get_thirdparty_protocols_mock = AsyncMock(
             return_value={"xmpp": {"instances": [{"desc": "remote xmpp"}]}}
         )
+        transport.get_thirdparty_protocols = self.get_thirdparty_protocols_mock  # type: ignore[method-assign]
 
         self.user = self.register_user("user", "pass")
         self.token = self.login(self.user, "pass")
@@ -85,7 +87,7 @@ class ThirdPartyFederatedLookupTests(unittest.HomeserverTestCase):
         )
         self.assertEqual(channel.code, 200, channel.result)
         self.assertEqual(channel.json_list, [LOCAL_USER_RESULT])
-        self.transport.get_thirdparty_entities.assert_not_called()
+        self.get_thirdparty_entities_mock.assert_not_called()
 
     def test_remote_user_lookup(self) -> None:
         channel = self.make_request(
@@ -96,9 +98,9 @@ class ThirdPartyFederatedLookupTests(unittest.HomeserverTestCase):
         )
         self.assertEqual(channel.code, 200, channel.result)
         self.assertEqual(channel.json_list, [REMOTE_USER_RESULT])
-        self.appservice_handler.query_3pe.assert_not_called()
+        self.query_3pe_mock.assert_not_called()
 
-        call = self.transport.get_thirdparty_entities.call_args
+        call = self.get_thirdparty_entities_mock.call_args
         self.assertEqual(call.args[0], "remote.example.com")
         self.assertEqual(call.args[1], "user")
         self.assertEqual(call.args[2], "xmpp")
@@ -106,7 +108,7 @@ class ThirdPartyFederatedLookupTests(unittest.HomeserverTestCase):
         self.assertEqual(call.args[3], {"username": ["someone"]})
 
     def test_remote_location_lookup(self) -> None:
-        self.transport.get_thirdparty_entities.return_value = {
+        self.get_thirdparty_entities_mock.return_value = {
             "results": [REMOTE_LOCATION_RESULT]
         }
         channel = self.make_request(
@@ -118,7 +120,7 @@ class ThirdPartyFederatedLookupTests(unittest.HomeserverTestCase):
         self.assertEqual(channel.code, 200, channel.result)
         self.assertEqual(channel.json_list, [REMOTE_LOCATION_RESULT])
         self.assertEqual(
-            self.transport.get_thirdparty_entities.call_args.args[1], "location"
+            self.get_thirdparty_entities_mock.call_args.args[1], "location"
         )
 
     def test_remote_protocols(self) -> None:
@@ -131,7 +133,7 @@ class ThirdPartyFederatedLookupTests(unittest.HomeserverTestCase):
         self.assertEqual(
             channel.json_body, {"xmpp": {"instances": [{"desc": "remote xmpp"}]}}
         )
-        self.appservice_handler.get_3pe_protocols.assert_not_called()
+        self.get_3pe_protocols_mock.assert_not_called()
 
     def test_own_server_name_is_local(self) -> None:
         channel = self.make_request(
@@ -141,13 +143,13 @@ class ThirdPartyFederatedLookupTests(unittest.HomeserverTestCase):
         )
         self.assertEqual(channel.code, 200, channel.result)
         self.assertEqual(channel.json_list, [LOCAL_USER_RESULT])
-        self.transport.get_thirdparty_entities.assert_not_called()
+        self.get_thirdparty_entities_mock.assert_not_called()
         # The stripped server param must not reach the local bridges either.
-        fields = self.appservice_handler.query_3pe.call_args.args[2]
+        fields = self.query_3pe_mock.call_args.args[2]
         self.assertNotIn(b"server", fields)
 
     def test_remote_failure_returns_empty(self) -> None:
-        self.transport.get_thirdparty_entities.side_effect = RuntimeError("boom")
+        self.get_thirdparty_entities_mock.side_effect = RuntimeError("boom")
         channel = self.make_request(
             "GET",
             "/_matrix/client/v3/thirdparty/user/xmpp"
@@ -168,14 +170,14 @@ class ThirdPartyFederatedLookupDisabledTests(unittest.HomeserverTestCase):
     ]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
-        self.appservice_handler = hs.get_application_service_handler()
-        self.appservice_handler.query_3pe = AsyncMock(  # type: ignore[method-assign]
-            return_value=[LOCAL_USER_RESULT]
-        )
-        self.transport = hs.get_federation_client().transport_layer
-        self.transport.get_thirdparty_entities = AsyncMock(  # type: ignore[method-assign]
+        appservice_handler = hs.get_application_service_handler()
+        self.query_3pe_mock = AsyncMock(return_value=[LOCAL_USER_RESULT])
+        appservice_handler.query_3pe = self.query_3pe_mock  # type: ignore[method-assign]
+        transport = hs.get_federation_client().transport_layer
+        self.get_thirdparty_entities_mock = AsyncMock(
             return_value={"results": [REMOTE_USER_RESULT]}
         )
+        transport.get_thirdparty_entities = self.get_thirdparty_entities_mock  # type: ignore[method-assign]
 
         self.user = self.register_user("user", "pass")
         self.token = self.login(self.user, "pass")
@@ -189,7 +191,7 @@ class ThirdPartyFederatedLookupDisabledTests(unittest.HomeserverTestCase):
         )
         self.assertEqual(channel.code, 200, channel.result)
         self.assertEqual(channel.json_list, [LOCAL_USER_RESULT])
-        self.transport.get_thirdparty_entities.assert_not_called()
+        self.get_thirdparty_entities_mock.assert_not_called()
         # The server param is still stripped from the bridge query fields.
-        fields = self.appservice_handler.query_3pe.call_args.args[2]
+        fields = self.query_3pe_mock.call_args.args[2]
         self.assertNotIn(b"server", fields)

--- a/tests/rest/client/test_versions.py
+++ b/tests/rest/client/test_versions.py
@@ -22,6 +22,7 @@ from synapse.types import JsonDict
 from synapse.util.clock import Clock
 
 from tests import unittest
+from tests.unittest import override_config
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +89,23 @@ class VersionsTestCase(unittest.HomeserverTestCase):
         )
         self.assertEqual(channel.code, 200, channel.result)
         self._sanity_check_versions_response(channel.json_body)
+
+    def test_msc4517_not_advertised_by_default(self) -> None:
+        channel = self.make_request("GET", "/_matrix/client/versions")
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertIs(
+            channel.json_body["unstable_features"]["org.matrix.msc4517.thirdparty"],
+            False,
+        )
+
+    @override_config({"experimental_features": {"msc4517_enabled": True}})
+    def test_msc4517_advertised_when_enabled(self) -> None:
+        channel = self.make_request("GET", "/_matrix/client/versions")
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertIs(
+            channel.json_body["unstable_features"]["org.matrix.msc4517.thirdparty"],
+            True,
+        )
 
     def test_authenticated_with_per_user_feature(self) -> None:
         user1_id = self.register_user("user1", "pass")


### PR DESCRIPTION
Allow the client /thirdparty/protocols, /thirdparty/user/{protocol} and /thirdparty/location/{protocol} endpoints to target a remote homeserver via a ?server= query parameter (analogous to /publicRooms?server=), proxying the query over new server-authenticated federation endpoints under org.matrix.msc4517. Only the remote server's own appservices are consulted; requests are never re-delegated. Gated behind msc4517_enabled, which is advertised in /versions unstable_features as org.matrix.msc4517.

drafted by claude
