### PR TITLE
fix RemoteJoinHelper to handle v12 rooms

### DIFF
--- a/changelog.d/20021.misc
+++ b/changelog.d/20021.misc
@@ -1,0 +1,1 @@
+Fix `RemoteJoinHelper` test helper to handle room version "12" rooms. Contributed by @famedly @jason-famedly.

--- a/tests/federation/_remote_join.py
+++ b/tests/federation/_remote_join.py
@@ -146,7 +146,9 @@ class RemoteJoinHelper:
                     "type": EventTypes.Member,
                     "state_key": remote_creator_user_id,
                     "content": {"membership": Membership.JOIN},
-                    "auth_events": [room_create_event.event_id],
+                    "auth_events": [room_create_event.event_id]
+                    if not room_version.msc4291_room_ids_as_hashes
+                    else [],
                     "prev_events": [room_create_event.event_id],
                 },
                 room_version=room_version,
@@ -173,7 +175,9 @@ class RemoteJoinHelper:
                         "auth_events": [
                             room_create_event.event_id,
                             creator_membership_event.event_id,
-                        ],
+                        ]
+                        if not room_version.msc4291_room_ids_as_hashes
+                        else [creator_membership_event.event_id],
                         "prev_events": [prev_event.event_id],
                     },
                     room_version=room_version,
@@ -215,7 +219,9 @@ class RemoteJoinHelper:
                     "auth_events": [
                         room_create_event.event_id,
                         creator_membership_event.event_id,
-                    ],
+                    ]
+                    if not room_version.msc4291_room_ids_as_hashes
+                    else [creator_membership_event.event_id],
                     "prev_events": [
                         extra_events[-1].event_id
                         if extra_events
@@ -254,7 +260,9 @@ class RemoteJoinHelper:
                 "auth_events": [
                     room_create_event.event_id,
                     invite_membership_event.event_id,
-                ],
+                ]
+                if not room_version.msc4291_room_ids_as_hashes
+                else [invite_membership_event.event_id],
                 "prev_events": [invite_membership_event.event_id],
             },
             room_version=room_version,


### PR DESCRIPTION
While preparing for the default room version change to "12", the new tests for [FederationJoinUpgradedRoomTestCase](https://github.com/element-hq/synapse/blob/36664cac4fdec38993c68078cd9a82452b56dca7/tests/federation/test_federation_join_upgraded_room.py#L44) were unable to handle creation events inside of the manufactured `auth_events` sections. All of these tests fail.

Related to https://github.com/element-hq/synapse/pull/20015 as another recent fix to `RemoteJoinHelper`


### Background on why changing the default room version change to "12"

Since #18118 is effectively done, #18531 is also effectively done, and #18731 is *mosty* done(I would like to see some polish into not [relying on `room_stats_state` table](https://github.com/element-hq/synapse/issues/19905)) that leaves #19414 to push Synapse to be Matrix Spec ~~1.18~~ 1.16 ready.

### Testing strategy

To test, I recommend changing the `DEFAULT_ROOM_VERSION` in [the `server.py` config file](https://github.com/element-hq/synapse/blob/36664cac4fdec38993c68078cd9a82452b56dca7/synapse/config/server.py#L179) to `"12"`, then running `poetry run trial tests.federation.test_federation_join_upgraded_room.FederationJoinUpgradedRoomTestCase` for these selective tests. Alternatively, creating the `default_config()` for the `TestCase` in question to set the default room version, but that is more work.


### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
