### PR TITLE
Rust Postgres backend: error hierarchy, executescript, description, executemany

### DIFF
--- a/changelog.d/20000.misc
+++ b/changelog.d/20000.misc
@@ -1,0 +1,1 @@
+Add foundations for a Rust backed database pool.

--- a/rust/src/database/postgres/connection.rs
+++ b/rust/src/database/postgres/connection.rs
@@ -57,7 +57,7 @@ use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
 use pyo3::{
     exceptions::PyRuntimeError,
     prelude::*,
-    types::{PyInt, PyTuple},
+    types::{PyInt, PyList, PyTuple},
 };
 use tokio_postgres::Client;
 
@@ -451,6 +451,45 @@ impl Cursor {
     /// where it isn't (yet) known it follows PEP-249 and returns `-1`.
     fn rowcount<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyInt>> {
         self.lock_state()?.rowcount(py)
+    }
+
+    /// Return the PEP-249 `description` for the current result set, or `None`.
+    ///
+    /// This is a list with one entry per column, each a 7-tuple
+    /// `(name, type_code, display_size, internal_size, precision, scale,
+    /// null_ok)` as PEP-249 specifies. Only the column name is populated; the
+    /// remaining six fields are always `None` — that is all Synapse needs, as
+    /// it only ever reads `column[0]`.
+    ///
+    /// It is `None` when there is no row-returning result set to describe:
+    /// before any query, after an error reset the cursor, or for a statement
+    /// that returns no rows (e.g. a bare `INSERT`), matching psycopg2.
+    fn description<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyList>>> {
+        let state = self.lock_state()?;
+        let Some(columns) = state.description() else {
+            return Ok(None);
+        };
+
+        let rows = columns
+            .iter()
+            .map(|name| {
+                // PEP-249's 7-tuple; only `name` carries a meaningful value.
+                PyTuple::new(
+                    py,
+                    [
+                        name.into_pyobject(py)?.into_any(),
+                        py.None().into_bound(py),
+                        py.None().into_bound(py),
+                        py.None().into_bound(py),
+                        py.None().into_bound(py),
+                        py.None().into_bound(py),
+                        py.None().into_bound(py),
+                    ],
+                )
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+
+        Ok(Some(PyList::new(py, rows)?))
     }
 
     /// Close the cursor, discarding any in-flight result set.

--- a/rust/src/database/postgres/connection.rs
+++ b/rust/src/database/postgres/connection.rs
@@ -394,6 +394,32 @@ impl Cursor {
         Ok(())
     }
 
+    /// Execute a multi-statement SQL script (statements separated by `;`).
+    ///
+    /// Unlike [`Cursor::execute`], which `prepare`s a single statement, this
+    /// runs the whole script on the simple-query protocol (`batch_execute`), so
+    /// it may contain many `;`-separated statements — as Synapse's schema files
+    /// do. It takes no parameters and produces no fetchable rows.
+    ///
+    /// This is a thin primitive: the script runs inside the connection's current
+    /// transaction, opening one lazily like `execute` and leaving it open for
+    /// the caller to commit. The higher-level engine `executescript` — which
+    /// also substitutes the auto-increment placeholder — is layered on top.
+    /// Note it does *not* commit any prior transaction first: unlike the
+    /// psycopg2 engine (which still prefixes `COMMIT; BEGIN TRANSACTION;`,
+    /// committing script-by-script), the Rust engine deliberately keeps a whole
+    /// sequence of schema/delta scripts in one transaction so it is applied
+    /// either completely or not at all — see
+    /// `BaseDatabaseEngine.executescript`'s docstring for the contract.
+    fn executescript(&self, py: Python<'_>, script: &str) -> PyResult<()> {
+        // A script yields no fetchable rows, so drop any previous result set.
+        self.lock_state()?.new_query();
+
+        self.connection.with_client(py, |client| {
+            client.batch_execute(script).block_on_result(py)
+        })
+    }
+
     /// Return the next row of the current result set, or `None` if exhausted.
     fn fetch_one<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyTuple>>> {
         self.lock_state()?.fetch_one(py)

--- a/rust/src/database/postgres/connection.rs
+++ b/rust/src/database/postgres/connection.rs
@@ -54,6 +54,7 @@
 
 use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
 
+use futures::future::try_join_all;
 use pyo3::{
     exceptions::PyRuntimeError,
     prelude::*,
@@ -390,6 +391,65 @@ impl Cursor {
         if !returns_rows {
             state.finish_no_rows(py)?;
         }
+
+        Ok(())
+    }
+
+    /// Execute `query` once for each parameter set in `params_seq`.
+    ///
+    /// This is DBAPI2's `executemany`, used by Synapse for batched writes. The
+    /// statement is `prepare`d once and then run for each parameter set; it
+    /// produces no fetchable rows. Like a single `execute`, the whole batch runs
+    /// inside the connection's (lazily opened) transaction, so a failure
+    /// part-way through aborts it and leaves the caller to roll back.
+    ///
+    /// The per-parameter-set executions are *pipelined*: their futures are
+    /// driven concurrently, so `tokio_postgres` streams the whole batch onto the
+    /// connection without waiting for a round-trip between each — one round-trip
+    /// for the batch rather than one per statement. Results are matched to
+    /// requests in order, and on the first error the rest are abandoned (the
+    /// transaction is aborted anyway).
+    ///
+    /// After it returns `rowcount` reports the total number of rows affected
+    /// across all executions (as psycopg2 does), `description` is `None`, and
+    /// any `fetch_*` is an error. An empty `params_seq` runs nothing at all —
+    /// no statement is sent and no transaction is opened — and leaves
+    /// `rowcount` at the PEP-249 "unknown" sentinel (`-1`).
+    #[pyo3(signature = (query, params_seq))]
+    fn executemany(
+        &self,
+        py: Python<'_>,
+        query: &str,
+        params_seq: Vec<Vec<PgValue>>,
+    ) -> PyResult<()> {
+        // Drop any previous result set before starting the new statement.
+        self.lock_state()?.new_query();
+
+        // An empty batch is a no-op (matching psycopg2): don't send anything or
+        // open a transaction, and leave `rowcount` reporting "unknown".
+        if params_seq.is_empty() {
+            self.lock_state()?.on_command_complete(None);
+            return Ok(());
+        }
+
+        let total = self.connection.with_client(py, |client| {
+            // Prepare once, then build a future per parameter set. Driving them
+            // concurrently is what makes `tokio_postgres` pipeline them onto the
+            // connection; blocking on the joined future runs the whole batch.
+            let statement = client.prepare(query).block_on_result(py)?;
+
+            let counts = try_join_all(
+                params_seq
+                    .into_iter()
+                    .map(|params| client.execute_raw(&statement, params)),
+            )
+            .block_on_result(py)?;
+
+            Ok(counts.into_iter().sum::<u64>())
+        })?;
+
+        // Retain the summed affected-row count for `rowcount`, as psycopg2 does.
+        self.lock_state()?.on_command_complete(Some(total));
 
         Ok(())
     }

--- a/rust/src/database/postgres/cursor_state.rs
+++ b/rust/src/database/postgres/cursor_state.rs
@@ -37,6 +37,7 @@ use pyo3::{
 use tokio_postgres::RowStream;
 
 use crate::database::postgres::{
+    errors::pg_err_to_py,
     helpers::{BlockingPostgres, BlockingPostgresStream as _},
     value::pg_row_to_py,
 };
@@ -83,7 +84,11 @@ impl CursorRowStream for RowStream {
     }
 
     fn stream_err(err: &Self::Error) -> PyErr {
-        PyRuntimeError::new_err(format!("error fetching row from postgres: {err}"))
+        // Route through the shared mapping so a server error surfacing while
+        // the result stream is drained (e.g. a constraint violation on an
+        // `INSERT`) becomes the right DBAPI2 exception with its `pgcode`, just
+        // as it would if it surfaced at `execute` time.
+        pg_err_to_py(err)
     }
 }
 

--- a/rust/src/database/postgres/cursor_state.rs
+++ b/rust/src/database/postgres/cursor_state.rs
@@ -107,9 +107,7 @@ pub enum CursorQueryState<S = RowStream> {
         /// Live row stream for the current query.
         stream: FusedStream<S>,
         /// Column names for the result set (empty for a DML statement).
-        ///
-        /// TODO: currently write-only; kept to back a future PEP-249
-        /// `Cursor.description` accessor.
+        /// Exposed to Python via [`CursorQueryState::description`].
         description: Vec<String>,
     },
     /// The result set has been fully consumed and exhaustion reported — a fetch
@@ -117,13 +115,9 @@ pub enum CursorQueryState<S = RowStream> {
     /// `fetch_*` is a programming error; `rowcount` still returns the count.
     Closed {
         /// Column names for the result set, carried over from `Active` so they
-        /// survive once the rows are gone.
-        ///
-        /// TODO: currently write-only; like `Active::description` it is kept to
-        /// back a future PEP-249 `Cursor.description` accessor. `#[allow]`d
-        /// until that reader lands rather than dropped, so the column metadata
-        /// isn't silently lost at the `Active` -> `Closed` transition.
-        #[allow(dead_code)]
+        /// survive once the rows are gone (PEP-249 keeps `description`
+        /// available after the rows have been fetched). Exposed to Python via
+        /// [`CursorQueryState::description`].
         description: Vec<String>,
         /// PEP-249 `rowcount` from the command tag, if it was captured.
         rowcount: Option<u64>,
@@ -341,6 +335,34 @@ impl<S: CursorRowStream> CursorQueryState<S> {
             // count. The stream is always drained by the block above before we
             // get here, so "not yet drained" isn't a case. PEP-249 says -1.
             _ => Ok(PyInt::new(py, -1)),
+        }
+    }
+
+    /// The column names of the current result set, or `None` when there is no
+    /// row-returning result set to describe.
+    ///
+    /// This backs the PEP-249 `Cursor.description`. It is `None` in the `Idle`
+    /// state (no query has run yet, or an error reset the cursor) and also for
+    /// a statement that returns no columns — e.g. an `INSERT`/`UPDATE`/`DELETE`
+    /// without `RETURNING` — matching psycopg2, which reports `description` as
+    /// `None` for such statements. For a row-returning statement the names stay
+    /// available after the rows have been fetched (the `Closed` state), as
+    /// PEP-249 requires.
+    ///
+    /// Only the column *names* are tracked (see `on_query_start`); it is the
+    /// caller's job to shape them into PEP-249's 7-tuples.
+    pub fn description(&self) -> Option<&[String]> {
+        let columns = match self {
+            Self::Active { description, .. } | Self::Closed { description, .. } => description,
+            Self::Idle => return None,
+        };
+
+        // A statement that returns no columns (DML) has an empty column list;
+        // PEP-249 / psycopg2 report `description` as `None` in that case.
+        if columns.is_empty() {
+            None
+        } else {
+            Some(columns)
         }
     }
 
@@ -806,6 +828,65 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("exhausted"));
+        });
+    }
+
+    #[test]
+    fn description_is_none_before_any_query() {
+        let state = CursorQueryState::<FakeStream>::new();
+        assert!(state.description().is_none());
+    }
+
+    #[test]
+    fn description_reports_columns_while_active_and_after_close() {
+        Python::initialize();
+        Python::attach(|py| {
+            let _guard = enter_runtime();
+            // `active_with` builds an `Active` state whose columns are `["col"]`.
+            let mut state = active_with(vec![vec![1]], Some(0));
+            assert_eq!(state.description(), Some(["col".to_string()].as_slice()));
+
+            // Draining the rows moves the cursor to `Closed`, but the column
+            // names survive so `description` is still available (PEP-249).
+            let _ = state.fetch_all(py).unwrap();
+            assert!(matches!(state, CursorQueryState::Closed { .. }));
+            assert_eq!(state.description(), Some(["col".to_string()].as_slice()));
+        });
+    }
+
+    #[test]
+    fn description_is_none_for_a_column_less_result() {
+        // A DML statement yields no columns; `description` should be `None`
+        // even while the (empty) result set is `Active`.
+        let mut state = CursorQueryState::<FakeStream>::new();
+        state.on_query_start(
+            FakeStream {
+                items: VecDeque::new(),
+                rows_affected: Some(3),
+            },
+            vec![],
+        );
+        assert!(state.description().is_none());
+    }
+
+    #[test]
+    fn description_is_none_after_an_error_resets_to_idle() {
+        Python::initialize();
+        Python::attach(|py| {
+            let _guard = enter_runtime();
+            let mut state = CursorQueryState::<FakeStream>::new();
+            state.on_query_start(
+                FakeStream {
+                    items: VecDeque::from(vec![Err(FakeError("boom"))]),
+                    rows_affected: None,
+                },
+                vec!["col".to_string()],
+            );
+
+            // The error resets the cursor to `Idle`, dropping the columns.
+            let _ = state.fetch_one(py).unwrap_err();
+            assert!(matches!(state, CursorQueryState::Idle));
+            assert!(state.description().is_none());
         });
     }
 

--- a/rust/src/database/postgres/cursor_state.rs
+++ b/rust/src/database/postgres/cursor_state.rs
@@ -366,6 +366,19 @@ impl<S: CursorRowStream> CursorQueryState<S> {
         }
     }
 
+    /// Record a completed command that produced no fetchable rows, retaining
+    /// its affected-row count for `rowcount`.
+    ///
+    /// Used by `executemany`, which runs a statement repeatedly for its side
+    /// effects: there is no result set to fetch (`description` is `None` and
+    /// any `fetch_*` errors as exhausted), but the (summed) rowcount is kept.
+    pub fn on_command_complete(&mut self, rowcount: Option<u64>) {
+        *self = Self::Closed {
+            description: Vec::new(),
+            rowcount,
+        };
+    }
+
     /// The error to raise when a `fetch_*` method finds no rows available,
     /// distinguishing "no query was ever run" from "the result set has already
     /// been exhausted". Only meaningful for the non-`Active` states.
@@ -886,6 +899,41 @@ mod tests {
             // The error resets the cursor to `Idle`, dropping the columns.
             let _ = state.fetch_one(py).unwrap_err();
             assert!(matches!(state, CursorQueryState::Idle));
+            assert!(state.description().is_none());
+        });
+    }
+
+    #[test]
+    fn on_command_complete_retains_rowcount_without_a_result_set() {
+        Python::initialize();
+        Python::attach(|py| {
+            let _guard = enter_runtime();
+            let mut state = CursorQueryState::<FakeStream>::new();
+            // Simulate a completed `executemany` that affected 5 rows.
+            state.on_command_complete(Some(5));
+
+            assert!(matches!(state, CursorQueryState::Closed { .. }));
+            // The rowcount is retained, but there is nothing to describe or
+            // fetch.
+            assert_eq!(state.rowcount(py).unwrap().extract::<i64>().unwrap(), 5);
+            assert!(state.description().is_none());
+            assert!(state
+                .fetch_one(py)
+                .unwrap_err()
+                .to_string()
+                .contains("exhausted"));
+        });
+    }
+
+    #[test]
+    fn on_command_complete_with_no_count_reports_minus_one() {
+        Python::initialize();
+        Python::attach(|py| {
+            let _guard = enter_runtime();
+            let mut state = CursorQueryState::<FakeStream>::new();
+            // An empty `executemany` batch: nothing ran, so no count.
+            state.on_command_complete(None);
+            assert_eq!(state.rowcount(py).unwrap().extract::<i64>().unwrap(), -1);
             assert!(state.description().is_none());
         });
     }

