### PR TITLE
Rust Postgres backend: value mapping and blocking runtime helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -71,10 +71,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -102,6 +117,29 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -138,6 +176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,14 +195,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -180,6 +257,12 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fnv"
@@ -316,9 +399,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -383,6 +478,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +530,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -711,10 +824,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -727,6 +858,16 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "memchr"
@@ -764,10 +905,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -780,6 +963,35 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
 
 [[package]]
 name = "potential_utf"
@@ -920,7 +1132,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -962,13 +1174,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -978,7 +1207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -988,6 +1217,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1159,6 +1403,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,8 +1499,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1260,8 +1510,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1269,6 +1530,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1309,6 +1576,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,6 +1623,7 @@ dependencies = [
  "log",
  "mime",
  "once_cell",
+ "postgres-protocol",
  "pyo3",
  "pyo3-log",
  "pythonize",
@@ -1353,8 +1632,9 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
+ "tokio-postgres",
  "ulid",
 ]
 
@@ -1441,6 +1721,32 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.6.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.1",
+ "socket2 0.6.0",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -1538,9 +1844,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ulid"
@@ -1548,15 +1854,36 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand",
+ "rand 0.9.4",
  "web-time",
 ]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "untrusted"
@@ -1609,6 +1936,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1713,6 +2049,17 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fae98cf96deed1b7572272dfc777713c249ae40aa1cf8862e091e8b745f5361"
+dependencies = [
+ "libredox",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/changelog.d/19996.misc
+++ b/changelog.d/19996.misc
@@ -1,0 +1,1 @@
+Add foundations for a Rust backed database pool.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -62,8 +62,10 @@ reqwest = { version = "0.12.15", default-features = false, features = [
 http-body-util = "0.1.3"
 futures = "0.3.31"
 tokio = { version = "1.44.2", features = ["rt", "rt-multi-thread"] }
+tokio-postgres = "0.7"
 once_cell = "1.18.0"
 itertools = "0.14.0"
+postgres-protocol = "0.6.10"
 
 [build-dependencies]
 blake2 = "0.10.4"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ name = "synapse"
 version = "0.1.0"
 
 edition = "2021"
-rust-version = "1.82.0"
+rust-version = "1.85.0"
 
 [lib]
 name = "synapse"

--- a/rust/src/database/mod.rs
+++ b/rust/src/database/mod.rs
@@ -1,0 +1,27 @@
+//! DBAPI2-shaped Connection / Cursor types implemented in Rust.
+//!
+//! Currently this provides a single Postgres backend ([`tokio_postgres`]); see
+//! the [`postgres`] submodule.
+
+pub mod postgres;
+
+use pyo3::prelude::*;
+use pyo3::types::PyModule;
+
+/// Register the `database` submodule (and its per-backend children) on the
+/// top-level `synapse_rust` module.
+pub fn register_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let child = PyModule::new(py, "database")?;
+
+    postgres::register_module(py, &child)?;
+
+    m.add_submodule(&child)?;
+
+    // Mirror the convention used by other rust submodules so
+    // `from synapse.synapse_rust import database` works.
+    py.import("sys")?
+        .getattr("modules")?
+        .set_item("synapse.synapse_rust.database", child)?;
+
+    Ok(())
+}

--- a/rust/src/database/mod.rs
+++ b/rust/src/database/mod.rs
@@ -1,4 +1,4 @@
-//! DBAPI2-shaped Connection / Cursor types implemented in Rust.
+//! Database access implemented in Rust.
 //!
 //! Currently this provides a single Postgres backend ([`tokio_postgres`]); see
 //! the [`postgres`] submodule.
@@ -17,8 +17,8 @@ pub fn register_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> 
 
     m.add_submodule(&child)?;
 
-    // Mirror the convention used by other rust submodules so
-    // `from synapse.synapse_rust import database` works.
+    // We need to manually add the module to sys.modules to make `from
+    // synapse.synapse_rust import database` work.
     py.import("sys")?
         .getattr("modules")?
         .set_item("synapse.synapse_rust.database", child)?;

--- a/rust/src/database/postgres/helpers.rs
+++ b/rust/src/database/postgres/helpers.rs
@@ -1,0 +1,261 @@
+/*
+ * This file is licensed under the Affero General Public License (AGPL) version 3.
+ *
+ * Copyright (C) 2026 Element Creations Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * See the GNU Affero General Public License for more details:
+ * <https://www.gnu.org/licenses/agpl-3.0.html>.
+ *
+ */
+
+//! Extension traits for driving [`tokio_postgres`] futures to completion from
+//! the synchronous, GIL-holding Python methods.
+//!
+//! Both [`BlockingPostgres`] and [`BlockingPostgresStream`] release the GIL
+//! (`py.detach`) while blocking on the shared tokio runtime, so other Python
+//! threads can make progress (and so the runtime's own connection task can run)
+//! while we wait. The [`Ungil`] bounds are what let us hand the future across
+//! the `detach` boundary.
+//!
+//! The stream helper is generic over the underlying stream type rather than
+//! hard-wired to [`tokio_postgres::RowStream`]. In production it is always used
+//! with a `RowStream`, but keeping it generic lets the cursor state machine
+//! (which uses these helpers) be unit-tested against an in-memory fake stream
+//! with no live database — see [`BlockingPostgresStream`]'s tests.
+
+use std::{future::Future, pin::Pin};
+
+use futures::{stream::Fuse, FutureExt, StreamExt};
+use pyo3::{marker::Ungil, PyResult, Python};
+use tokio::runtime::Handle;
+
+use crate::database::postgres::pg_err_to_py;
+
+/// Block on a future on the shared runtime, releasing the GIL while we wait.
+pub trait BlockingPostgres
+where
+    Self: Future + Sized + Send + Ungil,
+    Self::Output: Ungil + Send,
+{
+    /// Drive `self` to completion on the shared runtime, returning its output.
+    /// Releases the GIL for the duration so the wait doesn't block other Python
+    /// threads.
+    ///
+    /// Blocks on the runtime the calling thread has *entered* — taken from the
+    /// thread-local context via [`Handle::current`], not passed in. Every
+    /// thread that drives these calls must have the server's shared runtime
+    /// (see [`crate::tokio_runtime`]) entered first with
+    /// [`Handle::enter`](tokio::runtime::Handle::enter); [`Handle::current`]
+    /// panics otherwise. The blocking wait runs on the calling (Python) thread,
+    /// never on a runtime worker — see this module's docs for why that can't
+    /// deadlock.
+    fn block_on(self, py: Python<'_>) -> Self::Output {
+        py.detach(|| Handle::current().block_on(self))
+    }
+}
+
+/// Same as [`BlockingPostgres`], but for futures that yield a
+/// [`tokio_postgres::Result`], mapping any error into a Python exception.
+pub trait BlockingPostgresResult<T>
+where
+    Self: Future<Output = Result<T, tokio_postgres::Error>> + Sized + Send + Ungil,
+    Self::Output: Ungil + Send,
+{
+    /// Block on `self` and convert a Postgres error into a `PyErr`.
+    fn block_on_result(self, py: Python<'_>) -> PyResult<T> {
+        self.block_on(py).map_err(pg_err_to_py)
+    }
+}
+
+// Blanket impls: every suitable future automatically gets `block_on` /
+// `block_on_result`, so callers can write `fut.block_on(py)` directly.
+impl<F> BlockingPostgres for F
+where
+    F: Future + Sized + Send + Ungil,
+    F::Output: Ungil + Send,
+{
+}
+impl<F, T> BlockingPostgresResult<T> for F
+where
+    F: Future<Output = Result<T, tokio_postgres::Error>> + Sized + Send + Ungil,
+    F::Output: Ungil + Send,
+{
+}
+
+/// Pull items from a [`Fuse`]d stream from synchronous Python code, blocking on
+/// the shared runtime only when the next item isn't already buffered.
+///
+/// Implemented for any pinned, fused stream (`Pin<&mut Fuse<S>>`) whose items
+/// can cross the GIL-release boundary. In production `S` is
+/// [`tokio_postgres::RowStream`]; the generic bound is what lets the cursor
+/// logic be tested against an in-memory fake.
+///
+/// The [`Fuse`] is *required* by the impl (the trait is implemented only for
+/// `Pin<&mut Fuse<S>>`), not merely assumed. This matters because
+/// [`Self::get_next_if_ready`] may poll the stream again after it has finished:
+/// a bare `Stream` is free to panic if polled past completion, whereas a fused
+/// stream simply keeps yielding `None`. So repeated `get_next_if_ready` /
+/// `block_on_next` calls after exhaustion are safe by construction.
+pub trait BlockingPostgresStream
+where
+    Self: futures::Stream + Sized + Send + Ungil + Unpin,
+    Self::Item: Ungil + Send,
+{
+    /// Get the next item from the stream, blocking on the shared runtime if
+    /// necessary.
+    ///
+    /// If the stream is not ready to yield an item, this will release the GIL
+    /// and block until the next item is available.
+    ///
+    /// This method will return `None` if the stream is exhausted.
+    fn block_on_next(&mut self, py: Python<'_>) -> Option<Self::Item> {
+        match self.get_next_if_ready() {
+            // `Some(Some(item))` (ready) and `Some(None)` (exhausted) are both
+            // answers we can return immediately — we just hand the inner
+            // `Option<Item>` straight back.
+            Some(row) => row,
+            // `None` means "not ready yet": release the GIL and block until the
+            // next item (or end of stream) arrives.
+            None => self.next().block_on(py),
+        }
+    }
+
+    /// Get the next item from the stream if it's ready, without blocking.
+    ///
+    /// Returns `None` if the stream is not ready to yield an item. Returns
+    /// `Some(None)` if the stream is exhausted.
+    fn get_next_if_ready(&mut self) -> Option<Option<Self::Item>> {
+        self.next().now_or_never()
+    }
+}
+
+// Blanket impl over any pinned, fused stream. Requiring the helper bounds here
+// (rather than only for `RowStream`) is what makes the cursor logic testable
+// with a fake stream.
+impl<S> BlockingPostgresStream for Pin<&mut Fuse<S>>
+where
+    Self: futures::Stream + Send + Ungil + Unpin,
+    <Self as futures::Stream>::Item: Ungil + Send,
+{
+}
+
+#[cfg(test)]
+mod tests {
+    //! These tests don't touch Postgres: the future/stream helpers are generic,
+    //! so we exercise them with plain async blocks and an in-memory stream.
+
+    use std::pin::pin;
+
+    use futures::stream::{self, StreamExt};
+    use tokio::runtime::Runtime;
+
+    use super::*;
+
+    /// A throwaway runtime standing in for the shared one. Production code
+    /// enters `crate::tokio_runtime`'s runtime on each thread; the helpers only
+    /// need *some* runtime entered on the current thread (so [`Handle::current`]
+    /// resolves), and (as in production) the blocking wait runs on this test
+    /// thread rather than on a worker. Each test calls `rt.enter()` and holds
+    /// the guard for the duration.
+    fn test_runtime() -> Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn block_on_runs_future_and_returns_output() {
+        Python::initialize();
+        let rt = test_runtime();
+        let _guard = rt.enter();
+        Python::attach(|py| {
+            assert_eq!(async { 1 + 2 }.block_on(py), 3);
+        });
+    }
+
+    #[test]
+    fn block_on_result_maps_ok_through() {
+        Python::initialize();
+        let rt = test_runtime();
+        let _guard = rt.enter();
+        Python::attach(|py| {
+            let ok = async { Ok::<i32, tokio_postgres::Error>(5) };
+            assert_eq!(ok.block_on_result(py).unwrap(), 5);
+            // The error path (mapping a `tokio_postgres::Error` to a `PyErr`)
+            // can't be unit-tested here, as that error type can't be
+            // constructed by hand; it's exercised by the integration tests.
+        });
+    }
+
+    #[test]
+    fn get_next_if_ready_returns_buffered_rows_then_signals_end() {
+        Python::initialize();
+        let rt = test_runtime();
+        let _guard = rt.enter();
+        Python::attach(|py| {
+            // `stream::iter` yields each item immediately, so every poll is
+            // ready: we get the items, then a `Some(None)` end-of-stream once
+            // it's drained, without ever needing to block.
+            let stream = stream::iter(vec![Ok::<i32, ()>(1), Ok(2)]).fuse();
+            let mut stream = pin!(stream);
+
+            assert_eq!(stream.as_mut().get_next_if_ready(), Some(Some(Ok(1))));
+            assert_eq!(stream.as_mut().get_next_if_ready(), Some(Some(Ok(2))));
+            // Exhausted: the item is "ready" and is `None`.
+            assert_eq!(stream.as_mut().get_next_if_ready(), Some(None));
+            // A fused stream keeps reporting end-of-stream rather than panicking.
+            assert_eq!(stream.as_mut().get_next_if_ready(), Some(None));
+
+            // `block_on_next` takes the same already-ready value.
+            let stream = stream::iter(vec![Ok::<i32, ()>(9)]).fuse();
+            let mut stream = pin!(stream);
+            assert_eq!(stream.as_mut().block_on_next(py), Some(Ok(9)));
+            assert_eq!(stream.as_mut().block_on_next(py), None);
+        });
+    }
+
+    #[test]
+    fn block_on_next_blocks_when_first_poll_is_pending() {
+        Python::initialize();
+        let rt = test_runtime();
+        let _guard = rt.enter();
+        Python::attach(|py| {
+            // A stream whose first poll is `Pending` (it yields back to the
+            // runtime before producing the value). `get_next_if_ready` /
+            // `now_or_never` polls exactly once and so sees `Pending` and gives
+            // up, forcing `block_on_next` down its blocking path.
+            let stream = stream::once(async {
+                tokio::task::yield_now().await;
+                Ok::<i32, ()>(7)
+            })
+            .fuse();
+            let mut stream = pin!(stream);
+
+            assert_eq!(stream.as_mut().get_next_if_ready(), None);
+            // `get_next_if_ready` above polled (and so advanced) the *same*
+            // pinned stream; `block_on_next` re-polls that same stream via
+            // `&mut self`, resuming the yielded future rather than restarting
+            // it, so it still resolves to 7.
+            assert_eq!(stream.as_mut().block_on_next(py), Some(Ok(7)));
+            assert_eq!(stream.as_mut().block_on_next(py), None);
+
+            // And, on a fresh stream, `block_on_next` handles the pending first
+            // poll entirely on its own (no preceding `get_next_if_ready`),
+            // proving it doesn't rely on being "primed" by an earlier call.
+            let stream = stream::once(async {
+                tokio::task::yield_now().await;
+                Ok::<i32, ()>(8)
+            })
+            .fuse();
+            let mut stream = pin!(stream);
+            assert_eq!(stream.as_mut().block_on_next(py), Some(Ok(8)));
+        });
+    }
+}

--- a/rust/src/database/postgres/helpers.rs
+++ b/rust/src/database/postgres/helpers.rs
@@ -186,6 +186,31 @@ mod tests {
     }
 
     #[test]
+    fn block_on_handles_ready_future() {
+        Python::initialize();
+        let rt = test_runtime();
+        Python::attach(|py| {
+            // A future that returns ready on the first poll.
+            let fut = std::future::ready(9);
+            assert_eq!(fut.block_on(py, rt.handle()), 9);
+        });
+    }
+
+    #[test]
+    fn block_on_handles_not_ready_future() {
+        Python::initialize();
+        let rt = test_runtime();
+        Python::attach(|py| {
+            // A future that requires polling multiple times to complete.
+            let fut = async {
+                tokio::task::yield_now().await;
+                9
+            };
+            assert_eq!(fut.block_on(py, rt.handle()), 9);
+        });
+    }
+
+    #[test]
     fn block_on_pg_result_maps_ok_through() {
         Python::initialize();
         let rt = test_runtime();

--- a/rust/src/database/postgres/helpers.rs
+++ b/rust/src/database/postgres/helpers.rs
@@ -66,13 +66,14 @@ where
 {
     /// Block on `self` on the given runtime and convert a Postgres error into
     /// a `PyErr`.
-    fn block_on_result(self, py: Python<'_>, handle: &Handle) -> PyResult<T> {
+    fn block_on_pg_result(self, py: Python<'_>, handle: &Handle) -> PyResult<T> {
         self.block_on(py, handle).map_err(pg_err_to_py)
     }
 }
 
 // Blanket impls: every suitable future automatically gets `block_on` /
-// `block_on_result`, so callers can write `fut.block_on(py)` directly.
+// `block_on_pg_result`, so callers can write `fut.block_on(py, handle)`
+// directly.
 impl<F> BlockingPostgres for F
 where
     F: Future + Sized + Send + Ungil,
@@ -172,12 +173,12 @@ mod tests {
     }
 
     #[test]
-    fn block_on_result_maps_ok_through() {
+    fn block_on_pg_result_maps_ok_through() {
         Python::initialize();
         let rt = test_runtime();
         Python::attach(|py| {
             let ok = async { Ok::<i32, tokio_postgres::Error>(5) };
-            assert_eq!(ok.block_on_result(py, rt.handle()).unwrap(), 5);
+            assert_eq!(ok.block_on_pg_result(py, rt.handle()).unwrap(), 5);
             // The error path (mapping a `tokio_postgres::Error` to a `PyErr`)
             // isn't covered here, because that error type can't be constructed
             // by hand. Exercising it needs a live server.

--- a/rust/src/database/postgres/helpers.rs
+++ b/rust/src/database/postgres/helpers.rs
@@ -68,8 +68,8 @@ where
         let mut pin_self = pin!(self);
         {
             let _guard = handle.enter();
-            let noop_waker = futures::task::noop_waker();
-            let mut cx = futures::task::Context::from_waker(&noop_waker);
+            let noop_waker = std::task::Waker::noop();
+            let mut cx = std::task::Context::from_waker(noop_waker);
             match pin_self.poll_unpin(&mut cx) {
                 std::task::Poll::Ready(val) => return val,
                 std::task::Poll::Pending => (),

--- a/rust/src/database/postgres/helpers.rs
+++ b/rust/src/database/postgres/helpers.rs
@@ -27,7 +27,10 @@
 //! unit-tested against an in-memory stream with no live database — see
 //! [`BlockingPostgresStream`]'s tests.
 
-use std::{future::Future, pin::Pin};
+use std::{
+    future::Future,
+    pin::{pin, Pin},
+};
 
 use futures::{stream::Fuse, FutureExt, StreamExt};
 use pyo3::{marker::Ungil, PyResult, Python};
@@ -36,6 +39,9 @@ use tokio::runtime::Handle;
 use crate::database::postgres::pg_err_to_py;
 
 /// Block on a future on a given runtime, releasing the GIL while we wait.
+///
+/// Note that this drives the future on *this* thread, not on the runtime's
+/// worker threads. See [`tokio::runtime::Handle::block_on`] for details.
 pub trait BlockingPostgres
 where
     Self: Future + Sized + Send + Ungil,
@@ -53,7 +59,26 @@ where
     /// runtime worker, so it cannot starve the worker threads that complete the
     /// future.
     fn block_on(self, py: Python<'_>, handle: &Handle) -> Self::Output {
-        py.detach(|| handle.block_on(self))
+        // Check if this future is already ready, and if so return immediately
+        // without needlessly releasing and reacquiring the GIL.
+        //
+        // This is basically the same as `FutureExt::now_or_never`, except we a)
+        // keep the pinned future to poll again below, and b) enter the runtime
+        // in case the future needs it.
+        let mut pin_self = pin!(self);
+        {
+            let _guard = handle.enter();
+            let noop_waker = futures::task::noop_waker();
+            let mut cx = futures::task::Context::from_waker(&noop_waker);
+            match pin_self.poll_unpin(&mut cx) {
+                std::task::Poll::Ready(val) => return val,
+                std::task::Poll::Pending => (),
+            }
+        }
+
+        // Note: this will drive the future to completion on *this* thread, not
+        // on the runtime's worker threads. See `Handle::block_on` for details.
+        py.detach(|| handle.block_on(pin_self))
     }
 }
 
@@ -111,15 +136,7 @@ where
     ///
     /// This method will return `None` if the stream is exhausted.
     fn block_on_next(&mut self, py: Python<'_>, handle: &Handle) -> Option<Self::Item> {
-        match self.get_next_if_ready() {
-            // `Some(Some(item))` (ready) and `Some(None)` (exhausted) are both
-            // answers we can return immediately — we just hand the inner
-            // `Option<Item>` straight back.
-            Some(row) => row,
-            // `None` means "not ready yet": release the GIL and block until the
-            // next item (or end of stream) arrives.
-            None => self.next().block_on(py, handle),
-        }
+        self.next().block_on(py, handle)
     }
 
     /// Get the next item from the stream if it's ready, without blocking.
@@ -127,6 +144,9 @@ where
     /// Returns `None` if the stream is not ready to yield an item. Returns
     /// `Some(None)` if the stream is exhausted.
     fn get_next_if_ready(&mut self) -> Option<Option<Self::Item>> {
+        // Note it is safe to call `now_or_never` here as it's fine to
+        // repeatedly call `next()` (as it's a thin wrapper that simply calls
+        // `poll_next` on the underlying stream).
         self.next().now_or_never()
     }
 }

--- a/rust/src/database/postgres/helpers.rs
+++ b/rust/src/database/postgres/helpers.rs
@@ -235,8 +235,7 @@ mod tests {
             let stream = stream::once(async {
                 tokio::task::yield_now().await;
                 Ok::<i32, ()>(7)
-            })
-            .fuse();
+            });
             let mut stream = pin!(stream);
 
             assert_eq!(stream.as_mut().next().now_or_never(), None);
@@ -252,8 +251,7 @@ mod tests {
             let stream = stream::once(async {
                 tokio::task::yield_now().await;
                 Ok::<i32, ()>(8)
-            })
-            .fuse();
+            });
             let mut stream = pin!(stream);
             assert_eq!(stream.as_mut().block_on_next(py, rt.handle()), Some(Ok(8)));
         });

--- a/rust/src/database/postgres/helpers.rs
+++ b/rust/src/database/postgres/helpers.rs
@@ -35,26 +35,25 @@ use tokio::runtime::Handle;
 
 use crate::database::postgres::pg_err_to_py;
 
-/// Block on a future on the shared runtime, releasing the GIL while we wait.
+/// Block on a future on a given runtime, releasing the GIL while we wait.
 pub trait BlockingPostgres
 where
     Self: Future + Sized + Send + Ungil,
     Self::Output: Ungil + Send,
 {
-    /// Drive `self` to completion on the shared runtime, returning its output.
+    /// Drive `self` to completion on the given runtime, returning its output.
     /// Releases the GIL for the duration so the wait doesn't block other Python
     /// threads.
     ///
-    /// Blocks on the runtime the calling thread has *entered* — taken from the
-    /// thread-local context via [`Handle::current`], not passed in. Every
-    /// thread that drives these calls must have the server's shared runtime
-    /// (see [`crate::tokio_runtime`]) entered first with
-    /// [`Handle::enter`](tokio::runtime::Handle::enter); [`Handle::current`]
-    /// panics otherwise. The blocking wait runs on the calling (Python) thread,
-    /// never on a runtime worker, so it cannot starve the worker threads that
-    /// complete the future.
-    fn block_on(self, py: Python<'_>) -> Self::Output {
-        py.detach(|| Handle::current().block_on(self))
+    /// `handle` is expected to be the server's shared runtime (see
+    /// [`crate::tokio_runtime`]). It is passed in explicitly rather than taken
+    /// from the thread-local context via [`Handle::current`], so callers work
+    /// from any Python thread with no need to have *entered* the runtime first.
+    /// The blocking wait runs on the calling (Python) thread, never on a
+    /// runtime worker, so it cannot starve the worker threads that complete the
+    /// future.
+    fn block_on(self, py: Python<'_>, handle: &Handle) -> Self::Output {
+        py.detach(|| handle.block_on(self))
     }
 }
 
@@ -65,9 +64,10 @@ where
     Self: Future<Output = Result<T, tokio_postgres::Error>> + Sized + Send + Ungil,
     Self::Output: Ungil + Send,
 {
-    /// Block on `self` and convert a Postgres error into a `PyErr`.
-    fn block_on_result(self, py: Python<'_>) -> PyResult<T> {
-        self.block_on(py).map_err(pg_err_to_py)
+    /// Block on `self` on the given runtime and convert a Postgres error into
+    /// a `PyErr`.
+    fn block_on_result(self, py: Python<'_>, handle: &Handle) -> PyResult<T> {
+        self.block_on(py, handle).map_err(pg_err_to_py)
     }
 }
 
@@ -87,7 +87,7 @@ where
 }
 
 /// Pull items from a [`Fuse`]d stream from synchronous Python code, blocking on
-/// the shared runtime only when the next item isn't already buffered.
+/// a given runtime only when the next item isn't already buffered.
 ///
 /// Implemented for any pinned, fused stream (`Pin<&mut Fuse<S>>`) whose items
 /// can cross the GIL-release boundary, so it can be tested against an
@@ -102,14 +102,14 @@ where
     Self: futures::Stream + Sized + Send + Ungil + Unpin,
     Self::Item: Ungil + Send,
 {
-    /// Get the next item from the stream, blocking on the shared runtime if
+    /// Get the next item from the stream, blocking on the given runtime if
     /// necessary.
     ///
     /// If the stream is not ready to yield an item, this will release the GIL
     /// and block until the next item is available.
     ///
     /// This method will return `None` if the stream is exhausted.
-    fn block_on_next(&mut self, py: Python<'_>) -> Option<Self::Item> {
+    fn block_on_next(&mut self, py: Python<'_>, handle: &Handle) -> Option<Self::Item> {
         match self.get_next_if_ready() {
             // `Some(Some(item))` (ready) and `Some(None)` (exhausted) are both
             // answers we can return immediately — we just hand the inner
@@ -117,7 +117,7 @@ where
             Some(row) => row,
             // `None` means "not ready yet": release the GIL and block until the
             // next item (or end of stream) arrives.
-            None => self.next().block_on(py),
+            None => self.next().block_on(py, handle),
         }
     }
 
@@ -151,10 +151,9 @@ mod tests {
 
     use super::*;
 
-    /// A throwaway runtime standing in for the shared one. The helpers only
-    /// need *some* runtime entered on the current thread, so that
-    /// [`Handle::current`] resolves. Each test calls `rt.enter()` and holds
-    /// the guard for the duration.
+    /// A throwaway runtime standing in for the shared one. The helpers take
+    /// the runtime to block on explicitly, so each test just passes this
+    /// runtime's handle.
     fn test_runtime() -> Runtime {
         tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
@@ -167,9 +166,8 @@ mod tests {
     fn block_on_runs_future_and_returns_output() {
         Python::initialize();
         let rt = test_runtime();
-        let _guard = rt.enter();
         Python::attach(|py| {
-            assert_eq!(async { 1 + 2 }.block_on(py), 3);
+            assert_eq!(async { 1 + 2 }.block_on(py, rt.handle()), 3);
         });
     }
 
@@ -177,10 +175,9 @@ mod tests {
     fn block_on_result_maps_ok_through() {
         Python::initialize();
         let rt = test_runtime();
-        let _guard = rt.enter();
         Python::attach(|py| {
             let ok = async { Ok::<i32, tokio_postgres::Error>(5) };
-            assert_eq!(ok.block_on_result(py).unwrap(), 5);
+            assert_eq!(ok.block_on_result(py, rt.handle()).unwrap(), 5);
             // The error path (mapping a `tokio_postgres::Error` to a `PyErr`)
             // isn't covered here, because that error type can't be constructed
             // by hand. Exercising it needs a live server.
@@ -191,7 +188,6 @@ mod tests {
     fn get_next_if_ready_returns_buffered_rows_then_signals_end() {
         Python::initialize();
         let rt = test_runtime();
-        let _guard = rt.enter();
         Python::attach(|py| {
             // `stream::iter` yields each item immediately, so every poll is
             // ready: we get the items, then a `Some(None)` end-of-stream once
@@ -209,8 +205,8 @@ mod tests {
             // `block_on_next` takes the same already-ready value.
             let stream = stream::iter(vec![Ok::<i32, ()>(9)]).fuse();
             let mut stream = pin!(stream);
-            assert_eq!(stream.as_mut().block_on_next(py), Some(Ok(9)));
-            assert_eq!(stream.as_mut().block_on_next(py), None);
+            assert_eq!(stream.as_mut().block_on_next(py, rt.handle()), Some(Ok(9)));
+            assert_eq!(stream.as_mut().block_on_next(py, rt.handle()), None);
         });
     }
 
@@ -218,7 +214,6 @@ mod tests {
     fn block_on_next_blocks_when_first_poll_is_pending() {
         Python::initialize();
         let rt = test_runtime();
-        let _guard = rt.enter();
         Python::attach(|py| {
             // A stream whose first poll is `Pending` (it yields back to the
             // runtime before producing the value). `get_next_if_ready` /
@@ -236,8 +231,8 @@ mod tests {
             // pinned stream; `block_on_next` re-polls that same stream via
             // `&mut self`, resuming the yielded future rather than restarting
             // it, so it still resolves to 7.
-            assert_eq!(stream.as_mut().block_on_next(py), Some(Ok(7)));
-            assert_eq!(stream.as_mut().block_on_next(py), None);
+            assert_eq!(stream.as_mut().block_on_next(py, rt.handle()), Some(Ok(7)));
+            assert_eq!(stream.as_mut().block_on_next(py, rt.handle()), None);
 
             // And, on a fresh stream, `block_on_next` handles a pending first
             // poll on its own, with no preceding `get_next_if_ready`.
@@ -247,7 +242,7 @@ mod tests {
             })
             .fuse();
             let mut stream = pin!(stream);
-            assert_eq!(stream.as_mut().block_on_next(py), Some(Ok(8)));
+            assert_eq!(stream.as_mut().block_on_next(py, rt.handle()), Some(Ok(8)));
         });
     }
 }

--- a/rust/src/database/postgres/helpers.rs
+++ b/rust/src/database/postgres/helpers.rs
@@ -142,21 +142,6 @@ where
 
         self.next().block_on(py, handle)
     }
-
-    /// Get the next item from the stream if it's ready, without blocking.
-    ///
-    /// Returns `None` if the stream is not ready to yield an item. Returns
-    /// `Some(None)` if the stream is exhausted.
-    fn get_next_if_ready(&mut self) -> Option<Option<Self::Item>> {
-        if self.is_terminated() {
-            return Some(None);
-        }
-
-        // Note it is safe to call `now_or_never` here as it's fine to
-        // repeatedly call `next()` (as it's a thin wrapper that simply calls
-        // `poll_next` on the underlying stream).
-        self.next().now_or_never()
-    }
 }
 
 // Blanket impl over any pinned, fused stream, not just `RowStream`, so the
@@ -214,40 +199,14 @@ mod tests {
     }
 
     #[test]
-    fn get_next_if_ready_returns_buffered_rows_then_signals_end() {
-        Python::initialize();
-        let rt = test_runtime();
-        Python::attach(|py| {
-            // `stream::iter` yields each item immediately, so every poll is
-            // ready: we get the items, then a `Some(None)` end-of-stream once
-            // it's drained, without ever needing to block.
-            let stream = stream::iter(vec![Ok::<i32, ()>(1), Ok(2)]).fuse();
-            let mut stream = pin!(stream);
-
-            assert_eq!(stream.as_mut().get_next_if_ready(), Some(Some(Ok(1))));
-            assert_eq!(stream.as_mut().get_next_if_ready(), Some(Some(Ok(2))));
-            // Exhausted: the item is "ready" and is `None`.
-            assert_eq!(stream.as_mut().get_next_if_ready(), Some(None));
-            // A fused stream keeps reporting end-of-stream rather than panicking.
-            assert_eq!(stream.as_mut().get_next_if_ready(), Some(None));
-
-            // `block_on_next` takes the same already-ready value.
-            let stream = stream::iter(vec![Ok::<i32, ()>(9)]).fuse();
-            let mut stream = pin!(stream);
-            assert_eq!(stream.as_mut().block_on_next(py, rt.handle()), Some(Ok(9)));
-            assert_eq!(stream.as_mut().block_on_next(py, rt.handle()), None);
-        });
-    }
-
-    #[test]
     fn block_on_next_blocks_when_first_poll_is_pending() {
         Python::initialize();
         let rt = test_runtime();
         Python::attach(|py| {
             // A stream whose first poll is `Pending` (it yields back to the
-            // runtime before producing the value). `get_next_if_ready` /
-            // `now_or_never` polls exactly once and so sees `Pending` and gives
-            // up, forcing `block_on_next` down its blocking path.
+            // runtime before producing the value). `now_or_never` polls exactly
+            // once and so sees `Pending` and gives up, forcing `block_on_next`
+            // down its blocking path.
             let stream = stream::once(async {
                 tokio::task::yield_now().await;
                 Ok::<i32, ()>(7)
@@ -255,8 +214,8 @@ mod tests {
             .fuse();
             let mut stream = pin!(stream);
 
-            assert_eq!(stream.as_mut().get_next_if_ready(), None);
-            // `get_next_if_ready` above polled (and so advanced) the *same*
+            assert_eq!(stream.as_mut().next().now_or_never(), None);
+            // `next().now_or_never()` above polled (and so advanced) the *same*
             // pinned stream; `block_on_next` re-polls that same stream via
             // `&mut self`, resuming the yielded future rather than restarting
             // it, so it still resolves to 7.

--- a/rust/src/database/postgres/helpers.rs
+++ b/rust/src/database/postgres/helpers.rs
@@ -14,7 +14,7 @@
  */
 
 //! Extension traits for driving [`tokio_postgres`] futures to completion from
-//! the synchronous, GIL-holding Python methods.
+//! synchronous, GIL-holding Python code.
 //!
 //! Both [`BlockingPostgres`] and [`BlockingPostgresStream`] release the GIL
 //! (`py.detach`) while blocking on the shared tokio runtime, so other Python
@@ -23,10 +23,9 @@
 //! the `detach` boundary.
 //!
 //! The stream helper is generic over the underlying stream type rather than
-//! hard-wired to [`tokio_postgres::RowStream`]. In production it is always used
-//! with a `RowStream`, but keeping it generic lets the cursor state machine
-//! (which uses these helpers) be unit-tested against an in-memory fake stream
-//! with no live database — see [`BlockingPostgresStream`]'s tests.
+//! hard-wired to [`tokio_postgres::RowStream`], so code built on it can be
+//! unit-tested against an in-memory stream with no live database — see
+//! [`BlockingPostgresStream`]'s tests.
 
 use std::{future::Future, pin::Pin};
 
@@ -52,8 +51,8 @@ where
     /// (see [`crate::tokio_runtime`]) entered first with
     /// [`Handle::enter`](tokio::runtime::Handle::enter); [`Handle::current`]
     /// panics otherwise. The blocking wait runs on the calling (Python) thread,
-    /// never on a runtime worker — see this module's docs for why that can't
-    /// deadlock.
+    /// never on a runtime worker, so it cannot starve the worker threads that
+    /// complete the future.
     fn block_on(self, py: Python<'_>) -> Self::Output {
         py.detach(|| Handle::current().block_on(self))
     }
@@ -91,16 +90,13 @@ where
 /// the shared runtime only when the next item isn't already buffered.
 ///
 /// Implemented for any pinned, fused stream (`Pin<&mut Fuse<S>>`) whose items
-/// can cross the GIL-release boundary. In production `S` is
-/// [`tokio_postgres::RowStream`]; the generic bound is what lets the cursor
-/// logic be tested against an in-memory fake.
+/// can cross the GIL-release boundary, so it can be tested against an
+/// in-memory stream as well as a [`tokio_postgres::RowStream`].
 ///
-/// The [`Fuse`] is *required* by the impl (the trait is implemented only for
-/// `Pin<&mut Fuse<S>>`), not merely assumed. This matters because
-/// [`Self::get_next_if_ready`] may poll the stream again after it has finished:
-/// a bare `Stream` is free to panic if polled past completion, whereas a fused
-/// stream simply keeps yielding `None`. So repeated `get_next_if_ready` /
-/// `block_on_next` calls after exhaustion are safe by construction.
+/// The [`Fuse`] bound matters because [`Self::get_next_if_ready`] may poll the
+/// stream again after it has finished. A bare `Stream` is allowed to panic if
+/// polled past completion; a fused stream keeps yielding `None`, so calls
+/// after exhaustion are safe.
 pub trait BlockingPostgresStream
 where
     Self: futures::Stream + Sized + Send + Ungil + Unpin,
@@ -134,9 +130,8 @@ where
     }
 }
 
-// Blanket impl over any pinned, fused stream. Requiring the helper bounds here
-// (rather than only for `RowStream`) is what makes the cursor logic testable
-// with a fake stream.
+// Blanket impl over any pinned, fused stream, not just `RowStream`, so the
+// tests can use an in-memory stream.
 impl<S> BlockingPostgresStream for Pin<&mut Fuse<S>>
 where
     Self: futures::Stream + Send + Ungil + Unpin,
@@ -156,11 +151,9 @@ mod tests {
 
     use super::*;
 
-    /// A throwaway runtime standing in for the shared one. Production code
-    /// enters `crate::tokio_runtime`'s runtime on each thread; the helpers only
-    /// need *some* runtime entered on the current thread (so [`Handle::current`]
-    /// resolves), and (as in production) the blocking wait runs on this test
-    /// thread rather than on a worker. Each test calls `rt.enter()` and holds
+    /// A throwaway runtime standing in for the shared one. The helpers only
+    /// need *some* runtime entered on the current thread, so that
+    /// [`Handle::current`] resolves. Each test calls `rt.enter()` and holds
     /// the guard for the duration.
     fn test_runtime() -> Runtime {
         tokio::runtime::Builder::new_multi_thread()
@@ -189,8 +182,8 @@ mod tests {
             let ok = async { Ok::<i32, tokio_postgres::Error>(5) };
             assert_eq!(ok.block_on_result(py).unwrap(), 5);
             // The error path (mapping a `tokio_postgres::Error` to a `PyErr`)
-            // can't be unit-tested here, as that error type can't be
-            // constructed by hand; it's exercised by the integration tests.
+            // isn't covered here, because that error type can't be constructed
+            // by hand. Exercising it needs a live server.
         });
     }
 
@@ -246,9 +239,8 @@ mod tests {
             assert_eq!(stream.as_mut().block_on_next(py), Some(Ok(7)));
             assert_eq!(stream.as_mut().block_on_next(py), None);
 
-            // And, on a fresh stream, `block_on_next` handles the pending first
-            // poll entirely on its own (no preceding `get_next_if_ready`),
-            // proving it doesn't rely on being "primed" by an earlier call.
+            // And, on a fresh stream, `block_on_next` handles a pending first
+            // poll on its own, with no preceding `get_next_if_ready`.
             let stream = stream::once(async {
                 tokio::task::yield_now().await;
                 Ok::<i32, ()>(8)

--- a/rust/src/database/postgres/helpers.rs
+++ b/rust/src/database/postgres/helpers.rs
@@ -32,7 +32,7 @@ use std::{
     pin::{pin, Pin},
 };
 
-use futures::{stream::Fuse, FutureExt, StreamExt};
+use futures::{stream::FusedStream, FutureExt, StreamExt};
 use pyo3::{marker::Ungil, PyResult, Python};
 use tokio::runtime::Handle;
 
@@ -112,20 +112,20 @@ where
 {
 }
 
-/// Pull items from a [`Fuse`]d stream from synchronous Python code, blocking on
+/// Pull items from a [`FusedStream`] from synchronous Python code, blocking on
 /// a given runtime only when the next item isn't already buffered.
 ///
-/// Implemented for any pinned, fused stream (`Pin<&mut Fuse<S>>`) whose items
-/// can cross the GIL-release boundary, so it can be tested against an
+/// Implemented for any pinned, fused stream (e.g. `Pin<&mut Fuse<S>>`) whose
+/// items can cross the GIL-release boundary, so it can be tested against an
 /// in-memory stream as well as a [`tokio_postgres::RowStream`].
 ///
-/// The [`Fuse`] bound matters because [`Self::get_next_if_ready`] may poll the
-/// stream again after it has finished. A bare `Stream` is allowed to panic if
-/// polled past completion; a fused stream keeps yielding `None`, so calls
-/// after exhaustion are safe.
+/// The [`FusedStream`] bound matters because [`Self::get_next_if_ready`] may
+/// poll the stream again after it has finished. A bare `Stream` is allowed to
+/// panic if polled past completion; a fused stream keeps yielding `None`, so
+/// calls after exhaustion are safe.
 pub trait BlockingPostgresStream
 where
-    Self: futures::Stream + Sized + Send + Ungil + Unpin,
+    Self: FusedStream + Sized + Send + Ungil + Unpin,
     Self::Item: Ungil + Send,
 {
     /// Get the next item from the stream, blocking on the given runtime if
@@ -136,6 +136,10 @@ where
     ///
     /// This method will return `None` if the stream is exhausted.
     fn block_on_next(&mut self, py: Python<'_>, handle: &Handle) -> Option<Self::Item> {
+        if self.is_terminated() {
+            return None;
+        }
+
         self.next().block_on(py, handle)
     }
 
@@ -144,6 +148,10 @@ where
     /// Returns `None` if the stream is not ready to yield an item. Returns
     /// `Some(None)` if the stream is exhausted.
     fn get_next_if_ready(&mut self) -> Option<Option<Self::Item>> {
+        if self.is_terminated() {
+            return Some(None);
+        }
+
         // Note it is safe to call `now_or_never` here as it's fine to
         // repeatedly call `next()` (as it's a thin wrapper that simply calls
         // `poll_next` on the underlying stream).
@@ -153,10 +161,10 @@ where
 
 // Blanket impl over any pinned, fused stream, not just `RowStream`, so the
 // tests can use an in-memory stream.
-impl<S> BlockingPostgresStream for Pin<&mut Fuse<S>>
+impl<S> BlockingPostgresStream for Pin<&mut S>
 where
-    Self: futures::Stream + Send + Ungil + Unpin,
-    <Self as futures::Stream>::Item: Ungil + Send,
+    Self: FusedStream + Send + Ungil + Unpin,
+    <Self as futures::stream::Stream>::Item: Ungil + Send,
 {
 }
 

--- a/rust/src/database/postgres/mod.rs
+++ b/rust/src/database/postgres/mod.rs
@@ -7,14 +7,16 @@
 //! The driver itself is async; the eventual `Connection` / `Cursor` types will
 //! drive it from sync Python methods via a shared multi-thread tokio runtime.
 
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 
-// `pub` (rather than private) so the value-mapping types are reachable from the
-// crate root as public API while nothing inside the crate consumes them yet.
-// This is what stops clippy's `dead_code` lint from firing on them before the
+// `pub` (rather than private) so the not-yet-consumed public items in these
+// submodules are reachable from the crate root as public API. This is what
+// stops clippy's `dead_code` lint from firing on them before the
 // cursor/connection code (added in later changes) wires them up; the visibility
 // is tightened back to private once that happens.
+pub mod helpers;
 pub mod value;
 
 /// Register the `postgres` submodule under the parent `database` module.
@@ -34,4 +36,9 @@ pub fn register_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> 
         .set_item("synapse.synapse_rust.database.postgres", child)?;
 
     Ok(())
+}
+
+/// Map a [`tokio_postgres`] error into a Python `RuntimeError`.
+fn pg_err_to_py(e: tokio_postgres::Error) -> PyErr {
+    PyRuntimeError::new_err(format!("postgres error: {e}"))
 }

--- a/rust/src/database/postgres/mod.rs
+++ b/rust/src/database/postgres/mod.rs
@@ -1,0 +1,37 @@
+//! [`tokio_postgres`]-backed Postgres backend for the Rust `database` module.
+//!
+//! This module will grow the Python-facing `Connection` / `Cursor` classes and
+//! the `connect` factory; for now it hosts the value-mapping layer ([`value`])
+//! that converts between Python objects and Postgres' binary wire format.
+//!
+//! The driver itself is async; the eventual `Connection` / `Cursor` types will
+//! drive it from sync Python methods via a shared multi-thread tokio runtime.
+
+use pyo3::prelude::*;
+use pyo3::types::PyModule;
+
+// `pub` (rather than private) so the value-mapping types are reachable from the
+// crate root as public API while nothing inside the crate consumes them yet.
+// This is what stops clippy's `dead_code` lint from firing on them before the
+// cursor/connection code (added in later changes) wires them up; the visibility
+// is tightened back to private once that happens.
+pub mod value;
+
+/// Register the `postgres` submodule under the parent `database` module.
+///
+/// The `Connection` / `Cursor` classes and the `connect` factory are added in
+/// later changes; for now this just creates the (otherwise empty) submodule so
+/// the module tree — and the `value` mapping layer hanging off it — exists.
+pub fn register_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let child = PyModule::new(py, "postgres")?;
+
+    m.add_submodule(&child)?;
+
+    // We need to manually add the module to sys.modules to make `from
+    // synapse.synapse_rust.database import postgres` work.
+    py.import("sys")?
+        .getattr("modules")?
+        .set_item("synapse.synapse_rust.database.postgres", child)?;
+
+    Ok(())
+}

--- a/rust/src/database/postgres/mod.rs
+++ b/rust/src/database/postgres/mod.rs
@@ -1,29 +1,21 @@
 //! [`tokio_postgres`]-backed Postgres backend for the Rust `database` module.
 //!
-//! This module will grow the Python-facing `Connection` / `Cursor` classes and
-//! the `connect` factory; for now it hosts the value-mapping layer ([`value`])
-//! that converts between Python objects and Postgres' binary wire format.
-//!
-//! The driver itself is async; the eventual `Connection` / `Cursor` types will
-//! drive it from sync Python methods via a shared multi-thread tokio runtime.
+//! The driver is async. [`helpers`] drives its futures to completion from
+//! synchronous Python code on the shared tokio runtime, and [`value`] converts
+//! between Python objects and Postgres' binary wire format.
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 
-// `pub` (rather than private) so the not-yet-consumed public items in these
-// submodules are reachable from the crate root as public API. This is what
-// stops clippy's `dead_code` lint from firing on them before the
-// cursor/connection code (added in later changes) wires them up; the visibility
-// is tightened back to private once that happens.
+// `pub` so the items in these submodules count as public API even though
+// nothing consumes them yet, which keeps clippy's `dead_code` lint quiet.
+// Tighten to private once the connection/cursor code uses them.
 pub mod helpers;
 pub mod value;
 
-/// Register the `postgres` submodule under the parent `database` module.
-///
-/// The `Connection` / `Cursor` classes and the `connect` factory are added in
-/// later changes; for now this just creates the (otherwise empty) submodule so
-/// the module tree — and the `value` mapping layer hanging off it — exists.
+/// Register the (currently empty) `postgres` submodule under the parent
+/// `database` module.
 pub fn register_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     let child = PyModule::new(py, "postgres")?;
 

--- a/rust/src/database/postgres/value.rs
+++ b/rust/src/database/postgres/value.rs
@@ -1,0 +1,581 @@
+//! Conversions between Python values and the Postgres SQL value
+//! representations.
+//!
+//! Kept in its own module so the cursor code stays focused on the DBAPI shape
+//! rather than the type-mapping table.
+//!
+//! First cut: int / float / bool / str / bytes / None. Lists (for
+//! `ANY($1)`-style queries) and richer types — json, decimal, timestamps —
+//! are deferred to a follow-up.
+//!
+//! The mapping is column-type-driven on the way *out* (a single Python `int`
+//! becomes `INT2`/`INT4`/`INT8` depending on the column it is bound to) and
+//! type-driven on the way *in*. The supported correspondence is:
+//!
+//! | [`PgValue`] variant | Python type | Postgres column type(s)             |
+//! |---------------------|-------------|-------------------------------------|
+//! | `Null`              | `None`      | any (encoded as SQL `NULL`)         |
+//! | `Bool`              | `bool`      | `BOOL`                              |
+//! | `Int`               | `int`       | `INT2`, `INT4`, `INT8`              |
+//! | `Float`             | `float`     | `FLOAT4`, `FLOAT8`                  |
+//! | `Text`              | `str`       | `TEXT`, `VARCHAR`, `NAME`, `BPCHAR` |
+//! | `Bytea`             | `bytes`     | `BYTEA`                             |
+//!
+//! Both directions share these type lists via the two `accepts` methods, which
+//! must stay in sync with the `match` arms below.
+
+use std::error::Error;
+
+use bytes::BytesMut;
+use postgres_protocol::types::{
+    bool_to_sql, bytea_to_sql, float4_to_sql, float8_to_sql, int2_to_sql, int4_to_sql, int8_to_sql,
+    text_to_sql,
+};
+use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::types::{PyBool, PyBytes, PyFloat, PyInt, PyString, PyTuple};
+use pyo3::{prelude::*, BoundObject};
+use tokio_postgres::types::{to_sql_checked, IsNull, ToSql, Type, WrongType};
+
+/// Owned representation of a Python value that we can hand to [`tokio_postgres`]
+/// as a [`ToSql`] parameter.
+#[derive(Debug, Clone)]
+pub enum PgValue {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Text(Box<str>),
+    Bytea(Box<[u8]>),
+}
+
+impl PgValue {
+    /// Classify a Python object into a [`PgValue`], or error if its type isn't
+    /// one we know how to send to Postgres.
+    ///
+    /// Two subtleties worth calling out:
+    ///   * `bool` is classified as [`PgValue::Bool`], never [`PgValue::Int`],
+    ///     even though Python's `bool` is a subclass of `int`.
+    ///   * `int` must fit in an `i64`; a larger Python integer raises an
+    ///     `OverflowError` here, since Postgres has no wider integer type in
+    ///     this mapping.
+    ///
+    /// A type we don't recognise raises `TypeError`.
+    pub fn from_py(obj: &Bound<PyAny>) -> PyResult<Self> {
+        if obj.is_none() {
+            return Ok(PgValue::Null);
+        }
+        // `bool` must be checked before `int`, since in Python `bool` is a
+        // subclass of `int` and would otherwise be caught by the `PyInt` arm.
+        if let Ok(b) = obj.cast::<PyBool>() {
+            return Ok(PgValue::Bool(b.is_true()));
+        }
+        if let Ok(i) = obj.cast::<PyInt>() {
+            return Ok(PgValue::Int(i.extract::<i64>()?));
+        }
+        if let Ok(f) = obj.cast::<PyFloat>() {
+            return Ok(PgValue::Float(f.value()));
+        }
+        if let Ok(s) = obj.cast::<PyString>() {
+            return Ok(PgValue::Text(s.to_str()?.into()));
+        }
+        if let Ok(b) = obj.cast::<PyBytes>() {
+            return Ok(PgValue::Bytea(b.as_bytes().into()));
+        }
+        Err(PyTypeError::new_err(format!(
+            "unsupported parameter type for postgres: {}",
+            obj.get_type().name()?,
+        )))
+    }
+}
+
+// Lets PyO3 extract a `PgValue` directly from a Python argument, e.g. when a
+// cursor method takes `Option<Vec<PgValue>>` for its parameters.
+impl<'a, 'py> FromPyObject<'a, 'py> for PgValue {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        PgValue::from_py(&obj)
+    }
+}
+
+/// Serialises a [`PgValue`] into Postgres' binary wire format.
+///
+/// The target column type (`ty`) is supplied by [`tokio_postgres`] from the
+/// prepared statement, so the same `PgValue` (e.g. an `Int`) is encoded
+/// differently depending on whether the column is `INT2`/`INT4`/`INT8`. A
+/// value that doesn't match the column type yields a [`WrongType`] error.
+impl ToSql for PgValue {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        buf: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        match (self, ty) {
+            (PgValue::Null, _) => Ok(IsNull::Yes),
+            (&PgValue::Bool(v), &Type::BOOL) => {
+                bool_to_sql(v, buf);
+                Ok(IsNull::No)
+            }
+            (&PgValue::Int(i), &Type::INT2) => {
+                let v = i
+                    .try_into()
+                    .map_err(|_| format!("integer {i} out of range for INT2"))?;
+                int2_to_sql(v, buf);
+                Ok(IsNull::No)
+            }
+            (&PgValue::Int(i), &Type::INT4) => {
+                let v = i
+                    .try_into()
+                    .map_err(|_| format!("integer {i} out of range for INT4"))?;
+                int4_to_sql(v, buf);
+                Ok(IsNull::No)
+            }
+            (&PgValue::Int(i), &Type::INT8) => {
+                int8_to_sql(i, buf);
+                Ok(IsNull::No)
+            }
+            (&PgValue::Float(v), &Type::FLOAT4) => {
+                // The `as` cast here generates the closest f32 to the f64,
+                // with loss of precision. Since Python floats are variable
+                // precision anyway, this is the best we can do.
+                //
+                // (Crucially, there is no way of doing a "fallible" cast
+                // here, since unlike integers there is no notion of "out of
+                // range" for floats, just varying precision.)
+                float4_to_sql(v as f32, buf);
+                Ok(IsNull::No)
+            }
+            (&PgValue::Float(v), &Type::FLOAT8) => {
+                float8_to_sql(v, buf);
+                Ok(IsNull::No)
+            }
+            (PgValue::Text(v), &Type::TEXT | &Type::VARCHAR | &Type::NAME | &Type::BPCHAR) => {
+                text_to_sql(v, buf);
+                Ok(IsNull::No)
+            }
+            (PgValue::Bytea(v), &Type::BYTEA) => {
+                bytea_to_sql(v, buf);
+                Ok(IsNull::No)
+            }
+            // If we get here then the caller has passed a value that doesn't
+            // match the type of the column.
+            (&PgValue::Bool(_), _) => Err(Box::new(WrongType::new::<bool>(ty.clone()))),
+            (&PgValue::Int(_), _) => Err(Box::new(WrongType::new::<i64>(ty.clone()))),
+            (&PgValue::Float(_), _) => Err(Box::new(WrongType::new::<f64>(ty.clone()))),
+            (&PgValue::Text(_), _) => Err(Box::new(WrongType::new::<&str>(ty.clone()))),
+            (&PgValue::Bytea(_), _) => Err(Box::new(WrongType::new::<&[u8]>(ty.clone()))),
+        }
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        matches!(
+            *ty,
+            Type::BOOL
+                | Type::INT2
+                | Type::INT4
+                | Type::INT8
+                | Type::FLOAT4
+                | Type::FLOAT8
+                | Type::TEXT
+                | Type::VARCHAR
+                | Type::NAME
+                | Type::BPCHAR
+                | Type::BYTEA
+        )
+    }
+
+    to_sql_checked!();
+}
+
+/// Convert a Postgres row into a Python tuple, one element per column.
+///
+/// Each column is decoded via [`PythonPgFromSql`], so `NULL` becomes `None` and
+/// every other supported type becomes its natural Python equivalent.
+///
+/// Raises `ValueError` (including the column index and its Postgres type) if a
+/// column can't be decoded — e.g. its type isn't in [`PythonPgFromSql::accepts`]
+/// or the wire bytes are malformed (such as non-UTF-8 data in a `TEXT` column).
+pub fn pg_row_to_py<'py>(
+    py: Python<'py>,
+    row: &tokio_postgres::Row,
+) -> PyResult<Bound<'py, PyTuple>> {
+    let mut output_row = Vec::with_capacity(row.len());
+    for idx in 0..row.len() {
+        let obj: PythonPgFromSql = row.try_get(idx).map_err(|e| {
+            PyValueError::new_err(format!(
+                "failed to decode column {idx} (type {}): {e}",
+                row.columns()[idx].type_()
+            ))
+        })?;
+        output_row.push(obj.0);
+    }
+
+    PyTuple::new(py, output_row)
+}
+
+/// A decoded column value, ready to drop into a Python tuple. `None`
+/// represents SQL `NULL`; otherwise it holds the corresponding Python object.
+pub struct PythonPgFromSql(pub Option<Py<PyAny>>);
+
+impl<'a> tokio_postgres::types::FromSql<'a> for PythonPgFromSql {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        // Decoding builds Python objects, so we need the GIL. `try_get` (our
+        // only caller) already runs under it, so this attach is cheap.
+        Python::attach(|py| Self::from_sql_with_py(py, ty, raw))
+    }
+
+    fn from_sql_null(_ty: &Type) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        Ok(PythonPgFromSql(None))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        matches!(
+            *ty,
+            Type::BOOL
+                | Type::INT2
+                | Type::INT4
+                | Type::INT8
+                | Type::FLOAT4
+                | Type::FLOAT8
+                | Type::TEXT
+                | Type::VARCHAR
+                | Type::NAME
+                | Type::BPCHAR
+                | Type::BYTEA
+        )
+    }
+}
+
+impl PythonPgFromSql {
+    /// Decode a non-NULL column value into the matching Python object, given
+    /// an already-held GIL token.
+    fn from_sql_with_py(
+        py: Python<'_>,
+        ty: &Type,
+        raw: &[u8],
+    ) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        let obj = match *ty {
+            Type::BOOL => {
+                let b = postgres_protocol::types::bool_from_sql(raw)?;
+                PyBool::new(py, b).into_any().unbind()
+            }
+            Type::INT2 => {
+                let i = postgres_protocol::types::int2_from_sql(raw)?;
+                PyInt::new(py, i).into_any().unbind()
+            }
+            Type::INT4 => {
+                let i = postgres_protocol::types::int4_from_sql(raw)?;
+                PyInt::new(py, i).into_any().unbind()
+            }
+            Type::INT8 => {
+                let i = postgres_protocol::types::int8_from_sql(raw)?;
+                PyInt::new(py, i).into_any().unbind()
+            }
+            Type::FLOAT4 => {
+                let f = postgres_protocol::types::float4_from_sql(raw)?;
+                PyFloat::new(py, f.into()).into_any().unbind()
+            }
+            Type::FLOAT8 => {
+                let f = postgres_protocol::types::float8_from_sql(raw)?;
+                PyFloat::new(py, f).into_any().unbind()
+            }
+            Type::TEXT | Type::VARCHAR | Type::NAME | Type::BPCHAR => {
+                PyString::from_bytes(py, raw)?.into_any().unbind()
+            }
+            Type::BYTEA => PyBytes::new(py, raw).into_any().unbind(),
+            _ => {
+                // This should never happen, unless the `accepts` method is out
+                // of sync.
+                return Err(format!("unsupported column type for postgres: {ty}").into());
+            }
+        };
+
+        Ok(PythonPgFromSql(Some(obj)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! These tests exercise the value mapping in isolation — no live Postgres
+    //! server is needed. The `to_sql` / `from_sql` halves both operate on raw
+    //! byte buffers, so we can drive them directly with hand-built buffers and
+    //! a chosen column [`Type`], and the `from_py` classifier just needs a GIL.
+
+    use super::*;
+
+    /// Encode `value` for column type `ty`, returning the wire bytes and the
+    /// `IsNull` flag. Panics on a `ToSql` error so callers can assert on the
+    /// happy path concisely.
+    fn encode(value: &PgValue, ty: &Type) -> (Vec<u8>, bool) {
+        let mut buf = BytesMut::new();
+        let is_null = value.to_sql(ty, &mut buf).expect("encoding should succeed");
+        (buf.to_vec(), matches!(is_null, IsNull::Yes))
+    }
+
+    /// Like [`encode`], but surfaces the `ToSql` result so a test can assert on
+    /// the error path (e.g. an out-of-range integer).
+    fn encode_result(value: &PgValue, ty: &Type) -> Result<(), Box<dyn Error + Sync + Send>> {
+        let mut buf = BytesMut::new();
+        value.to_sql(ty, &mut buf).map(|_| ())
+    }
+
+    #[test]
+    fn from_py_classifies_supported_types() {
+        Python::initialize();
+        Python::attach(|py| {
+            // `None` -> NULL.
+            assert!(matches!(
+                PgValue::from_py(&py.None().into_bound(py)).unwrap(),
+                PgValue::Null
+            ));
+
+            // `bool` must win over `int` (it is an `int` subclass in Python).
+            assert!(matches!(
+                PgValue::from_py(&true.into_pyobject(py).unwrap()).unwrap(),
+                PgValue::Bool(true)
+            ));
+
+            assert!(matches!(
+                PgValue::from_py(&7i64.into_pyobject(py).unwrap()).unwrap(),
+                PgValue::Int(7)
+            ));
+
+            assert!(matches!(
+                PgValue::from_py(&1.5f64.into_pyobject(py).unwrap()).unwrap(),
+                PgValue::Float(1.5)
+            ));
+
+            match PgValue::from_py(&"hello".into_pyobject(py).unwrap()).unwrap() {
+                PgValue::Text(s) => assert_eq!(&*s, "hello"),
+                other => panic!("expected Text, got {other:?}"),
+            }
+
+            match PgValue::from_py(&PyBytes::new(py, b"\x00\xff").into_any()).unwrap() {
+                PgValue::Bytea(b) => assert_eq!(&*b, b"\x00\xff"),
+                other => panic!("expected Bytea, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn from_py_extracts_via_frompyobject() {
+        // The cursor binds parameters by extracting `PgValue` straight off the
+        // Python argument; check that `FromPyObject` path forwards to `from_py`.
+        Python::initialize();
+        Python::attach(|py| {
+            let obj = 7i64.into_pyobject(py).unwrap().into_any();
+            assert!(matches!(obj.extract::<PgValue>().unwrap(), PgValue::Int(7)));
+        });
+    }
+
+    #[test]
+    fn from_py_rejects_unsupported_type() {
+        Python::initialize();
+        Python::attach(|py| {
+            // A list is not a scalar we know how to bind.
+            let list = pyo3::types::PyList::new(py, [1, 2, 3]).unwrap();
+            let err = PgValue::from_py(&list.into_any()).unwrap_err();
+            assert!(err.is_instance_of::<PyTypeError>(py));
+            // The message names the offending type, which is the useful part.
+            assert!(err.to_string().contains("list"), "got: {err}");
+        });
+    }
+
+    #[test]
+    fn to_sql_encodes_each_type_for_its_column() {
+        // NULL is encoded as "no bytes, IsNull::Yes" regardless of column type.
+        let (bytes, is_null) = encode(&PgValue::Null, &Type::INT4);
+        assert!(is_null);
+        assert!(bytes.is_empty());
+
+        // Integers are width-specific: the same `Int` encodes to 2/4/8 bytes
+        // depending on the column type.
+        assert_eq!(encode(&PgValue::Int(1), &Type::INT2).0, 1i16.to_be_bytes());
+        assert_eq!(encode(&PgValue::Int(1), &Type::INT4).0, 1i32.to_be_bytes());
+        assert_eq!(encode(&PgValue::Int(1), &Type::INT8).0, 1i64.to_be_bytes());
+
+        assert_eq!(encode(&PgValue::Bool(true), &Type::BOOL).0, vec![1]);
+        assert_eq!(encode(&PgValue::Bool(false), &Type::BOOL).0, vec![0]);
+        assert_eq!(
+            encode(&PgValue::Float(1.0), &Type::FLOAT8).0,
+            1.0f64.to_be_bytes()
+        );
+        assert_eq!(
+            encode(&PgValue::Text("hi".into()), &Type::TEXT).0,
+            b"hi".to_vec()
+        );
+        assert_eq!(
+            encode(&PgValue::Bytea(Box::from(&b"\x01\x02"[..])), &Type::BYTEA).0,
+            vec![1, 2]
+        );
+    }
+
+    #[test]
+    fn to_sql_float4_narrows_with_precision_loss() {
+        // `0.1` is not representable in binary floating point, so the f64 and
+        // f32 encodings genuinely differ. Encoding to a FLOAT4 column must use
+        // the (lossy) f32 narrowing, not reinterpret the f64 bytes.
+        let value = 0.1f64;
+        assert_eq!(
+            encode(&PgValue::Float(value), &Type::FLOAT4).0,
+            (value as f32).to_be_bytes()
+        );
+        // And the result is provably narrower than the FLOAT8 encoding.
+        assert_ne!(
+            encode(&PgValue::Float(value), &Type::FLOAT4).0,
+            value.to_be_bytes()[..4].to_vec()
+        );
+    }
+
+    #[test]
+    fn to_sql_rejects_mismatched_column_type() {
+        // A value whose type doesn't match the column is a `WrongType` error
+        // rather than a silent reinterpretation. Hit a few distinct arms.
+        let cases: &[(PgValue, Type)] = &[
+            (PgValue::Int(1), Type::TEXT),
+            (PgValue::Text("x".into()), Type::INT4),
+            (PgValue::Bytea(Box::from(&b"x"[..])), Type::TEXT),
+            (PgValue::Bool(true), Type::INT4),
+            (PgValue::Float(1.0), Type::INT8),
+        ];
+        for (value, ty) in cases {
+            let mut buf = BytesMut::new();
+            assert!(
+                value.to_sql(ty, &mut buf).is_err(),
+                "expected {value:?} -> {ty} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn to_sql_integer_width_boundaries() {
+        // Boundary values for each width encode; one step past the boundary is
+        // rejected by the `try_into` guards (INT8 spans all of i64, so there is
+        // nothing out of range for it).
+        assert!(encode_result(&PgValue::Int(i16::MAX as i64), &Type::INT2).is_ok());
+        assert!(encode_result(&PgValue::Int(i16::MIN as i64), &Type::INT2).is_ok());
+        assert!(encode_result(&PgValue::Int(i16::MAX as i64 + 1), &Type::INT2).is_err());
+        assert!(encode_result(&PgValue::Int(i16::MIN as i64 - 1), &Type::INT2).is_err());
+
+        assert!(encode_result(&PgValue::Int(i32::MAX as i64), &Type::INT4).is_ok());
+        assert!(encode_result(&PgValue::Int(i32::MIN as i64), &Type::INT4).is_ok());
+        assert!(encode_result(&PgValue::Int(i32::MAX as i64 + 1), &Type::INT4).is_err());
+        assert!(encode_result(&PgValue::Int(i32::MIN as i64 - 1), &Type::INT4).is_err());
+
+        assert_eq!(
+            encode(&PgValue::Int(i64::MAX), &Type::INT8).0,
+            i64::MAX.to_be_bytes()
+        );
+        assert_eq!(
+            encode(&PgValue::Int(i64::MIN), &Type::INT8).0,
+            i64::MIN.to_be_bytes()
+        );
+    }
+
+    #[test]
+    fn accepts_lists_match_supported_types() {
+        // The encode and decode sides must accept exactly the supported column
+        // types and reject everything else; a drift between the two `accepts`
+        // lists and the `match` arms would surface here.
+        for ty in [
+            Type::BOOL,
+            Type::INT2,
+            Type::INT4,
+            Type::INT8,
+            Type::FLOAT4,
+            Type::FLOAT8,
+            Type::TEXT,
+            Type::VARCHAR,
+            Type::NAME,
+            Type::BPCHAR,
+            Type::BYTEA,
+        ] {
+            assert!(<PgValue as ToSql>::accepts(&ty), "ToSql should accept {ty}");
+            assert!(
+                <PythonPgFromSql as tokio_postgres::types::FromSql>::accepts(&ty),
+                "FromSql should accept {ty}"
+            );
+        }
+
+        for ty in [Type::JSON, Type::TIMESTAMPTZ, Type::UUID] {
+            assert!(
+                !<PgValue as ToSql>::accepts(&ty),
+                "ToSql should reject {ty}"
+            );
+            assert!(
+                !<PythonPgFromSql as tokio_postgres::types::FromSql>::accepts(&ty),
+                "FromSql should reject {ty}"
+            );
+        }
+    }
+
+    #[test]
+    fn from_sql_decodes_into_python_objects() {
+        use tokio_postgres::types::FromSql;
+
+        Python::initialize();
+        Python::attach(|py| {
+            // Each supported type round-trips from its wire bytes to the
+            // matching Python object. This mirrors the encode test's type list.
+            let int2 = PythonPgFromSql::from_sql(&Type::INT2, &7i16.to_be_bytes()).unwrap();
+            assert_eq!(int2.0.unwrap().extract::<i64>(py).unwrap(), 7);
+
+            let int4 = PythonPgFromSql::from_sql(&Type::INT4, &42i32.to_be_bytes()).unwrap();
+            assert_eq!(int4.0.unwrap().extract::<i64>(py).unwrap(), 42);
+
+            // A wide INT8 that wouldn't fit in INT4, to prove the width is honoured.
+            let big = i64::MAX - 1;
+            let int8 = PythonPgFromSql::from_sql(&Type::INT8, &big.to_be_bytes()).unwrap();
+            assert_eq!(int8.0.unwrap().extract::<i64>(py).unwrap(), big);
+
+            // FLOAT4 decodes via an f32, then widens to a Python float.
+            let f4 = PythonPgFromSql::from_sql(&Type::FLOAT4, &1.5f32.to_be_bytes()).unwrap();
+            assert_eq!(f4.0.unwrap().extract::<f64>(py).unwrap(), 1.5);
+
+            let f8 = PythonPgFromSql::from_sql(&Type::FLOAT8, &2.5f64.to_be_bytes()).unwrap();
+            assert_eq!(f8.0.unwrap().extract::<f64>(py).unwrap(), 2.5);
+
+            let b = PythonPgFromSql::from_sql(&Type::BOOL, &[1]).unwrap();
+            assert!(b.0.unwrap().extract::<bool>(py).unwrap());
+
+            let text = PythonPgFromSql::from_sql(&Type::TEXT, b"hi").unwrap();
+            assert_eq!(text.0.unwrap().extract::<String>(py).unwrap(), "hi");
+
+            // BYTEA passes raw bytes through unchanged, including NULs and
+            // non-UTF-8 data — the natural inverse of the encode test.
+            let bytea = PythonPgFromSql::from_sql(&Type::BYTEA, b"\x00\xff").unwrap();
+            assert_eq!(
+                bytea.0.unwrap().extract::<Vec<u8>>(py).unwrap(),
+                b"\x00\xff"
+            );
+
+            // A SQL NULL decodes to `None` via `from_sql_null`.
+            let null = PythonPgFromSql::from_sql_null(&Type::INT4).unwrap();
+            assert!(null.0.is_none());
+        });
+    }
+
+    #[test]
+    fn from_sql_rejects_unsupported_column_type() {
+        use tokio_postgres::types::FromSql;
+
+        // The `_ =>` arm in `from_sql_with_py` guards against `accepts` drifting
+        // out of sync; decoding an unsupported type is an error, not a panic.
+        Python::initialize();
+        Python::attach(|_py| {
+            assert!(PythonPgFromSql::from_sql(&Type::JSON, b"{}").is_err());
+        });
+    }
+
+    #[test]
+    fn from_sql_rejects_non_utf8_text() {
+        use tokio_postgres::types::FromSql;
+
+        // TEXT decode goes through `PyString::from_bytes`, which validates
+        // UTF-8: malformed bytes surface as an error rather than a panic.
+        Python::initialize();
+        Python::attach(|_py| {
+            assert!(PythonPgFromSql::from_sql(&Type::TEXT, b"\xff\xfe").is_err());
+        });
+    }
+}

--- a/rust/src/database/postgres/value.rs
+++ b/rust/src/database/postgres/value.rs
@@ -1,12 +1,9 @@
 //! Conversions between Python values and the Postgres SQL value
 //! representations.
 //!
-//! Kept in its own module so the cursor code stays focused on the DBAPI shape
-//! rather than the type-mapping table.
-//!
-//! First cut: int / float / bool / str / bytes / None. Lists (for
-//! `ANY($1)`-style queries) and richer types — json, decimal, timestamps —
-//! are deferred to a follow-up.
+//! Supports int / float / bool / str / bytes / None. Lists (for
+//! `ANY($1)`-style queries) and richer types such as json, decimal and
+//! timestamps are not yet supported.
 //!
 //! The mapping is column-type-driven on the way *out* (a single Python `int`
 //! becomes `INT2`/`INT4`/`INT8` depending on the column it is bound to) and
@@ -52,14 +49,12 @@ impl PgValue {
     /// Classify a Python object into a [`PgValue`], or error if its type isn't
     /// one we know how to send to Postgres.
     ///
-    /// Two subtleties worth calling out:
     ///   * `bool` is classified as [`PgValue::Bool`], never [`PgValue::Int`],
     ///     even though Python's `bool` is a subclass of `int`.
     ///   * `int` must fit in an `i64`; a larger Python integer raises an
     ///     `OverflowError` here, since Postgres has no wider integer type in
     ///     this mapping.
-    ///
-    /// A type we don't recognise raises `TypeError`.
+    ///   * A type we don't recognise raises `TypeError`.
     pub fn from_py(obj: &Bound<PyAny>) -> PyResult<Self> {
         if obj.is_none() {
             return Ok(PgValue::Null);
@@ -88,8 +83,8 @@ impl PgValue {
     }
 }
 
-// Lets PyO3 extract a `PgValue` directly from a Python argument, e.g. when a
-// cursor method takes `Option<Vec<PgValue>>` for its parameters.
+// Lets PyO3 extract a `PgValue` directly from a Python argument, e.g. from a
+// method that takes `Option<Vec<PgValue>>` as its parameter list.
 impl<'a, 'py> FromPyObject<'a, 'py> for PgValue {
     type Error = PyErr;
 
@@ -135,13 +130,10 @@ impl ToSql for PgValue {
                 Ok(IsNull::No)
             }
             (&PgValue::Float(v), &Type::FLOAT4) => {
-                // The `as` cast here generates the closest f32 to the f64,
-                // with loss of precision. Since Python floats are variable
-                // precision anyway, this is the best we can do.
-                //
-                // (Crucially, there is no way of doing a "fallible" cast
-                // here, since unlike integers there is no notion of "out of
-                // range" for floats, just varying precision.)
+                // The `as` cast narrows to the nearest f32, losing precision.
+                // Unlike the integer arms there is no fallible conversion to
+                // use, since floats have no notion of "out of range", just
+                // varying precision.
                 float4_to_sql(v as f32, buf);
                 Ok(IsNull::No)
             }
@@ -359,8 +351,8 @@ mod tests {
 
     #[test]
     fn from_py_extracts_via_frompyobject() {
-        // The cursor binds parameters by extracting `PgValue` straight off the
-        // Python argument; check that `FromPyObject` path forwards to `from_py`.
+        // Check that extracting a `PgValue` from a Python object (the
+        // `FromPyObject` path) forwards to `from_py`.
         Python::initialize();
         Python::attach(|py| {
             let obj = 7i64.into_pyobject(py).unwrap().into_any();
@@ -376,7 +368,7 @@ mod tests {
             let list = pyo3::types::PyList::new(py, [1, 2, 3]).unwrap();
             let err = PgValue::from_py(&list.into_any()).unwrap_err();
             assert!(err.is_instance_of::<PyTypeError>(py));
-            // The message names the offending type, which is the useful part.
+            // The message should name the offending type.
             assert!(err.to_string().contains("list"), "got: {err}");
         });
     }
@@ -420,7 +412,7 @@ mod tests {
             encode(&PgValue::Float(value), &Type::FLOAT4).0,
             (value as f32).to_be_bytes()
         );
-        // And the result is provably narrower than the FLOAT8 encoding.
+        // And the bytes are not just a truncation of the f64 encoding.
         assert_ne!(
             encode(&PgValue::Float(value), &Type::FLOAT4).0,
             value.to_be_bytes()[..4].to_vec()

--- a/rust/src/database/postgres/value.rs
+++ b/rust/src/database/postgres/value.rs
@@ -224,7 +224,6 @@ impl<'a> tokio_postgres::types::FromSql<'a> for PythonPgFromSql {
         // only caller) already runs under it, so this attach is cheap. This
         // also only runs on the python thread and *not* the tokio runtime's
         // worker threads, so we don't need to blocking wait for the GIL.
-        Python::initialize();
         Python::attach(|py| Self::from_sql_with_py(py, ty, raw))
     }
 

--- a/rust/src/database/postgres/value.rs
+++ b/rust/src/database/postgres/value.rs
@@ -207,12 +207,15 @@ pub fn pg_row_to_py<'py>(
 
 /// A decoded column value, ready to drop into a Python tuple. `None`
 /// represents SQL `NULL`; otherwise it holds the corresponding Python object.
-pub struct PythonPgFromSql(pub Option<Py<PyAny>>);
+struct PythonPgFromSql(pub Option<Py<PyAny>>);
 
 impl<'a> tokio_postgres::types::FromSql<'a> for PythonPgFromSql {
     fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
         // Decoding builds Python objects, so we need the GIL. `try_get` (our
-        // only caller) already runs under it, so this attach is cheap.
+        // only caller) already runs under it, so this attach is cheap. This
+        // also only runs on the python thread and *not* the tokio runtime's
+        // worker threads, so we don't need to blocking wait for the GIL.
+        Python::initialize();
         Python::attach(|py| Self::from_sql_with_py(py, ty, raw))
     }
 

--- a/rust/src/database/postgres/value.rs
+++ b/rust/src/database/postgres/value.rs
@@ -214,8 +214,14 @@ pub fn pg_row_to_py<'py>(
     PyTuple::new(py, output_row)
 }
 
-/// A decoded column value, ready to drop into a Python tuple. `None`
-/// represents SQL `NULL`; otherwise it holds the corresponding Python object.
+/// A decoded column value, ready to drop into a Python tuple. `None` represents
+/// SQL `NULL`; otherwise it holds the corresponding Python object.
+///
+/// Must only be used on a blocking thread (i.e. not on a tokio runtime worker
+/// thread) because it attaches to the Python interpreter to build the Python
+/// object. Hence why it is private.
+///
+/// Use [`pg_row_to_py`] directly.
 struct PythonPgFromSql(pub Option<Py<PyAny>>);
 
 impl<'a> tokio_postgres::types::FromSql<'a> for PythonPgFromSql {
@@ -224,6 +230,9 @@ impl<'a> tokio_postgres::types::FromSql<'a> for PythonPgFromSql {
         // only caller) already runs under it, so this attach is cheap. This
         // also only runs on the python thread and *not* the tokio runtime's
         // worker threads, so we don't need to blocking wait for the GIL.
+        //
+        // Ideally we'd assert that we already hold the GIL, but PyO3 doesn't
+        // expose that.
         Python::attach(|py| Self::from_sql_with_py(py, ty, raw))
     }
 

--- a/rust/src/database/postgres/value.rs
+++ b/rust/src/database/postgres/value.rs
@@ -284,6 +284,9 @@ impl PythonPgFromSql {
                 PyFloat::new(py, f).into_any().unbind()
             }
             Type::TEXT | Type::VARCHAR | Type::NAME | Type::BPCHAR => {
+                // Note: PyString::from_bytes expects UTF-8, and
+                // postgres_protocol::types::text_from_sql demonstrates that the
+                // wire bytes are indeed UTF-8, so this should be safe.
                 PyString::from_bytes(py, raw)?.into_any().unbind()
             }
             Type::BYTEA => PyBytes::new(py, raw).into_any().unbind(),

--- a/rust/src/database/postgres/value.rs
+++ b/rust/src/database/postgres/value.rs
@@ -29,20 +29,21 @@ use postgres_protocol::types::{
     text_to_sql,
 };
 use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::pybacked::{PyBackedBytes, PyBackedStr};
 use pyo3::types::{PyBool, PyBytes, PyFloat, PyInt, PyString, PyTuple};
 use pyo3::{prelude::*, BoundObject};
 use tokio_postgres::types::{to_sql_checked, IsNull, ToSql, Type, WrongType};
 
 /// Owned representation of a Python value that we can hand to [`tokio_postgres`]
 /// as a [`ToSql`] parameter.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum PgValue {
     Null,
     Bool(bool),
     Int(i64),
     Float(f64),
-    Text(Box<str>),
-    Bytea(Box<[u8]>),
+    Text(PyBackedStr),
+    Bytea(PyBackedBytes),
 }
 
 impl PgValue {
@@ -55,7 +56,7 @@ impl PgValue {
     ///     `OverflowError` here, since Postgres has no wider integer type in
     ///     this mapping.
     ///   * A type we don't recognise raises `TypeError`.
-    pub fn from_py(obj: &Bound<PyAny>) -> PyResult<Self> {
+    pub fn from_py(obj: Bound<PyAny>) -> PyResult<Self> {
         if obj.is_none() {
             return Ok(PgValue::Null);
         }
@@ -70,12 +71,20 @@ impl PgValue {
         if let Ok(f) = obj.cast::<PyFloat>() {
             return Ok(PgValue::Float(f.value()));
         }
-        if let Ok(s) = obj.cast::<PyString>() {
-            return Ok(PgValue::Text(s.to_str()?.into()));
-        }
-        if let Ok(b) = obj.cast::<PyBytes>() {
-            return Ok(PgValue::Bytea(b.as_bytes().into()));
-        }
+
+        // The `cast_into` calls below are a bit awkward because we need to take
+        // ownership of `obj`, so we need to use `cast_into` and then
+        // `into_inner` to get the original `obj` back if the cast fails.
+        let obj = match obj.cast_into::<PyString>() {
+            Ok(s) => return Ok(PgValue::Text(s.try_into()?)),
+            Err(err) => err.into_inner(),
+        };
+
+        let obj = match obj.cast_into::<PyBytes>() {
+            Ok(s) => return Ok(PgValue::Bytea(s.into())),
+            Err(err) => err.into_inner(),
+        };
+
         Err(PyTypeError::new_err(format!(
             "unsupported parameter type for postgres: {}",
             obj.get_type().name()?,
@@ -89,7 +98,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for PgValue {
     type Error = PyErr;
 
     fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
-        PgValue::from_py(&obj)
+        PgValue::from_py(obj.into_bound())
     }
 }
 
@@ -296,6 +305,8 @@ mod tests {
     //! byte buffers, so we can drive them directly with hand-built buffers and
     //! a chosen column [`Type`], and the `from_py` classifier just needs a GIL.
 
+    use pyo3::IntoPyObjectExt;
+
     use super::*;
 
     /// Encode `value` for column type `ty`, returning the wire bytes and the
@@ -314,38 +325,50 @@ mod tests {
         value.to_sql(ty, &mut buf).map(|_| ())
     }
 
+    /// Build a [`PgValue::Text`] from a Rust string. The variant is backed by a
+    /// Python `str`, so this needs an attached interpreter.
+    fn text(py: Python<'_>, s: &str) -> PgValue {
+        PgValue::Text(PyString::new(py, s).try_into().unwrap())
+    }
+
+    /// Build a [`PgValue::Bytea`] from a Rust byte slice. As with [`text`], the
+    /// variant is backed by a Python `bytes`.
+    fn bytea(py: Python<'_>, b: &[u8]) -> PgValue {
+        PgValue::Bytea(PyBytes::new(py, b).into())
+    }
+
     #[test]
     fn from_py_classifies_supported_types() {
         Python::initialize();
         Python::attach(|py| {
             // `None` -> NULL.
             assert!(matches!(
-                PgValue::from_py(&py.None().into_bound(py)).unwrap(),
+                PgValue::from_py(py.None().into_bound(py)).unwrap(),
                 PgValue::Null
             ));
 
             // `bool` must win over `int` (it is an `int` subclass in Python).
             assert!(matches!(
-                PgValue::from_py(&true.into_pyobject(py).unwrap()).unwrap(),
+                PgValue::from_py(true.into_bound_py_any(py).unwrap()).unwrap(),
                 PgValue::Bool(true)
             ));
 
             assert!(matches!(
-                PgValue::from_py(&7i64.into_pyobject(py).unwrap()).unwrap(),
+                PgValue::from_py(7i64.into_bound_py_any(py).unwrap()).unwrap(),
                 PgValue::Int(7)
             ));
 
             assert!(matches!(
-                PgValue::from_py(&1.5f64.into_pyobject(py).unwrap()).unwrap(),
+                PgValue::from_py(1.5f64.into_bound_py_any(py).unwrap()).unwrap(),
                 PgValue::Float(1.5)
             ));
 
-            match PgValue::from_py(&"hello".into_pyobject(py).unwrap()).unwrap() {
+            match PgValue::from_py("hello".into_bound_py_any(py).unwrap()).unwrap() {
                 PgValue::Text(s) => assert_eq!(&*s, "hello"),
                 other => panic!("expected Text, got {other:?}"),
             }
 
-            match PgValue::from_py(&PyBytes::new(py, b"\x00\xff").into_any()).unwrap() {
+            match PgValue::from_py(PyBytes::new(py, b"\x00\xff").into_any()).unwrap() {
                 PgValue::Bytea(b) => assert_eq!(&*b, b"\x00\xff"),
                 other => panic!("expected Bytea, got {other:?}"),
             }
@@ -369,7 +392,7 @@ mod tests {
         Python::attach(|py| {
             // A list is not a scalar we know how to bind.
             let list = pyo3::types::PyList::new(py, [1, 2, 3]).unwrap();
-            let err = PgValue::from_py(&list.into_any()).unwrap_err();
+            let err = PgValue::from_py(list.into_any()).unwrap_err();
             assert!(err.is_instance_of::<PyTypeError>(py));
             // The message should name the offending type.
             assert!(err.to_string().contains("list"), "got: {err}");
@@ -395,14 +418,11 @@ mod tests {
             encode(&PgValue::Float(1.0), &Type::FLOAT8).0,
             1.0f64.to_be_bytes()
         );
-        assert_eq!(
-            encode(&PgValue::Text("hi".into()), &Type::TEXT).0,
-            b"hi".to_vec()
-        );
-        assert_eq!(
-            encode(&PgValue::Bytea(Box::from(&b"\x01\x02"[..])), &Type::BYTEA).0,
-            vec![1, 2]
-        );
+        Python::initialize();
+        Python::attach(|py| {
+            assert_eq!(encode(&text(py, "hi"), &Type::TEXT).0, b"hi".to_vec());
+            assert_eq!(encode(&bytea(py, b"\x01\x02"), &Type::BYTEA).0, vec![1, 2]);
+        });
     }
 
     #[test]
@@ -426,20 +446,23 @@ mod tests {
     fn to_sql_rejects_mismatched_column_type() {
         // A value whose type doesn't match the column is a `WrongType` error
         // rather than a silent reinterpretation. Hit a few distinct arms.
-        let cases: &[(PgValue, Type)] = &[
-            (PgValue::Int(1), Type::TEXT),
-            (PgValue::Text("x".into()), Type::INT4),
-            (PgValue::Bytea(Box::from(&b"x"[..])), Type::TEXT),
-            (PgValue::Bool(true), Type::INT4),
-            (PgValue::Float(1.0), Type::INT8),
-        ];
-        for (value, ty) in cases {
-            let mut buf = BytesMut::new();
-            assert!(
-                value.to_sql(ty, &mut buf).is_err(),
-                "expected {value:?} -> {ty} to be rejected"
-            );
-        }
+        Python::initialize();
+        Python::attach(|py| {
+            let cases: &[(PgValue, Type)] = &[
+                (PgValue::Int(1), Type::TEXT),
+                (text(py, "x"), Type::INT4),
+                (bytea(py, b"x"), Type::TEXT),
+                (PgValue::Bool(true), Type::INT4),
+                (PgValue::Float(1.0), Type::INT8),
+            ];
+            for (value, ty) in cases {
+                let mut buf = BytesMut::new();
+                assert!(
+                    value.to_sql(ty, &mut buf).is_err(),
+                    "expected {value:?} -> {ty} to be rejected"
+                );
+            }
+        });
     }
 
     #[test]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,6 +7,7 @@ use pyo3_log::ResetHandle;
 pub mod acl;
 pub mod canonical_json;
 pub mod config;
+pub mod database;
 pub mod deferred;
 pub mod duration;
 pub mod errors;
@@ -71,6 +72,7 @@ fn synapse_rust(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     acl::register_module(py, m)?;
     deferred::register_module(py, m)?;
+    database::register_module(py, m)?;
     push::register_module(py, m)?;
     events::register_module(py, m)?;
     handlers::register_module(py, m)?;

--- a/rust/src/tokio_runtime.rs
+++ b/rust/src/tokio_runtime.rs
@@ -15,7 +15,7 @@
 
 use anyhow::Context;
 use pyo3::prelude::*;
-use tokio::runtime::Runtime;
+use tokio::runtime::{Handle, Runtime};
 
 /// This is the name of the attribute where we store the runtime on the reactor
 static TOKIO_RUNTIME_ATTR: &str = "__synapse_rust_tokio_runtime";
@@ -32,15 +32,7 @@ pub struct PyTokioRuntime {
 #[pymethods]
 impl PyTokioRuntime {
     fn start(&mut self) -> PyResult<()> {
-        // TODO: allow customization of the runtime like the number of threads
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(4)
-            .enable_all()
-            .build()?;
-
-        self.runtime = Some(runtime);
-
-        Ok(())
+        self.ensure_started()
     }
 
     fn shutdown(&mut self) -> PyResult<()> {
@@ -57,6 +49,28 @@ impl PyTokioRuntime {
 }
 
 impl PyTokioRuntime {
+    /// Build the runtime if it hasn't been built yet.
+    ///
+    /// Idempotent, so it is safe to call both from the reactor's
+    /// `callWhenRunning(start)` hook and from a caller that needs the runtime
+    /// before the reactor has run that hook (see [`runtime_handle`]): whichever
+    /// runs first builds it, the other is a no-op.
+    fn ensure_started(&mut self) -> PyResult<()> {
+        if self.runtime.is_some() {
+            return Ok(());
+        }
+
+        // TODO: allow customization of the runtime like the number of threads
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(4)
+            .enable_all()
+            .build()?;
+
+        self.runtime = Some(runtime);
+
+        Ok(())
+    }
+
     /// Get the handle to the Tokio runtime, if it is running.
     pub fn handle(&self) -> PyResult<&tokio::runtime::Handle> {
         let handle = self
@@ -72,11 +86,22 @@ impl PyTokioRuntime {
 /// Get a handle to the Tokio runtime stored on the reactor instance, or create
 /// a new one.
 pub fn runtime<'a>(reactor: &Bound<'a, PyAny>) -> PyResult<PyRef<'a, PyTokioRuntime>> {
-    if !reactor.hasattr(TOKIO_RUNTIME_ATTR)? {
-        install_runtime(reactor)?;
-    }
+    Ok(get_or_install(reactor)?.borrow())
+}
 
-    get_runtime(reactor)
+/// Get a clonable handle to the shared runtime, starting it on demand.
+///
+/// Unlike [`runtime`], this does not require the reactor to have already run
+/// its `callWhenRunning(start)` hook: it starts the runtime if necessary. That
+/// lets callers that need the runtime before the reactor is up — the database
+/// backend's schema setup, `synapse_port_db`, and trial tests — still get a
+/// working handle. Once the reactor does run, its `start` hook finds the
+/// runtime already built and is a no-op, so there is still only one runtime.
+pub fn runtime_handle(reactor: &Bound<'_, PyAny>) -> PyResult<Handle> {
+    let runtime = get_or_install(reactor)?;
+    let mut runtime = runtime.borrow_mut();
+    runtime.ensure_started()?;
+    Ok(runtime.handle()?.clone())
 }
 
 /// Install a new Tokio runtime on the reactor instance.
@@ -97,11 +122,16 @@ fn install_runtime(reactor: &Bound<PyAny>) -> PyResult<()> {
     Ok(())
 }
 
-/// Get a reference to a Tokio runtime handle stored on the reactor instance.
-fn get_runtime<'a>(reactor: &Bound<'a, PyAny>) -> PyResult<PyRef<'a, PyTokioRuntime>> {
+/// Get the [`PyTokioRuntime`] stored on the reactor instance, installing a
+/// fresh one (wired to the reactor's start/shutdown) if it isn't there yet.
+fn get_or_install<'a>(reactor: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyTokioRuntime>> {
+    if !reactor.hasattr(TOKIO_RUNTIME_ATTR)? {
+        install_runtime(reactor)?;
+    }
+
     // This will raise if `TOKIO_RUNTIME_ATTR` is not set or if it is
     // not a `Runtime`. Careful that this could happen if the user sets it
     // manually, or if multiple versions of `pyo3-twisted` are used!
     let runtime: Bound<PyTokioRuntime> = reactor.getattr(TOKIO_RUNTIME_ATTR)?.extract()?;
-    Ok(runtime.borrow())
+    Ok(runtime)
 }

--- a/rust/src/tokio_runtime.rs
+++ b/rust/src/tokio_runtime.rs
@@ -51,10 +51,9 @@ impl PyTokioRuntime {
 impl PyTokioRuntime {
     /// Build the runtime if it hasn't been built yet.
     ///
-    /// Idempotent, so it is safe to call both from the reactor's
-    /// `callWhenRunning(start)` hook and from a caller that needs the runtime
-    /// before the reactor has run that hook (see [`runtime_handle`]): whichever
-    /// runs first builds it, the other is a no-op.
+    /// Both the reactor's `callWhenRunning(start)` hook and [`runtime_handle`]
+    /// call this, in either order. Whichever runs first builds the runtime;
+    /// for the other it is a no-op.
     fn ensure_started(&mut self) -> PyResult<()> {
         if self.runtime.is_some() {
             return Ok(());
@@ -92,11 +91,10 @@ pub fn runtime<'a>(reactor: &Bound<'a, PyAny>) -> PyResult<PyRef<'a, PyTokioRunt
 /// Get a clonable handle to the shared runtime, starting it on demand.
 ///
 /// Unlike [`runtime`], this does not require the reactor to have already run
-/// its `callWhenRunning(start)` hook: it starts the runtime if necessary. That
-/// lets callers that need the runtime before the reactor is up — the database
-/// backend's schema setup, `synapse_port_db`, and trial tests — still get a
-/// working handle. Once the reactor does run, its `start` hook finds the
-/// runtime already built and is a no-op, so there is still only one runtime.
+/// its `callWhenRunning(start)` hook; the runtime is started here if needed,
+/// so a caller that needs it before the reactor is up still gets a working
+/// handle. Once the reactor does run, its `start` hook finds the runtime
+/// already built and is a no-op, so there is still only one runtime.
 pub fn runtime_handle(reactor: &Bound<'_, PyAny>) -> PyResult<Handle> {
     let runtime = get_or_install(reactor)?;
     let mut runtime = runtime.borrow_mut();

--- a/synapse/synapse_rust/database/__init__.pyi
+++ b/synapse/synapse_rust/database/__init__.pyi
@@ -1,0 +1,11 @@
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 Element Creations Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.

--- a/synapse/synapse_rust/database/postgres.pyi
+++ b/synapse/synapse_rust/database/postgres.pyi
@@ -1,0 +1,13 @@
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 Element Creations Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+# Empty stub file for `synapse::database::postgres` module


### PR DESCRIPTION
  Lays the two foundations the Rust DBAPI2 backend needs before any connection code: a Python↔Postgres value-mapping layer, and the helpers that drive async work from sync Python.

  Value mapping:
  - `PgValue` — enum that implements `tokio_postgres::types::ToSql`, encoding into Postgres' binary wire format per the prepared-statement column type (so a single Python `int` becomes INT2/INT4/INT8 with range checks).
  - `PythonPgFromSql` — the decode counterpart, turning wire bytes back into Python objects (SQL NULL → `None`).
  - Covers int / float / bool / str / bytes / None; lists etc are left to a follow-up.

  Blocking helpers:

  - `block_on` / `block_on_result` / `block_on_next` drive `tokio-postgres` futures to completion from sync, GIL-holding Python methods, releasing the GIL for the wait.

  Both modules are `pub` for now so not-yet-consumed items don't trip clippy's `dead_code` lint; later PRs in the stack tighten visibility. Everything here is unit-tested with no live Postgres server.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>