### PR TITLE
Fix `RemoteJoinHelper` signing events with the default room version (room version mismatch)

### DIFF
--- a/changelog.d/20015.misc
+++ b/changelog.d/20015.misc
@@ -1,0 +1,1 @@
+Fix `RemoteJoinHelper` test helper signing events with the default room version (room version mismatch).

--- a/tests/federation/_remote_join.py
+++ b/tests/federation/_remote_join.py
@@ -127,6 +127,7 @@ class RemoteJoinHelper:
         room_create_event = make_test_event(
             test_case.add_hashes_and_signatures_from_other_server(
                 create_event_dict,
+                room_version=room_version,
             ),
             room_version=room_version,
         )
@@ -146,7 +147,8 @@ class RemoteJoinHelper:
                     "content": {"membership": Membership.JOIN},
                     "auth_events": [room_create_event.event_id],
                     "prev_events": [room_create_event.event_id],
-                }
+                },
+                room_version=room_version,
             ),
             room_version=room_version,
         )
@@ -172,7 +174,8 @@ class RemoteJoinHelper:
                             creator_membership_event.event_id,
                         ],
                         "prev_events": [prev_event.event_id],
-                    }
+                    },
+                    room_version=room_version,
                 ),
                 room_version=room_version,
             )
@@ -217,7 +220,8 @@ class RemoteJoinHelper:
                         if extra_events
                         else creator_membership_event.event_id
                     ],
-                }
+                },
+                room_version=room_version,
             ),
             room_version=room_version,
         )
@@ -315,7 +319,9 @@ class RemoteJoinHelper:
             ):
                 # As the remote server, sign the join event before returning it.
                 join_membership_event_signed = make_test_event(
-                    self._test_case.add_hashes_and_signatures_from_other_server(data),
+                    self._test_case.add_hashes_and_signatures_from_other_server(
+                        data, room_version=room_version
+                    ),
                     room_version=room_version,
                 )
                 return SendJoinResponse(

--- a/tests/federation/_remote_join.py
+++ b/tests/federation/_remote_join.py
@@ -21,7 +21,8 @@ from unittest.mock import Mock
 import attr
 
 from synapse.api.constants import EventContentFields, EventTypes, Membership
-from synapse.api.room_versions import RoomVersion, RoomVersions
+from synapse.api.room_versions import KNOWN_ROOM_VERSIONS, RoomVersion
+from synapse.config.server import DEFAULT_ROOM_VERSION
 from synapse.events import EventBase
 from synapse.events.utils import strip_event
 from synapse.federation.transport.client import SendJoinResponse
@@ -87,7 +88,7 @@ class RemoteJoinHelper:
         federation_http_client: Mock,
         *,
         remote_creator_user_id: str | None = None,
-        room_version: RoomVersion = RoomVersions.V10,
+        room_version: RoomVersion = KNOWN_ROOM_VERSIONS[DEFAULT_ROOM_VERSION],
         create_content: JsonDict | None = None,
         state_events: list[RemoteStateEvent] | None = None,
     ) -> None:


### PR DESCRIPTION
Fix `RemoteJoinHelper` signing events with mismatched room version compared to the `room_version` arg. The default room version on `develop` is `11` but the `RemoteJoinHelper` `room_version` arg defaults to `10` (room version mismatch). This mismatch wasn't present where this fix was developed (https://github.com/element-hq/synapse-private/pull/136) as the default room version was only recently bumped to `11` via https://github.com/element-hq/synapse/pull/18680 (not even in a release yet).

Fixes the CI being broken on `develop` :x::

```
[ERROR]
Traceback (most recent call last):
  File "/home/runner/work/synapse/synapse/tests/federation/test_federation_join_upgraded_room.py", line 298, in test_no_transfer_when_tombstone_does_not_match
    join_helper.join(local_user_id, local_user_tok)
  File "/home/runner/work/synapse/synapse/tests/federation/_remote_join.py", line 350, in join
    self._test_case.helper.join(remote_room_id, local_user_id, tok=local_user_tok)
  File "/home/runner/work/synapse/synapse/tests/rest/client/utils.py", line 195, in join
    return self.change_membership(
  File "/home/runner/work/synapse/synapse/tests/rest/client/utils.py", line 333, in change_membership
    assert channel.code == expect_code, (
builtins.AssertionError: Expected: 200, got: 400, PUT /_matrix/client/r0/rooms/!remote-room:other.example.com/state/m.room.member/@user1:test?access_token=syt_dXNlcjE_JSEarRndiAGqtydnrdLn_33qlLD -> resp: b'{"errcode":"M_UNKNOWN","error":"No create event in state"}'

tests.federation.test_federation_join_upgraded_room.FederationJoinUpgradedRoomTestCase.test_no_transfer_when_tombstone_does_not_match
```

These tests were originally introduced https://github.com/element-hq/synapse-private/pull/136 (developed private as this was part of the Synapse security release) and introduced into the public codebase via https://github.com/element-hq/synapse/commit/cbc6934821aab314506c5957223c60c74eeda091


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
