### PR TITLE
Implement MSC4258 federated user directory search

### DIFF
--- a/changelog.d/19995.feature
+++ b/changelog.d/19995.feature
@@ -1,0 +1,1 @@
+Add an experimental implementation of [MSC4258](https://github.com/matrix-org/matrix-spec-proposals/pull/4258): federated user directory search.

--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -73,4 +73,5 @@ pub struct ExperimentalConfig {
     pub msc4491_enabled: bool,
     pub msc4143_enabled: bool,
     pub msc4446_enabled: bool,
+    pub msc4258_enabled: bool,
 }

--- a/rust/src/handlers/versions.rs
+++ b/rust/src/handlers/versions.rs
@@ -269,6 +269,9 @@ pub struct UnstableFeatureMap {
     /// MSC4446: Allow moving the fully read marker backwards.
     #[serde(rename = "com.beeper.msc4446")]
     msc4446_enabled: bool,
+    /// MSC4258: Federated user directory search
+    #[serde(rename = "org.matrix.msc4258")]
+    msc4258_enabled: bool,
 
     // Whether new rooms will be set to encrypted or not (based on presets).
     #[serde(rename = "io.element.e2ee_forced.public")]
@@ -320,6 +323,7 @@ pub fn synapse_config_to_global_unstable_feature_map(
         msc4491_enabled: config.experimental.msc4491_enabled,
         msc4143_enabled: config.experimental.msc4143_enabled,
         msc4446_enabled: config.experimental.msc4446_enabled,
+        msc4258_enabled: config.experimental.msc4258_enabled,
         e2ee_forced_public: config
             .room
             .encryption_enabled_by_default_for_room_presets

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -309,3 +309,12 @@ class ExperimentalConfig(Config):
 
         # MSC4491: Invite reasons in room creation
         self.msc4491_enabled: bool = experimental.get("msc4491_enabled", False)
+
+        # MSC4258: Federated user directory search
+        self.msc4258_enabled: bool = experimental.get("msc4258_enabled", False)
+
+        # How long (in ms) to wait for a remote server to answer a federated
+        # user directory search before giving up on it.
+        self.msc4258_federation_search_timeout: int = experimental.get(
+            "msc4258_federation_search_timeout", 2000
+        )

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -71,7 +71,7 @@ from synapse.http.types import QueryParams
 from synapse.logging.opentracing import SynapseTags, log_kv, set_tag, tag_args, trace
 from synapse.metrics import SERVER_NAME_LABEL
 from synapse.types import JsonDict, StrCollection, UserID, get_domain_from_id
-from synapse.util.async_helpers import concurrently_execute
+from synapse.util.async_helpers import concurrently_execute, yieldable_gather_results
 from synapse.util.caches.expiringcache import ExpiringCache
 from synapse.util.duration import Duration
 from synapse.util.retryutils import NotRetryingDestination
@@ -134,6 +134,9 @@ class FederationClient(FederationBase):
         self._clock.looping_call(self._clear_tried_cache, Duration(minutes=1))
         self.state = hs.get_state_handler()
         self.transport_layer = hs.get_federation_transport_client()
+        self._user_directory_search_timeout = (
+            hs.config.experimental.msc4258_federation_search_timeout
+        )
 
         self.server_name = hs.hostname
         self.signing_key = hs.signing_key
@@ -1915,6 +1918,75 @@ class FederationClient(FederationBase):
         filtered_failures = list(filter(filter_user_id, failures))
 
         return filtered_statuses, filtered_failures
+
+    async def user_directory_search(
+        self,
+        destination: str,
+        requester: str,
+        search_term: str,
+        limit: int,
+    ) -> JsonDict:
+        """Search the user directory of a single remote server (MSC4258).
+
+        Returns an empty result set if the remote query fails, so that one
+        slow or broken destination never breaks a merged search.
+        """
+        try:
+            return await self.transport_layer.user_directory_search(
+                destination,
+                requester,
+                search_term,
+                limit,
+                self._user_directory_search_timeout,
+            )
+        except Exception:
+            logger.warning(
+                "Error searching user directory of %s", destination, exc_info=True
+            )
+            return {"limited": False, "results": []}
+
+    async def search_user_directory_across_federation(
+        self,
+        destinations: StrCollection,
+        requester: str,
+        search_term: str,
+        limit: int,
+    ) -> JsonDict:
+        """Search the user directories of several remote servers in parallel
+        (MSC4258) and concatenate the results.
+
+        Args:
+            destinations: The servers to query; our own name is skipped.
+            requester: The user ID performing the search.
+            search_term: The term to search for.
+            limit: Maximum number of results to return overall.
+        """
+        remote_destinations = [
+            destination
+            for destination in destinations
+            if not self._is_mine_server_name(destination)
+        ]
+        if not remote_destinations:
+            return {"limited": False, "results": []}
+
+        server_results = await yieldable_gather_results(
+            lambda destination: self.user_directory_search(
+                destination, requester, search_term, limit
+            ),
+            remote_destinations,
+        )
+
+        limited = False
+        results: list[JsonDict] = []
+        for result in server_results:
+            limited = limited or bool(result.get("limited", False))
+            results.extend(result.get("results", []))
+
+        if len(results) > limit:
+            results = results[:limit]
+            limited = True
+
+        return {"limited": limited, "results": results}
 
     async def federation_download_media(
         self,

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -853,6 +853,37 @@ class TransportLayerClient:
             destination=destination, path=path, data={"user_ids": user_ids}
         )
 
+    async def user_directory_search(
+        self,
+        destination: str,
+        requester: str,
+        search_term: str,
+        limit: int,
+        timeout: int,
+    ) -> JsonDict:
+        """Search the user directory of a remote server (MSC4258).
+
+        Args:
+            destination: The remote server.
+            requester: The user ID performing the search.
+            search_term: The term to search for.
+            limit: Maximum number of results to return.
+            timeout: How long to wait for the remote response, in ms.
+        """
+        path = _create_path(
+            FEDERATION_UNSTABLE_PREFIX, "/org.matrix.msc4258/user_directory/search"
+        )
+
+        return await self.client.post_json(
+            destination=destination,
+            path=path,
+            data={"requester": requester, "search_term": search_term, "limit": limit},
+            # Searches are interactive: fail fast rather than waiting out a
+            # backoff period.
+            ignore_backoff=True,
+            timeout=timeout,
+        )
+
     async def download_media_r0(
         self,
         destination: str,

--- a/synapse/federation/transport/server/__init__.py
+++ b/synapse/federation/transport/server/__init__.py
@@ -35,6 +35,7 @@ from synapse.federation.transport.server.federation import (
     FederationMediaThumbnailServlet,
     FederationUnstableClientKeysClaimServlet,
     FederationUnstableGetExtremitiesServlet,
+    FederationUserDirectorySearchServlet,
 )
 from synapse.http.server import HttpServer, JsonResource
 from synapse.http.servlet import (
@@ -331,6 +332,12 @@ def register_servlets(
             if (
                 servletclass == FederationUnstableGetExtremitiesServlet
                 and not hs.config.experimental.msc4370_enabled
+            ):
+                continue
+
+            if (
+                servletclass == FederationUserDirectorySearchServlet
+                and not hs.config.experimental.msc4258_enabled
             ):
                 continue
 

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -48,7 +48,7 @@ from synapse.http.servlet import (
 from synapse.http.site import SynapseRequest
 from synapse.media._base import DEFAULT_MAX_TIMEOUT_MS, MAXIMUM_ALLOWED_MAX_TIMEOUT_MS
 from synapse.media.thumbnailer import ANIMATED_THUMBNAIL_TYPE, ThumbnailProvider
-from synapse.types import JsonDict
+from synapse.types import JsonDict, JsonMapping, get_domain_from_id
 from synapse.util import SYNAPSE_VERSION
 from synapse.util.ratelimitutils import FederationRateLimiter
 
@@ -842,6 +842,74 @@ class FederationMediaDownloadServlet(BaseFederationServerServlet):
         )
 
 
+class FederationUserDirectorySearchServlet(BaseFederationServerServlet):
+    """Search this server's user directory on behalf of a remote user (MSC4258).
+
+    POST /_matrix/federation/unstable/org.matrix.msc4258/user_directory/search
+    {
+        "requester": "@user:origin.example.com",
+        "search_term": "foo",
+        "limit": 10
+    }
+
+    The requester's server name must match the origin of the signed request;
+    the search is performed with that user's visibility (the same results they
+    would get searching locally on this server).
+    """
+
+    PATH = "/user_directory/search"
+    PREFIX = FEDERATION_UNSTABLE_PREFIX + "/org.matrix.msc4258"
+    RATELIMIT = True
+
+    def __init__(
+        self,
+        hs: "HomeServer",
+        authenticator: Authenticator,
+        ratelimiter: FederationRateLimiter,
+        server_name: str,
+    ):
+        super().__init__(hs, authenticator, ratelimiter, server_name)
+        self._user_directory_handler = hs.get_user_directory_handler()
+        self._user_directory_search_enabled = (
+            hs.config.userdirectory.user_directory_search_enabled
+        )
+
+    async def on_POST(
+        self,
+        origin: str,
+        content: JsonDict,
+        query: Mapping[bytes, Sequence[bytes]],
+    ) -> tuple[int, JsonMapping]:
+        if not self._user_directory_search_enabled:
+            return 200, {"limited": False, "results": []}
+
+        requester = content.get("requester")
+        if not isinstance(requester, str) or get_domain_from_id(requester) != origin:
+            raise SynapseError(400, "Missing or invalid requester", Codes.BAD_JSON)
+
+        search_term = content.get("search_term")
+        if not search_term or not isinstance(search_term, str):
+            raise SynapseError(400, "Missing or invalid search_term", Codes.BAD_JSON)
+
+        limit = content.get("limit", 10)
+        if not isinstance(limit, int):
+            raise SynapseError(400, "Invalid limit", Codes.BAD_JSON)
+        limit = max(min(limit, 50), 0)
+
+        # Don't serve directory-trawling queries: require a minimally
+        # specific term, mirroring the MSC's anti-enumeration recommendation.
+        if len(search_term) < 4:
+            return 200, {"limited": False, "results": []}
+
+        # The requester (verified against the origin above) is used as the
+        # searching user, so the results are limited to what that user could
+        # see if they searched locally here.
+        results = await self._user_directory_handler.search_users(
+            requester, search_term, limit
+        )
+        return 200, results
+
+
 class FederationMediaThumbnailServlet(BaseFederationServerServlet):
     """
     Implementation of new federation media `/thumbnail` endpoint outlined in MSC3916. Returns
@@ -935,4 +1003,5 @@ FEDERATION_SERVLET_CLASSES: tuple[type[BaseFederationServlet], ...] = (
     FederationV1SendKnockServlet,
     FederationMakeKnockServlet,
     FederationAccountStatusServlet,
+    FederationUserDirectorySearchServlet,
 )

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -39,7 +39,7 @@ from synapse.metrics import SERVER_NAME_LABEL
 from synapse.storage.databases.main.state_deltas import StateDelta
 from synapse.storage.databases.main.user_directory import SearchResult
 from synapse.storage.roommember import ProfileInfo
-from synapse.types import UserID
+from synapse.types import JsonMapping, StrCollection, UserID
 from synapse.util.duration import Duration
 from synapse.util.metrics import Measure
 from synapse.util.retryutils import NotRetryingDestination
@@ -115,6 +115,10 @@ class UserDirectoryHandler(StateDeltasHandler):
         self.show_locked_users = hs.config.userdirectory.show_locked_users
         self._spam_checker_module_callbacks = hs.get_module_api_callbacks().spam_checker
         self._hs = hs
+        self._federation_client = hs.get_federation_client()
+        self._federation_domain_whitelist = (
+            hs.config.federation.federation_domain_whitelist
+        )
 
         # The current position in the current_state_delta stream
         self.pos: int | None = None
@@ -181,6 +185,39 @@ class UserDirectoryHandler(StateDeltasHandler):
         results["results"] = non_spammy_users
 
         return results
+
+    async def search_remote_users(
+        self,
+        user_id: str,
+        search_term: str,
+        limit: int,
+        server: str | None,
+    ) -> JsonMapping:
+        """Search the user directories of remote servers (MSC4258).
+
+        Args:
+            user_id: The user performing the search (sent to the remote
+                servers as the requester, so they can apply visibility).
+            search_term: The term to search for.
+            limit: Maximum number of results to return.
+            server: An explicit remote server whose directory to search. If
+                None, all servers on the federation whitelist (if one is
+                configured) are queried; with no whitelist there is nowhere
+                sensible to broadcast to, so no results are returned.
+        """
+        if server is not None:
+            destinations: StrCollection = [server]
+        elif self._federation_domain_whitelist is not None:
+            destinations = list(self._federation_domain_whitelist)
+        else:
+            destinations = []
+
+        if not destinations:
+            return {"limited": False, "results": []}
+
+        return await self._federation_client.search_user_directory_across_federation(
+            destinations, user_id, search_term, limit
+        )
 
     def notify_new_event(self) -> None:
         """Called when there may be more deltas to process"""

--- a/synapse/rest/client/user_directory.py
+++ b/synapse/rest/client/user_directory.py
@@ -52,6 +52,7 @@ class UserDirectorySearchRestServlet(RestServlet):
             clock=hs.get_clock(),
             cfg=hs.config.ratelimiting.rc_user_directory,
         )
+        self._msc4258_enabled = hs.config.experimental.msc4258_enabled
 
     async def on_POST(self, request: SynapseRequest) -> tuple[int, JsonMapping]:
         """Searches for users in directory
@@ -88,11 +89,67 @@ class UserDirectorySearchRestServlet(RestServlet):
         except Exception:
             raise SynapseError(400, "`search_term` is required field")
 
+        # MSC4258 federated search parameters. `search_scope` is from the MSC
+        # (local/restricted searches must not leave this server); `server` is
+        # a targeted extension letting the client search one specific remote
+        # server's directory (analogous to /publicRooms?server=).
+        search_scope = body.get("search_scope", "remote")
+        if search_scope not in ("local", "restricted", "remote"):
+            raise SynapseError(400, "Invalid search_scope")
+        server = body.get("server")
+        if server is not None and not isinstance(server, str):
+            raise SynapseError(400, "Invalid server")
+        if server is not None and self.hs.is_mine_server_name(server):
+            server = None
+
+        federate = (
+            self._msc4258_enabled
+            and search_scope == "remote"
+            # Mirror the remote side's anti-enumeration threshold rather than
+            # sending queries that will be refused.
+            and len(search_term) >= 4
+        )
+
+        if federate and server is not None:
+            # The client asked for one specific server's directory: return
+            # that server's results alone.
+            results = await self.user_directory_handler.search_remote_users(
+                user_id, search_term, limit, server
+            )
+            return 200, results
+
         results = await self.user_directory_handler.search_users(
             user_id, search_term, limit
         )
 
+        if federate:
+            remote_results = await self.user_directory_handler.search_remote_users(
+                user_id, search_term, limit, None
+            )
+            return 200, _merge_search_results(results, remote_results, limit)
+
         return 200, results
+
+
+def _merge_search_results(
+    local_results: JsonMapping, remote_results: JsonMapping, limit: int
+) -> JsonMapping:
+    """Concatenate local and remote user directory results, deduplicating by
+    user ID. Local results come first, preserving their relevance ordering.
+    """
+    seen = set()
+    results = []
+    for user in list(local_results["results"]) + list(remote_results["results"]):
+        if user["user_id"] not in seen:
+            seen.add(user["user_id"])
+            results.append(user)
+
+    limited = bool(local_results.get("limited")) or bool(remote_results.get("limited"))
+    if len(results) > limit:
+        results = results[:limit]
+        limited = True
+
+    return {"limited": limited, "results": results}
 
 
 def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -94,6 +94,117 @@ class FederationServerTests(unittest.FederatingHomeserverTestCase):
         self.assertEqual(500, channel.code, channel.result)
 
 
+class FederationUserDirectorySearchTests(unittest.FederatingHomeserverTestCase):
+    """Tests for the MSC4258 federated user directory search servlet."""
+
+    servlets = [
+        admin.register_servlets,
+        login.register_servlets,
+    ]
+
+    PATH = "/_matrix/federation/unstable/org.matrix.msc4258/user_directory/search"
+
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        config["experimental_features"] = {"msc4258_enabled": True}
+        config["user_directory"] = {
+            "enabled": True,
+            "search_all_users": True,
+        }
+        return config
+
+    def test_search(self) -> None:
+        self.register_user("userlambda", "password")
+
+        channel = self.make_signed_federation_request(
+            "POST",
+            self.PATH,
+            content={
+                "requester": f"@requester:{self.OTHER_SERVER_NAME}",
+                "search_term": "userlambda",
+                "limit": 10,
+            },
+        )
+
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertEqual(channel.json_body["limited"], False)
+        results = channel.json_body["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["user_id"], "@userlambda:test")
+
+    def test_no_results(self) -> None:
+        self.register_user("userlambda", "password")
+
+        channel = self.make_signed_federation_request(
+            "POST",
+            self.PATH,
+            content={
+                "requester": f"@requester:{self.OTHER_SERVER_NAME}",
+                "search_term": "nonexistent",
+                "limit": 10,
+            },
+        )
+
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertEqual(channel.json_body["results"], [])
+
+    def test_missing_search_term(self) -> None:
+        channel = self.make_signed_federation_request(
+            "POST",
+            self.PATH,
+            content={"requester": f"@requester:{self.OTHER_SERVER_NAME}", "limit": 10},
+        )
+
+        self.assertEqual(channel.code, 400, channel.result)
+        self.assertEqual(channel.json_body["errcode"], "M_BAD_JSON")
+
+    def test_requester_must_match_origin(self) -> None:
+        """A requester on a different server than the request signer is rejected."""
+        channel = self.make_signed_federation_request(
+            "POST",
+            self.PATH,
+            content={
+                "requester": "@requester:not.the.origin.example.com",
+                "search_term": "userlambda",
+            },
+        )
+
+        self.assertEqual(channel.code, 400, channel.result)
+        self.assertEqual(channel.json_body["errcode"], "M_BAD_JSON")
+
+    def test_short_term_returns_nothing(self) -> None:
+        """Directory-trawling with very short terms is refused."""
+        self.register_user("userlambda", "password")
+
+        channel = self.make_signed_federation_request(
+            "POST",
+            self.PATH,
+            content={
+                "requester": f"@requester:{self.OTHER_SERVER_NAME}",
+                "search_term": "use",
+            },
+        )
+
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertEqual(channel.json_body["results"], [])
+
+
+class FederationUserDirectorySearchDisabledTests(unittest.FederatingHomeserverTestCase):
+    """The MSC4258 servlet is not registered when the flag is off."""
+
+    def test_unrecognised(self) -> None:
+        channel = self.make_signed_federation_request(
+            "POST",
+            "/_matrix/federation/unstable/org.matrix.msc4258/user_directory/search",
+            content={
+                "requester": f"@requester:{self.OTHER_SERVER_NAME}",
+                "search_term": "whatever",
+            },
+        )
+
+        self.assertEqual(channel.code, 404, channel.result)
+
+
 def _create_acl_event(content: JsonDict) -> EventBase:
     return make_test_event(
         {

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -1207,6 +1207,167 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
                 i += 2
 
 
+class TestUserDirFederatedSearch(unittest.HomeserverTestCase):
+    """Tests for MSC4258 federated user directory search, client side."""
+
+    servlets = [
+        user_directory.register_servlets,
+        room.register_servlets,
+        login.register_servlets,
+        synapse.rest.admin.register_servlets_for_client_rest_resource,
+    ]
+
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        config["experimental_features"] = {"msc4258_enabled": True}
+        config["update_user_directory_from_worker"] = None
+        return config
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.transport = hs.get_federation_client().transport_layer
+        self.transport.user_directory_search = AsyncMock(  # type: ignore[method-assign]
+            return_value={
+                "limited": False,
+                "results": [
+                    {
+                        "user_id": "@remoteuser:remote.example.com",
+                        "display_name": "Remote User",
+                        "avatar_url": None,
+                    }
+                ],
+            }
+        )
+
+        # Two local users sharing a room, so local search has something to find.
+        self.u1 = self.register_user("user1", "pass")
+        self.u1_token = self.login(self.u1, "pass")
+        u2 = self.register_user("user2", "pass")
+        u2_token = self.login(u2, "pass")
+        room_id = self.helper.create_room_as(self.u1, tok=self.u1_token)
+        self.helper.join(room_id, user=u2, tok=u2_token)
+
+    def search(self, body: JsonDict) -> JsonDict:
+        channel = self.make_request(
+            "POST",
+            "user_directory/search",
+            body,
+            access_token=self.u1_token,
+        )
+        self.assertEqual(200, channel.code, channel.result)
+        return channel.json_body
+
+    def test_targeted_server_search(self) -> None:
+        """Searching an explicit remote server returns that server's results."""
+        results = self.search(
+            {"search_term": "remoteuser", "server": "remote.example.com"}
+        )
+        self.assertEqual(
+            [r["user_id"] for r in results["results"]],
+            ["@remoteuser:remote.example.com"],
+        )
+        self.transport.user_directory_search.assert_called_once()
+        call = self.transport.user_directory_search.call_args
+        self.assertEqual(call.args[0], "remote.example.com")
+        self.assertEqual(call.args[1], self.u1)
+        self.assertEqual(call.args[2], "remoteuser")
+
+    def test_short_term_stays_local(self) -> None:
+        """A below-threshold term never leaves the server, even with server set."""
+        results = self.search({"search_term": "use", "server": "remote.example.com"})
+        self.assertIn("@user2:test", [r["user_id"] for r in results["results"]])
+        self.transport.user_directory_search.assert_not_called()
+
+    def test_local_scope_stays_local(self) -> None:
+        results = self.search(
+            {
+                "search_term": "user2",
+                "server": "remote.example.com",
+                "search_scope": "local",
+            }
+        )
+        self.assertEqual([r["user_id"] for r in results["results"]], ["@user2:test"])
+        self.transport.user_directory_search.assert_not_called()
+
+    def test_no_whitelist_no_broadcast(self) -> None:
+        """Without a targeted server or a federation whitelist, a plain search
+        is local-only."""
+        results = self.search({"search_term": "user2"})
+        self.assertEqual([r["user_id"] for r in results["results"]], ["@user2:test"])
+        self.transport.user_directory_search.assert_not_called()
+
+    def test_own_server_name_is_local(self) -> None:
+        """Explicitly naming our own server behaves like a local search."""
+        results = self.search({"search_term": "user2", "server": "test"})
+        self.assertEqual([r["user_id"] for r in results["results"]], ["@user2:test"])
+        self.transport.user_directory_search.assert_not_called()
+
+
+class TestUserDirFederatedSearchWhitelist(unittest.HomeserverTestCase):
+    """MSC4258 broadcast search against the federation whitelist."""
+
+    servlets = [
+        user_directory.register_servlets,
+        room.register_servlets,
+        login.register_servlets,
+        synapse.rest.admin.register_servlets_for_client_rest_resource,
+    ]
+
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        config["experimental_features"] = {"msc4258_enabled": True}
+        config["update_user_directory_from_worker"] = None
+        config["federation_domain_whitelist"] = ["remote.example.com", "test"]
+        return config
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.transport = hs.get_federation_client().transport_layer
+        self.transport.user_directory_search = AsyncMock(  # type: ignore[method-assign]
+            return_value={
+                "limited": False,
+                "results": [
+                    {
+                        "user_id": "@remoteuser:remote.example.com",
+                        "display_name": "user2 elsewhere",
+                        "avatar_url": None,
+                    },
+                    # A duplicate of a local result, to exercise dedup.
+                    {
+                        "user_id": "@user2:test",
+                        "display_name": "user2",
+                        "avatar_url": None,
+                    },
+                ],
+            }
+        )
+
+        self.u1 = self.register_user("user1", "pass")
+        self.u1_token = self.login(self.u1, "pass")
+        u2 = self.register_user("user2", "pass")
+        u2_token = self.login(u2, "pass")
+        room_id = self.helper.create_room_as(self.u1, tok=self.u1_token)
+        self.helper.join(room_id, user=u2, tok=u2_token)
+
+    def test_broadcast_merges_and_dedupes(self) -> None:
+        channel = self.make_request(
+            "POST",
+            "user_directory/search",
+            {"search_term": "user2"},
+            access_token=self.u1_token,
+        )
+        self.assertEqual(200, channel.code, channel.result)
+        # Local result first, then the remote one, with the remote duplicate
+        # of the local user dropped. Our own name is skipped as a destination.
+        self.assertEqual(
+            [r["user_id"] for r in channel.json_body["results"]],
+            ["@user2:test", "@remoteuser:remote.example.com"],
+        )
+        self.transport.user_directory_search.assert_called_once()
+        self.assertEqual(
+            self.transport.user_directory_search.call_args.args[0],
+            "remote.example.com",
+        )
+
+
 class TestUserDirSearchDisabled(unittest.HomeserverTestCase):
     servlets = [
         user_directory.register_servlets,

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -1224,8 +1224,8 @@ class TestUserDirFederatedSearch(unittest.HomeserverTestCase):
         return config
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
-        self.transport = hs.get_federation_client().transport_layer
-        self.transport.user_directory_search = AsyncMock(  # type: ignore[method-assign]
+        transport = hs.get_federation_client().transport_layer
+        self.user_directory_search_mock = AsyncMock(
             return_value={
                 "limited": False,
                 "results": [
@@ -1237,6 +1237,7 @@ class TestUserDirFederatedSearch(unittest.HomeserverTestCase):
                 ],
             }
         )
+        transport.user_directory_search = self.user_directory_search_mock  # type: ignore[method-assign]
 
         # Two local users sharing a room, so local search has something to find.
         self.u1 = self.register_user("user1", "pass")
@@ -1265,8 +1266,8 @@ class TestUserDirFederatedSearch(unittest.HomeserverTestCase):
             [r["user_id"] for r in results["results"]],
             ["@remoteuser:remote.example.com"],
         )
-        self.transport.user_directory_search.assert_called_once()
-        call = self.transport.user_directory_search.call_args
+        self.user_directory_search_mock.assert_called_once()
+        call = self.user_directory_search_mock.call_args
         self.assertEqual(call.args[0], "remote.example.com")
         self.assertEqual(call.args[1], self.u1)
         self.assertEqual(call.args[2], "remoteuser")
@@ -1275,7 +1276,7 @@ class TestUserDirFederatedSearch(unittest.HomeserverTestCase):
         """A below-threshold term never leaves the server, even with server set."""
         results = self.search({"search_term": "use", "server": "remote.example.com"})
         self.assertIn("@user2:test", [r["user_id"] for r in results["results"]])
-        self.transport.user_directory_search.assert_not_called()
+        self.user_directory_search_mock.assert_not_called()
 
     def test_local_scope_stays_local(self) -> None:
         results = self.search(
@@ -1286,20 +1287,20 @@ class TestUserDirFederatedSearch(unittest.HomeserverTestCase):
             }
         )
         self.assertEqual([r["user_id"] for r in results["results"]], ["@user2:test"])
-        self.transport.user_directory_search.assert_not_called()
+        self.user_directory_search_mock.assert_not_called()
 
     def test_no_whitelist_no_broadcast(self) -> None:
         """Without a targeted server or a federation whitelist, a plain search
         is local-only."""
         results = self.search({"search_term": "user2"})
         self.assertEqual([r["user_id"] for r in results["results"]], ["@user2:test"])
-        self.transport.user_directory_search.assert_not_called()
+        self.user_directory_search_mock.assert_not_called()
 
     def test_own_server_name_is_local(self) -> None:
         """Explicitly naming our own server behaves like a local search."""
         results = self.search({"search_term": "user2", "server": "test"})
         self.assertEqual([r["user_id"] for r in results["results"]], ["@user2:test"])
-        self.transport.user_directory_search.assert_not_called()
+        self.user_directory_search_mock.assert_not_called()
 
 
 class TestUserDirFederatedSearchWhitelist(unittest.HomeserverTestCase):
@@ -1320,8 +1321,8 @@ class TestUserDirFederatedSearchWhitelist(unittest.HomeserverTestCase):
         return config
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
-        self.transport = hs.get_federation_client().transport_layer
-        self.transport.user_directory_search = AsyncMock(  # type: ignore[method-assign]
+        transport = hs.get_federation_client().transport_layer
+        self.user_directory_search_mock = AsyncMock(
             return_value={
                 "limited": False,
                 "results": [
@@ -1339,6 +1340,7 @@ class TestUserDirFederatedSearchWhitelist(unittest.HomeserverTestCase):
                 ],
             }
         )
+        transport.user_directory_search = self.user_directory_search_mock  # type: ignore[method-assign]
 
         self.u1 = self.register_user("user1", "pass")
         self.u1_token = self.login(self.u1, "pass")
@@ -1361,9 +1363,9 @@ class TestUserDirFederatedSearchWhitelist(unittest.HomeserverTestCase):
             [r["user_id"] for r in channel.json_body["results"]],
             ["@user2:test", "@remoteuser:remote.example.com"],
         )
-        self.transport.user_directory_search.assert_called_once()
+        self.user_directory_search_mock.assert_called_once()
         self.assertEqual(
-            self.transport.user_directory_search.call_args.args[0],
+            self.user_directory_search_mock.call_args.args[0],
             "remote.example.com",
         )
 

--- a/tests/rest/client/test_versions.py
+++ b/tests/rest/client/test_versions.py
@@ -89,6 +89,21 @@ class VersionsTestCase(unittest.HomeserverTestCase):
         self.assertEqual(channel.code, 200, channel.result)
         self._sanity_check_versions_response(channel.json_body)
 
+    def test_msc4258_not_advertised_by_default(self) -> None:
+        channel = self.make_request("GET", "/_matrix/client/versions")
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertIs(
+            channel.json_body["unstable_features"]["org.matrix.msc4258"], False
+        )
+
+    @unittest.override_config({"experimental_features": {"msc4258_enabled": True}})
+    def test_msc4258_advertised_when_enabled(self) -> None:
+        channel = self.make_request("GET", "/_matrix/client/versions")
+        self.assertEqual(channel.code, 200, channel.result)
+        self.assertIs(
+            channel.json_body["unstable_features"]["org.matrix.msc4258"], True
+        )
+
     def test_authenticated_with_per_user_feature(self) -> None:
         user1_id = self.register_user("user1", "pass")
         user1_tok = self.login(user1_id, "pass")


### PR DESCRIPTION
Adds the org.matrix.msc4258 federation servlet (requester verified against the origin, 4-char anti-enumeration threshold, results limited to what the requesting user could see searching locally) and extends POST /user_directory/search: search_scope per the MSC, plus a targeted 'server' field to search one specific remote server's directory (analogous to /publicRooms?server=). Without a target, remote scope broadcasts to the federation whitelist when one is configured. Local results keep their relevance order and are deduplicated against remote ones.

The federation servlet and wire format are ported from the Tchap implementation by @mcalinghee and @MatMaul (tchapgouv/synapse#4, https://github.com/tchapgouv/synapse), with which this interoperates: both use /_matrix/federation/unstable/org.matrix.msc4258/ rather than the fr.tchap prefix in the MSC's (stale) unstable-prefix section.

drafted by claude