--- a/rust/src/database/postgres/errors.rs
+++ b/rust/src/database/postgres/errors.rs
@@ -1,0 +1,281 @@
+//! The DBAPI2 exception hierarchy for the Postgres backend, and the mapping
+//! from a [`tokio_postgres`] error onto it.
+//!
+//! Synapse's transaction driver (`synapse.storage.database.new_transaction`)
+//! and the Postgres engine branch on the *type* of the exception a database
+//! call raises, and on its `pgcode` (the 5-character SQLSTATE). To be a drop-in
+//! for psycopg2 we therefore need to raise exceptions of the right class and
+//! carry a `pgcode`.
+//!
+//! Rather than reproduce psycopg2's full PEP-249 hierarchy (ten classes) and
+//! its complete SQLSTATE→class table, we expose only the distinctions Synapse
+//! actually acts on:
+//!
+//! * [`Error`] — the base every database error derives from. Synapse catches it
+//!   when a rollback itself fails.
+//! * [`DatabaseError`] — a server-side error. Synapse catches this and calls
+//!   `is_deadlock`, which reads `pgcode` to spot serialization/deadlock failures
+//!   (`40001`/`40P01`) and retry them.
+//! * [`OperationalError`] — a transient/connection-level failure ("the database
+//!   disappeared mid-transaction"). Synapse catches this and retries.
+//! * [`IntegrityError`] — a constraint violation. Synapse catches this to retry
+//!   upserts and to handle insert races.
+//! * [`ProgrammingError`] — a SQL-level mistake (syntax error, duplicate table
+//!   or index, …; SQLSTATE class `42`). Caught by the search store's GIN-index
+//!   migration to ignore "already exists".
+//!
+//! Every other Postgres error (data errors, …) surfaces as a plain
+//! [`DatabaseError`]. Nothing in Synapse catches the remaining psycopg2 classes
+//! (`DataError`, `InternalError`, …), so collapsing them is invisible at
+//! runtime. If full [`DBAPI2Module`] conformance is needed later (when a Rust
+//! engine is wired up) the remaining PEP-249 names can be added as aliases of
+//! [`DatabaseError`].
+//!
+//! [`DBAPI2Module`]: (see `synapse/storage/types.py`)
+
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+use pyo3::{create_exception, types::PyModule};
+
+create_exception!(
+    postgres,
+    Error,
+    PyException,
+    "Base class for every error raised by the Rust Postgres backend (PEP-249 `Error`)."
+);
+create_exception!(
+    postgres,
+    DatabaseError,
+    Error,
+    "A server-side database error. Carries the SQLSTATE as `pgcode`."
+);
+create_exception!(
+    postgres,
+    OperationalError,
+    DatabaseError,
+    "A transient/connection-level failure that is worth retrying."
+);
+create_exception!(
+    postgres,
+    IntegrityError,
+    DatabaseError,
+    "A constraint violation (e.g. a unique or foreign-key violation)."
+);
+create_exception!(
+    postgres,
+    ProgrammingError,
+    DatabaseError,
+    "A SQL-level mistake (syntax error, duplicate table/index, undefined column, ...)."
+);
+
+/// Build the Python exception for a Postgres failure, tagging it with `pgcode`.
+///
+/// `code` is the SQLSTATE (`None` for an error that never got a server
+/// response). When present, the class is chosen from the SQLSTATE *class* (its
+/// first two characters):
+///
+/// * `23` (integrity constraint violation) → [`IntegrityError`]
+/// * `08`/`53`/`57`/`58` (connection, resource, operator-intervention,
+///   system errors) → [`OperationalError`]
+/// * `42` (syntax error or access rule violation, e.g. `42P07` duplicate
+///   table/index) → [`ProgrammingError`], matching psycopg2's mapping
+/// * everything else → [`DatabaseError`]
+///
+/// Note deadlock/serialization failures (`40001`/`40P01`) deliberately fall
+/// into the [`DatabaseError`] bucket, not [`OperationalError`]: Synapse retries
+/// them via `is_deadlock`, which only needs a `DatabaseError` with the right
+/// `pgcode`.
+///
+/// A codeless error is one that never reached, or never heard back from, the
+/// server. We can't inspect its kind, but `closed` (from
+/// [`tokio_postgres::Error::is_closed`]) tells us whether it was a lost
+/// connection: if so it's [`OperationalError`] and worth retrying; otherwise
+/// it's a client-side problem (a bad parameter, a failed connect) that
+/// shouldn't be retried, so it becomes a plain [`DatabaseError`].
+fn new_err_for(py: Python<'_>, code: Option<&str>, closed: bool, msg: &str) -> PyErr {
+    let err = match code.map(sqlstate_class) {
+        Some("23") => IntegrityError::new_err(msg.to_string()),
+        Some("08" | "53" | "57" | "58") => OperationalError::new_err(msg.to_string()),
+        Some("42") => ProgrammingError::new_err(msg.to_string()),
+        // A server error we don't single out, e.g. a deadlock (`40*`) or a
+        // data error (`22*`), …
+        Some(_) => DatabaseError::new_err(msg.to_string()),
+        // No SQLSTATE: a lost connection is operational (retry); any other
+        // codeless error is client-side and propagates as a `DatabaseError`.
+        None if closed => OperationalError::new_err(msg.to_string()),
+        None => DatabaseError::new_err(msg.to_string()),
+    };
+
+    // Attach `pgcode` (the SQLSTATE string, or Python `None`) so engine code
+    // such as `is_deadlock` can read `error.pgcode` exactly as it does for
+    // psycopg2. Setting an attribute on a fresh exception instance does not
+    // fail in practice, so a failure here is not worth propagating.
+    let _ = err.value(py).setattr("pgcode", code);
+
+    err
+}
+
+/// The SQLSTATE *class*: the first two characters of a 5-character code.
+fn sqlstate_class(code: &str) -> &str {
+    &code[..2.min(code.len())]
+}
+
+/// Map a [`tokio_postgres`] error into the appropriate Python exception.
+///
+/// Takes the error by reference so it can be called both from the `block_on`
+/// helpers (which own the error) and from the cursor's row-stream draining
+/// (which only has a borrow).
+///
+/// For a server-reported error the message includes the SQLSTATE, the server's
+/// message and, when present, its DETAIL and HINT — `tokio_postgres`'s own
+/// `Display` is just "db error", which buries the reason (psycopg2 surfaces
+/// the full server message).
+pub(crate) fn pg_err_to_py(e: &tokio_postgres::Error) -> PyErr {
+    let code = e.code().map(|c| c.code());
+    let msg = match e.as_db_error() {
+        Some(db_err) => {
+            let mut msg = format!(
+                "postgres error {}: {}",
+                db_err.code().code(),
+                db_err.message()
+            );
+            if let Some(detail) = db_err.detail() {
+                msg.push_str(&format!(" DETAIL: {detail}"));
+            }
+            if let Some(hint) = db_err.hint() {
+                msg.push_str(&format!(" HINT: {hint}"));
+            }
+            msg
+        }
+        None => format!("postgres error: {e}"),
+    };
+    Python::attach(|py| new_err_for(py, code, e.is_closed(), &msg))
+}
+
+/// Add the exception classes to the `postgres` submodule so the module conforms
+/// to (the load-bearing part of) Synapse's `DBAPI2Module` protocol.
+pub(crate) fn register_exceptions(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("Error", py.get_type::<Error>())?;
+    m.add("DatabaseError", py.get_type::<DatabaseError>())?;
+    m.add("OperationalError", py.get_type::<OperationalError>())?;
+    m.add("IntegrityError", py.get_type::<IntegrityError>())?;
+    m.add("ProgrammingError", py.get_type::<ProgrammingError>())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    //! These tests don't touch Postgres: `new_err_for` takes the SQLSTATE as a
+    //! plain string, so the whole classification and `pgcode` tagging can be
+    //! exercised without a live database (a `tokio_postgres::Error` can't be
+    //! constructed by hand anyway).
+
+    use pyo3::PyTypeInfo;
+
+    use super::*;
+
+    /// Assert `code` maps to exception type `T`, is a `DatabaseError` and an
+    /// `Error`, and carries the expected `pgcode`.
+    fn assert_maps<T: PyTypeInfo>(code: &str) {
+        Python::attach(|py| {
+            let err = new_err_for(py, Some(code), false, "boom");
+            let value = err.value(py);
+            assert!(
+                value.is_instance_of::<T>(),
+                "{code} did not map to the expected type"
+            );
+            assert!(value.is_instance_of::<DatabaseError>());
+            assert!(value.is_instance_of::<Error>());
+
+            let pgcode: String = value.getattr("pgcode").unwrap().extract().unwrap();
+            assert_eq!(pgcode, code);
+        });
+    }
+
+    #[test]
+    fn integrity_class_maps_to_integrity_error() {
+        Python::initialize();
+        // Unique violation, foreign-key violation, not-null violation.
+        assert_maps::<IntegrityError>("23505");
+        assert_maps::<IntegrityError>("23503");
+    }
+
+    #[test]
+    fn connection_and_resource_classes_map_to_operational_error() {
+        Python::initialize();
+        assert_maps::<OperationalError>("08006"); // connection failure
+        assert_maps::<OperationalError>("53100"); // disk full
+        assert_maps::<OperationalError>("57014"); // query canceled
+        assert_maps::<OperationalError>("58000"); // system error
+    }
+
+    #[test]
+    fn programming_class_maps_to_programming_error() {
+        Python::initialize();
+        // Syntax error, duplicate table/index (what the GIN-index migration
+        // catches to ignore "already exists").
+        assert_maps::<ProgrammingError>("42601");
+        assert_maps::<ProgrammingError>("42P07");
+    }
+
+    #[test]
+    fn other_server_errors_map_to_plain_database_error() {
+        Python::initialize();
+        // A data error is a `DatabaseError` but none of the specific classes.
+        Python::attach(|py| {
+            let value = new_err_for(py, Some("22012"), false, "boom");
+            let value = value.value(py);
+            assert!(value.is_instance_of::<DatabaseError>());
+            assert!(!value.is_instance_of::<OperationalError>());
+            assert!(!value.is_instance_of::<IntegrityError>());
+            assert!(!value.is_instance_of::<ProgrammingError>());
+        });
+    }
+
+    #[test]
+    fn deadlock_and_serialization_are_retryable_database_errors() {
+        Python::initialize();
+        // The behaviour Synapse's `is_deadlock` relies on: a `DatabaseError`
+        // (so the `isinstance` check passes) carrying the right `pgcode`.
+        for code in ["40001", "40P01"] {
+            Python::attach(|py| {
+                let err = new_err_for(py, Some(code), false, "boom");
+                let value = err.value(py);
+                assert!(value.is_instance_of::<DatabaseError>());
+                let pgcode: String = value.getattr("pgcode").unwrap().extract().unwrap();
+                assert_eq!(pgcode, code);
+            });
+        }
+    }
+
+    #[test]
+    fn closed_connection_error_is_operational() {
+        Python::initialize();
+        Python::attach(|py| {
+            // A lost connection (codeless, `is_closed()`) is operational, so
+            // Synapse retries it.
+            let err = new_err_for(py, None, true, "connection closed");
+            let value = err.value(py);
+            assert!(value.is_instance_of::<OperationalError>());
+            assert!(value.is_instance_of::<DatabaseError>());
+            // `pgcode` is present but `None`, so `error.pgcode in (...)` is a
+            // safe membership test rather than an `AttributeError`.
+            assert!(value.getattr("pgcode").unwrap().is_none());
+        });
+    }
+
+    #[test]
+    fn other_codeless_error_is_a_plain_database_error() {
+        Python::initialize();
+        Python::attach(|py| {
+            // A client-side error that isn't a lost connection (a bad
+            // parameter, a failed connect) is *not* retryable, so it is a plain
+            // `DatabaseError`, not `OperationalError`.
+            let err = new_err_for(py, None, false, "error serializing parameter");
+            let value = err.value(py);
+            assert!(value.is_instance_of::<DatabaseError>());
+            assert!(!value.is_instance_of::<OperationalError>());
+            assert!(value.getattr("pgcode").unwrap().is_none());
+        });
+    }
+}

