### PR TITLE
Use weakref to Python `DatabasePool` to allow homeserver to cleanly shutdown

### DIFF
--- a/changelog.d/20009.bugfix
+++ b/changelog.d/20009.bugfix
@@ -1,0 +1,1 @@
+Fix `HomeServer.shutdown()` not being able to cleanly shutdown the homeserver (caused by Rust code referencing Python `DatabasePool`).

--- a/rust/src/handlers/mod.rs
+++ b/rust/src/handlers/mod.rs
@@ -41,15 +41,14 @@ impl RustHandlers {
 
         // The Twisted reactor, used both to drive our Tokio runtime and to
         // marshal database work back onto the reactor thread.
-        let reactor: Py<PyAny> = homeserver.call_method0("get_reactor")?.unbind();
+        let reactor = homeserver.call_method0("get_reactor")?.unbind();
 
         // hs.get_datastores().main.db_pool
-        let db_pool_py: Py<PyAny> = homeserver
+        let db_pool_py = homeserver
             .call_method0("get_datastores")?
             .getattr("main")?
-            .getattr("db_pool")?
-            .unbind();
-        let db_pool = PythonDatabasePoolWrapper::new(db_pool_py, reactor.clone_ref(py));
+            .getattr("db_pool")?;
+        let db_pool = PythonDatabasePoolWrapper::new(&db_pool_py, reactor.clone_ref(py))?;
 
         // Store is shared across all of the handlers so let's use an `Arc`
         let store = Arc::new(Store {

--- a/rust/src/storage/db/python_db_pool.rs
+++ b/rust/src/storage/db/python_db_pool.rs
@@ -34,7 +34,9 @@ use pyo3::{
     exceptions::{PyAssertionError, PyRuntimeError, PyTypeError},
     intern,
     prelude::*,
-    types::{PyBool, PyCFunction, PyFloat, PyInt, PyList, PyString},
+    types::{
+        PyBool, PyCFunction, PyFloat, PyInt, PyList, PyString, PyWeakrefMethods, PyWeakrefReference,
+    },
 };
 
 use crate::deferred::run_python_awaitable;
@@ -95,23 +97,32 @@ impl DatabaseEngine {
 
 /// Wrapper for a `DatabasePool` from the Python side of Synapse.
 pub struct PythonDatabasePoolWrapper {
-    /// The underlying Python `DatabasePool`
-    database_pool_py: Py<PyAny>,
+    /// A *weak* reference to the underlying Python `DatabasePool`.
+    ///
+    /// We use a *weak* reference to ensure the homeserver can cleanly shut down as
+    /// otherwise we hold onto `DatabasePool` which references the homeserver and keeps
+    /// the homeserver from being garbage collected.
+    database_pool_py_ref: Py<PyWeakrefReference>,
 
-    /// The Twisted reactor. We need this to marshal back onto the reactor thread
-    /// (via `callFromThread`) when starting transactions, since Twisted's thread
-    /// pool machinery must be driven from there.
+    /// The Twisted reactor. We need this to marshal database work back onto the
+    /// reactor thread (via `callFromThread`) when starting transactions, since
+    /// Twisted's thread pool machinery must be driven from there.
+    ///
+    /// A strong reference is fine here: the reactor is a process-global singleton that
+    /// never gets garbage collected and never points back at the homeserver, so it is
+    /// not part of any reference cycle. Ideally, we could worry about it but
+    /// practically probably doesn't matter.
     reactor: Py<PyAny>,
 }
 
 impl PythonDatabasePoolWrapper {
     /// Build a wrapper around the Python `DatabasePool` (e.g.
     /// `hs.get_datastores().main.db_pool`) and the Twisted `reactor`.
-    pub fn new(database_pool_py: Py<PyAny>, reactor: Py<PyAny>) -> Self {
-        Self {
-            database_pool_py,
+    pub fn new(database_pool: &Bound<'_, PyAny>, reactor: Py<PyAny>) -> PyResult<Self> {
+        Ok(Self {
+            database_pool_py_ref: PyWeakrefReference::new(database_pool)?.unbind(),
             reactor,
-        }
+        })
     }
 }
 
@@ -193,9 +204,24 @@ impl DatabasePool for PythonDatabasePoolWrapper {
                 )?
                 .unbind();
 
+                // Upgrade our weak reference to the Python `DatabasePool` into a strong
+                // one for the duration of this interaction.
+                let database_pool_py = self
+                    .database_pool_py_ref
+                    .bind(py)
+                    .upgrade()
+                    .ok_or_else(|| {
+                        PyRuntimeError::new_err(
+                            "The Python `DatabasePool` has already been dropped \
+                            (the homeserver is likely shutdown), so we cannot \
+                            run the database interaction.",
+                        )
+                    })?
+                    .unbind();
+
                 Ok((
                     callback,
-                    self.database_pool_py.clone_ref(py),
+                    database_pool_py,
                     self.reactor.clone_ref(py),
                 ))
             })

--- a/tests/app/test_homeserver_shutdown.py
+++ b/tests/app/test_homeserver_shutdown.py
@@ -58,6 +58,11 @@ class HomeserverCleanShutdownTestCase(HomeserverTestCase):
             homeserver_to_use=SynapseHomeServer,
             clock=self.clock,
         )
+        # Since we're driving the entire homeserver creation in these tests (something
+        # normally handled by `HomeserverTestCase` if we defined some `servlets`), make
+        # sure we get the Rust side instantiated to verify nothing on the Rust side is
+        # holding onto a Python reference that would prevent shutdown.
+        self.hs.get_rust_handlers()
         self.wait_for_background_updates()
 
         hs_ref = weakref.ref(self.hs)
@@ -109,6 +114,11 @@ class HomeserverCleanShutdownTestCase(HomeserverTestCase):
             homeserver_to_use=SynapseHomeServer,
             clock=self.clock,
         )
+        # Since we're driving the entire homeserver creation in these tests (something
+        # normally handled by `HomeserverTestCase` if we defined some `servlets`), make
+        # sure we get the Rust side instantiated to verify nothing on the Rust side is
+        # holding onto a Python reference that would prevent shutdown.
+        self.hs.get_rust_handlers()
 
         # Pump the background updates by a single iteration, just to ensure any extra
         # resources it uses have been started.


### PR DESCRIPTION
Use weakref to Python `DatabasePool` to allow homeserver to cleanly shutdown

Spawning from [upgrading](https://github.com/element-hq/synapse-small-hosts/pull/420#discussion_r3661700252) the Synapse version in Synapse Pro for small hosts and seeing our tenant deprovision tests failing (end-to-end Complement tests). Specifically, it was failing with a test in [`TestLogging`](https://github.com/element-hq/synapse-small-hosts/blob/f24ee731ff419890680d1d80ef6eafe44f87f2c2/complement/tests/multi_synapse/logging_test.go#L328-L385) in CI but was equally reproducible with any test where we deprovision (`deployment.StopServer(...)`) like [`TestProvisionHomeserverTenant/deprovision_homeserver_tenant`](https://github.com/element-hq/synapse-small-hosts/blob/f24ee731ff419890680d1d80ef6eafe44f87f2c2/complement/tests/multi_synapse/provision_test.go#L48-L58).

Clean homeserver shutdown specifically regressed with the changes from https://github.com/element-hq/synapse/pull/19878. The `PythonDatabasePoolWrapper` in Rust holds onto a reference to the Python `DatabasePool` which references the Python `HomeServer` and keeps the `HomeServer` from being garbage collected on the Python side.

This PR updates `PythonDatabasePoolWrapper` to use a weak reference.


### Dev notes

Previous PR where we had to deal with Rust <-> Python reference cycles, https://github.com/element-hq/synapse/pull/19837#discussion_r3425358096

PyO3 garbage collector docs (`__traverse__`, `__clear__`): https://pyo3.rs/v0.28.3/class/protocols#garbage-collector-integration


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
