### PR TITLE
Fix `assertIncludes` printing `None` at the end of the message

### DIFF
--- a/changelog.d/20020.misc
+++ b/changelog.d/20020.misc
@@ -1,0 +1,1 @@
+Fix `assertIncludes` printing `None` at the end of the message.

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -317,7 +317,11 @@ class TestCase(unittest.TestCase):
         )
         diff_message = f"{first_message}\n{expected_string}\n{actual_string}"
 
-        self.fail(f"{diff_message}\n{message}")
+        extra_message = ""
+        if message is not None:
+            extra_message = "f\n{message}"
+
+        self.fail(f"{diff_message}{extra_message}")
 
 
 def DEBUG(target: TV) -> TV:


### PR DESCRIPTION
Fix `assertIncludes` printing `None` at the end of the message

As spotted by @reivilibre, https://github.com/element-hq/synapse/pull/20019#discussion_r3676368265

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