--- a/rust/src/database/postgres/helpers.rs
+++ b/rust/src/database/postgres/helpers.rs
@@ -34,7 +34,7 @@ use futures::{stream::Fuse, FutureExt, StreamExt};
 use pyo3::{marker::Ungil, PyResult, Python};
 use tokio::runtime::Handle;
 
-use crate::database::postgres::pg_err_to_py;
+use crate::database::postgres::errors::pg_err_to_py;
 
 /// Block on a future on the shared runtime, releasing the GIL while we wait.
 pub trait BlockingPostgres
@@ -68,7 +68,7 @@ where
 {
     /// Block on `self` and convert a Postgres error into a `PyErr`.
     fn block_on_result(self, py: Python<'_>) -> PyResult<T> {
-        self.block_on(py).map_err(pg_err_to_py)
+        self.block_on(py).map_err(|e| pg_err_to_py(&e))
     }
 }
 

--- a/rust/src/database/postgres/mod.rs
+++ b/rust/src/database/postgres/mod.rs
@@ -19,18 +19,21 @@ use crate::tokio_runtime::runtime_handle;
 
 mod connection;
 mod cursor_state;
+mod errors;
 mod helpers;
 mod libpq;
 mod value;
 
-/// Register the `postgres` submodule (the `Connection` / `Cursor` classes and
-/// the `connect` factory) under the parent `database` module.
+/// Register the `postgres` submodule (the `Connection` / `Cursor` classes, the
+/// DBAPI2 exception hierarchy and the `connect` factory) under the parent
+/// `database` module.
 pub fn register_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     let child = PyModule::new(py, "postgres")?;
 
     child.add_class::<connection::Connection>()?;
     child.add_class::<connection::Cursor>()?;
     child.add_function(wrap_pyfunction!(connect, &child)?)?;
