### PR TITLE
Gitignore `CLAUDE.local.md`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ book/
 
 # Don't include users' poetry configs
 /poetry.toml
+
+# Don't include local CLAUDE config
+/CLAUDE.local.md

--- a/changelog.d/20008.misc
+++ b/changelog.d/20008.misc
@@ -1,0 +1,1 @@
+Add a `.gitignore` entry for `CLAUDE.local.md`.


### PR DESCRIPTION
This is useful while we don't have a committed `CLAUDE.md` file.

These are used by Claude Code to understand the project.