+    errors::register_exceptions(py, &child)?;
 
     m.add_submodule(&child)?;
 
@@ -41,11 +44,6 @@ pub fn register_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> 
         .set_item("synapse.synapse_rust.database.postgres", child)?;
 
     Ok(())
-}
-
-/// Map a [`tokio_postgres`] error into a Python `RuntimeError`.
-fn pg_err_to_py(e: tokio_postgres::Error) -> PyErr {
-    PyRuntimeError::new_err(format!("postgres error: {e}"))
 }
 
 /// Open a new Postgres connection from a libpq-style DSN.

--- a/synapse/storage/databases/main/search.py
+++ b/synapse/storage/databases/main/search.py
@@ -286,9 +286,9 @@ class SearchBackgroundUpdateStore(SearchWorkerStore):
                 # if we skipped the conversion to GIST, we may already/still
                 # have an event_search_fts_idx; unfortunately postgres 9.4
                 # doesn't support CREATE INDEX IF EXISTS so we just catch the
-                # exception and ignore it.
-                import psycopg2
-
+                # exception and ignore it. Catch the error class via the
+                # engine's module so this works on both the psycopg2 and the
+                # native Rust drivers.
                 try:
                     c.execute(
                         """
@@ -296,7 +296,7 @@ class SearchBackgroundUpdateStore(SearchWorkerStore):
                         ON event_search USING GIN (vector)
                         """
                     )
-                except psycopg2.ProgrammingError as e:
+                except self.database_engine.module.ProgrammingError as e:
                     logger.warning(
                         "Ignoring error %r when trying to switch from GIST to GIN", e
                     )

--- a/tests/synapse_rust/test_database_postgres.py
+++ b/tests/synapse_rust/test_database_postgres.py
@@ -829,6 +829,71 @@ class PostgresConnectionDrivenTestCase(unittest.TestCase):
             self.conn.set_autocommit(True)
         self.conn.rollback()
 
+    # -- executescript (multi-statement) ------------------------------------
+
+    def test_executescript_runs_all_statements(self) -> None:
+        """A `;`-separated script runs every statement (unlike `execute`, which
+        prepares a single one)."""
+        table = "rust_pg_script"
+        try:
+            cursor = self.conn.cursor()
+            cursor.executescript(
+                f"CREATE TABLE {table} (id int); "
+                f"INSERT INTO {table} VALUES (1); "
+                f"INSERT INTO {table} VALUES (2), (3);"
+            )
+            self.conn.commit()
+
+            read = self.conn.cursor()
+            read.execute(f"SELECT id FROM {table} ORDER BY id")
+            self.assertEqual(read.fetch_all(), [(1,), (2,), (3,)])
+            self.conn.commit()
+        finally:
+            self._exec_commit(f"DROP TABLE IF EXISTS {table}")
+
+    def test_executescript_leaves_transaction_open_for_caller(self) -> None:
+        """The script runs in the connection's transaction, left open — so a
+        following `rollback()` undoes it (it was not autocommitted)."""
+        table = "rust_pg_script_open"
+        try:
+            self.conn.cursor().executescript(f"CREATE TABLE {table} (id int);")
+            self.conn.rollback()
+            self.assertFalse(self._table_exists(table))
+            self.conn.commit()
+        finally:
+            self._exec_commit(f"DROP TABLE IF EXISTS {table}")
+
+    def test_executescript_error_surfaces_as_database_error(self) -> None:
+        """A failing statement mid-script surfaces via the exception hierarchy;
+        the aborted transaction rolls back cleanly."""
+        cursor = self.conn.cursor()
+        with self.assertRaises(postgres.DatabaseError):
+            cursor.executescript("CREATE TABLE rust_pg_script_bad (id int); NOT SQL;")
+        self.conn.rollback()
+        # The CREATE was in the same aborted, rolled-back transaction, so it
+        # left nothing behind.
+        self.assertFalse(self._table_exists("rust_pg_script_bad"))
+        self.conn.commit()
+
+    def test_successive_scripts_share_one_transaction(self) -> None:
+        """Successive `executescript` calls accumulate in the same open
+        transaction -- there is no implicit commit between them (unlike
+        `sqlite3.executescript`) -- so a single rollback discards them all.
+        This is the atomicity `prepare_database` relies on."""
+        try:
+            cursor = self.conn.cursor()
+            cursor.executescript("CREATE TABLE rust_pg_script_a (id int);")
+            cursor.executescript("CREATE TABLE rust_pg_script_b (id int);")
+            # Nothing was committed between the two calls, so one rollback
+            # undoes both.
+            self.conn.rollback()
+            self.assertFalse(self._table_exists("rust_pg_script_a"))
+            self.assertFalse(self._table_exists("rust_pg_script_b"))
+            self.conn.commit()
+        finally:
+            self._exec_commit("DROP TABLE IF EXISTS rust_pg_script_a")
+            self._exec_commit("DROP TABLE IF EXISTS rust_pg_script_b")
+
 
 @unittest.skip_unless(
     bool(USE_POSTGRES_FOR_TESTS), "requires a Postgres server (set SYNAPSE_POSTGRES)"
@@ -844,7 +909,7 @@ class PostgresErrorMappingTestCase(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.conn = postgres.connect(_build_dsn())
+        self.conn = _connect(_build_dsn())
 
     def tearDown(self) -> None:
         del self.conn

--- a/tests/synapse_rust/test_database_postgres.py
+++ b/tests/synapse_rust/test_database_postgres.py
@@ -181,6 +181,107 @@ class PostgresConnectionTestCase(unittest.TestCase):
         self.assertEqual(run_interaction(self.conn, interaction), [1, 2, 3])
 
     # ------------------------------------------------------------------
+    # executemany()
+    # ------------------------------------------------------------------
+
+    def test_executemany_runs_once_per_param_set(self) -> None:
+        """executemany applies the statement for each parameter set."""
+
+        def interaction(cursor: Any) -> list[Any]:
+            cursor.execute("CREATE TEMP TABLE em (id int, name text)")
+            cursor.executemany(
+                "INSERT INTO em (id, name) VALUES ($1, $2)",
+                [[1, "a"], [2, "b"], [3, "c"]],
+            )
+            cursor.execute("SELECT id, name FROM em ORDER BY id")
+            return cursor.fetch_all()
+
+        self.assertEqual(
+            run_interaction(self.conn, interaction),
+            [(1, "a"), (2, "b"), (3, "c")],
+        )
+
+    def test_executemany_rowcount_is_total_affected(self) -> None:
+        """rowcount after executemany is the sum across all executions."""
+
+        def interaction(cursor: Any) -> int:
+            cursor.execute("CREATE TEMP TABLE em (id int)")
+            cursor.executemany("INSERT INTO em VALUES ($1)", [[1], [2], [3]])
+            return cursor.rowcount()
+
+        self.assertEqual(run_interaction(self.conn, interaction), 3)
+
+    def test_executemany_leaves_no_result_set(self) -> None:
+        """executemany produces nothing to describe."""
+
+        def describe(cursor: Any) -> Any:
+            cursor.execute("CREATE TEMP TABLE em (id int)")
+            cursor.executemany("INSERT INTO em VALUES ($1)", [[1], [2]])
+            return cursor.description()
+
+        self.assertIsNone(run_interaction(self.conn, describe))
+
+    def test_executemany_fetch_after_raises(self) -> None:
+        """There is no result set after executemany, so fetching is an error."""
+
+        def interaction(cursor: Any) -> Any:
+            cursor.execute("CREATE TEMP TABLE em (id int)")
+            cursor.executemany("INSERT INTO em VALUES ($1)", [[1], [2]])
+            cursor.fetch_one()
+
+        with self.assertRaises(RuntimeError):
+            run_interaction(self.conn, interaction)
+
+    def test_executemany_empty_is_noop(self) -> None:
+        """An empty parameter sequence runs nothing and affects no rows."""
+
+        def interaction(cursor: Any) -> int:
+            cursor.execute("CREATE TEMP TABLE em (id int)")
+            cursor.executemany("INSERT INTO em VALUES ($1)", [])
+            # Nothing ran, so rowcount is the "unknown" sentinel...
+            self.assertEqual(cursor.rowcount(), -1)
+            # ...and the table is untouched.
+            cursor.execute("SELECT count(*) FROM em")
+            row = cursor.fetch_one()
+            assert row is not None
+            return row[0]
+
+        self.assertEqual(run_interaction(self.conn, interaction), 0)
+
+    def test_executemany_rolls_back_on_error(self) -> None:
+        """A failure part-way through executemany aborts the transaction, so
+        no rows from the batch survive."""
+
+        table = "rust_pg_test_executemany_rollback"
+        try:
+
+            def interaction(cursor: Any) -> None:
+                cursor.execute(f"CREATE TABLE {table} (id int PRIMARY KEY)")
+                # The third set duplicates the first, violating the primary key.
+                cursor.executemany(
+                    f"INSERT INTO {table} VALUES ($1)",
+                    [[1], [2], [1]],
+                )
+
+            with self.assertRaises(postgres.IntegrityError):
+                run_interaction(self.conn, interaction)
+
+            # The CREATE TABLE and the whole batch were in one transaction that
+            # rolled back, so the table should not exist.
+            def table_exists(cursor: Any) -> Any:
+                cursor.execute("SELECT to_regclass($1)::text", [table])
+                row = cursor.fetch_one()
+                assert row is not None
+                return row[0]
+
+            self.assertIsNone(run_interaction(self.conn, table_exists))
+        finally:
+            run_interaction(
+                self.conn,
+                lambda cursor: cursor.execute(f"DROP TABLE IF EXISTS {table}"),
+            )
+
+    # ------------------------------------------------------------------
     # fetch_next_batch()
     # ------------------------------------------------------------------
 

--- a/tests/synapse_rust/test_database_postgres.py
+++ b/tests/synapse_rust/test_database_postgres.py
@@ -110,9 +110,9 @@ class PostgresConnectionTestCase(unittest.TestCase):
     # ------------------------------------------------------------------
 
     def test_connect_bad_dsn_raises(self) -> None:
-        # A syntactically valid but unconnectable DSN should raise rather than
-        # return a half-open connection.
-        with self.assertRaises(RuntimeError):
+        # A syntactically valid but unconnectable DSN should raise one of our
+        # DBAPI2 errors rather than return a half-open connection.
+        with self.assertRaises(postgres.Error):
             _connect("host=127.0.0.1 port=1 dbname=does_not_exist")
 
     # ------------------------------------------------------------------
@@ -468,8 +468,12 @@ class PostgresConnectionTestCase(unittest.TestCase):
             cursor.execute("CREATE TEMP TABLE oor (x int4)")
             cursor.execute("INSERT INTO oor VALUES ($1)", [10**12])
 
-        with self.assertRaises(RuntimeError):
+        # This is a client-side encoding error (no SQLSTATE), so it surfaces as
+        # a plain DatabaseError -- not an OperationalError, since retrying a
+        # deterministic bad value would be pointless.
+        with self.assertRaises(postgres.DatabaseError) as ctx:
             run_interaction(self.conn, interaction)
+        self.assertNotIsInstance(ctx.exception, postgres.OperationalError)
 
     # ------------------------------------------------------------------
     # rowcount()
@@ -583,10 +587,10 @@ class PostgresConnectionTestCase(unittest.TestCase):
 
         def bad_sql(cursor: Any) -> None:
             # A syntax error: the server rejects this during prepare, which
-            # surfaces as a RuntimeError and rolls the transaction back.
+            # surfaces as a DatabaseError and rolls the transaction back.
             cursor.execute("SELECT FROM WHERE not valid sql")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(postgres.DatabaseError):
             run_interaction(self.conn, bad_sql)
 
         # The transaction was rolled back and the connection handed back clean,
@@ -606,12 +610,15 @@ class PostgresConnectionTestCase(unittest.TestCase):
             cursor.execute("INSERT INTO uniq VALUES (1)")
             # Duplicate key. The error is reported by the server while the
             # statement's result stream is driven, so we drain it (via
-            # rowcount) to surface it as a RuntimeError.
+            # rowcount) to surface it -- as an IntegrityError, the same class
+            # (with the same 23505 pgcode) it would carry had it surfaced at
+            # execute time.
             cursor.execute("INSERT INTO uniq VALUES (1)")
             cursor.rowcount()
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(postgres.IntegrityError) as ctx:
             run_interaction(self.conn, violate)
+        self.assertEqual(ctx.exception.pgcode, "23505")
 
         # TEMP table lived only in the rolled-back transaction; the connection
         # itself is fine.
@@ -820,6 +827,71 @@ class PostgresConnectionDrivenTestCase(unittest.TestCase):
         cursor.execute("SELECT 1")  # opens an implicit transaction
         with self.assertRaises(RuntimeError):
             self.conn.set_autocommit(True)
+        self.conn.rollback()
+
+
+@unittest.skip_unless(
+    bool(USE_POSTGRES_FOR_TESTS), "requires a Postgres server (set SYNAPSE_POSTGRES)"
+)
+class PostgresErrorMappingTestCase(unittest.TestCase):
+    """The DBAPI2 exception hierarchy and the SQLSTATE→exception mapping.
+
+    Synapse's transaction driver branches on the *type* of the exception a
+    database call raises (``OperationalError`` → retry, ``IntegrityError`` →
+    retry upserts) and on its ``pgcode`` (``is_deadlock``). These tests check
+    the Rust backend raises the right class and carries a ``pgcode``, the way
+    psycopg2 does.
+    """
+
+    def setUp(self) -> None:
+        self.conn = postgres.connect(_build_dsn())
+
+    def tearDown(self) -> None:
+        del self.conn
+
+    def _exec_commit(self, sql: str) -> None:
+        """Run a single statement and commit it (its own transaction)."""
+        self.conn.cursor().execute(sql)
+        self.conn.commit()
+
+    # -- the hierarchy exposed on the module --------------------------------
+
+    def test_module_exposes_dbapi2_hierarchy(self) -> None:
+        """The exception attributes Synapse's engine code and DBAPI2Module
+        protocol rely on, with the expected subclass links."""
+        self.assertTrue(issubclass(postgres.DatabaseError, postgres.Error))
+        self.assertTrue(issubclass(postgres.OperationalError, postgres.DatabaseError))
+        self.assertTrue(issubclass(postgres.IntegrityError, postgres.DatabaseError))
+
+    # -- SQLSTATE → exception class -----------------------------------------
+
+    def test_unique_violation_is_integrity_error(self) -> None:
+        """A constraint violation raises ``IntegrityError`` with pgcode 23505."""
+        table = "rust_pg_err_integrity"
+        try:
+            self._exec_commit(f"CREATE TABLE {table} (id int PRIMARY KEY)")
+            self._exec_commit(f"INSERT INTO {table} VALUES (1)")
+
+            cursor = self.conn.cursor()
+            with self.assertRaises(postgres.IntegrityError) as ctx:
+                cursor.execute(f"INSERT INTO {table} VALUES (1)")
+                # The INSERT's error is reported while its result stream is
+                # driven, so drain it (via rowcount) to surface it.
+                cursor.rowcount()
+            self.assertEqual(ctx.exception.pgcode, "23505")
+            self.conn.rollback()
+        finally:
+            self._exec_commit(f"DROP TABLE IF EXISTS {table}")
+
+    def test_undefined_table_is_plain_database_error(self) -> None:
+        """An error we don't single out surfaces as a plain ``DatabaseError``
+        (not one of the specialised subclasses), still carrying its pgcode."""
+        cursor = self.conn.cursor()
+        with self.assertRaises(postgres.DatabaseError) as ctx:
+            cursor.execute("SELECT * FROM rust_pg_no_such_table")
+        self.assertNotIsInstance(ctx.exception, postgres.OperationalError)
+        self.assertNotIsInstance(ctx.exception, postgres.IntegrityError)
+        self.assertEqual(ctx.exception.pgcode, "42P01")  # undefined_table
         self.conn.rollback()
 
 

--- a/tests/synapse_rust/test_database_postgres.py
+++ b/tests/synapse_rust/test_database_postgres.py
@@ -499,6 +499,55 @@ class PostgresConnectionTestCase(unittest.TestCase):
         self.assertEqual(run_interaction(self.conn, interaction), [3, 2, 3])
 
     # ------------------------------------------------------------------
+    # description
+    # ------------------------------------------------------------------
+
+    def test_description_is_none_before_query(self) -> None:
+        """A cursor that has not run a query has no description."""
+
+        def interaction(cursor: Any) -> Any:
+            return cursor.description()
+
+        self.assertIsNone(run_interaction(self.conn, interaction))
+
+    def test_description_reports_column_names(self) -> None:
+        """A row-returning statement describes its columns; only the name is
+        populated, in a PEP-249 7-tuple."""
+
+        def interaction(cursor: Any) -> Any:
+            cursor.execute("SELECT 1 AS a, 'x'::text AS b")
+            return cursor.description()
+
+        description = run_interaction(self.conn, interaction)
+        self.assertEqual([col[0] for col in description], ["a", "b"])
+        # Each entry is a PEP-249 7-tuple with only the name populated.
+        for col in description:
+            self.assertEqual(len(col), 7)
+            self.assertTrue(all(field is None for field in col[1:]))
+
+    def test_description_available_after_fetch(self) -> None:
+        """The description survives after the rows have been fetched."""
+
+        def interaction(cursor: Any) -> Any:
+            cursor.execute("SELECT 1 AS a")
+            cursor.fetch_all()  # exhausts the result set
+            return cursor.description()
+
+        description = run_interaction(self.conn, interaction)
+        self.assertEqual([col[0] for col in description], ["a"])
+
+    def test_description_is_none_for_dml(self) -> None:
+        """A statement that returns no rows (a bare INSERT) has no
+        description, matching psycopg2."""
+
+        def interaction(cursor: Any) -> Any:
+            cursor.execute("CREATE TEMP TABLE d (id int)")
+            cursor.execute("INSERT INTO d VALUES (1)")
+            return cursor.description()
+
+        self.assertIsNone(run_interaction(self.conn, interaction))
+
+    # ------------------------------------------------------------------
     # Transaction handling (COMMIT on success, ROLLBACK on error)
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
  Completes the DBAPI2 surface Synapse relies on, layering four related pieces onto the working backend.

  **DBAPI2 exception hierarchy** — previously every `tokio_postgres` error became a bare `RuntimeError`, so Synapse's retry logic never fired (`new_transaction` retries `OperationalError` and pgcode-recognised deadlocks on  `DatabaseError`; `simple_upsert` retries `IntegrityError`). Adds just the distinctions Synapse acts on: `Error` → `DatabaseError` → {`OperationalError`, `IntegrityError`}, each tagged with `pgcode`. A classifier maps the SQLSTATE class  (`23`→Integrity; `08`/`53`/`57`/`58`→Operational; else DatabaseError, incl. `40*` deadlocks which retry via `pgcode`); codeless errors split on `is_closed()`. Errors surfacing while a result stream drains route through the same
  mapping.

  **`Cursor.executescript`** — `prepare_database.py` runs `;`-separated scripts, which `execute` can't serve (Postgres rejects multiple commands in a prepared statement). Runs the whole script on the simple-query protocol  (`batch_execute`) inside the connection's current transaction, left open for the caller to commit. Deliberately does *not* reproduce sqlite3's commit-first behaviour, which would undercut the atomicity `prepare_database` sets out to  get.

  **`Cursor.description`** — exposes the PEP-249 accessor on top of column names already carried (write-only) through the state machine: one 7-tuple per column (name populated, all Synapse reads), or `None` when there's no row-returning  result set — matching psycopg2.

  **`Cursor.executemany`** — prepares the statement once and runs it per parameter set inside the transaction (a mid-batch failure aborts the whole batch), pipelining the executions so tokio_postgres streams the batch in one round-trip.  `rowcount` then reports total rows affected across all executions; an empty parameter sequence is a no-op leaving `rowcount` at -1.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>