### PR TITLE
Fix release announcement to link to correct release branch of changelog

### DIFF
--- a/changelog.d/20023.misc
+++ b/changelog.d/20023.misc
@@ -1,0 +1,1 @@
+Fix release script announcement to link to correct release branch of changelog.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -736,8 +736,8 @@ def announce(_gh_token: str | None) -> None:
 def _announce() -> None:
     """Generate markdown to announce the release."""
 
-    synapse_repo = get_repo_and_check_clean_checkout()
     current_version = get_package_version()
+    release_branch_name = get_release_branch_name(current_version)
     tag_name = f"v{current_version}"
     is_rc = "rc" in tag_name
 
@@ -756,7 +756,7 @@ Hi everyone. Synapse {current_version} has just been released.
         )
 
     release_text += f"""
-[notes](https://github.com/element-hq/synapse/blob/{synapse_repo.active_branch.name}/CHANGES.md) | \
+[notes](https://github.com/element-hq/synapse/blob/{release_branch_name}/CHANGES.md) | \
 [docker](https://hub.docker.com/r/matrixdotorg/synapse/tags?name={tag_name}) | \
 [debs](https://packages.matrix.org/debian/) | \
 [pypi](https://pypi.org/project/matrix-synapse/{current_version}/)"""


### PR DESCRIPTION
Fix release announcement to link to correct release branch of changelog. Without this change, it was linking to `develop` as we were on the `develop` branch because of the previous `merge-back` step at this point in the release process.

Follow-up to https://github.com/element-hq/synapse/pull/19984 as this was an oversight and I assumed we would still be on the `release-v1.158` branch by that point.

Test:
```
poetry run ./scripts-dev/release.py announce
```

#### Before

```
[notes](https://github.com/element-hq/synapse/blob/develop/CHANGES.md)
```


#### After

```
[notes](https://github.com/element-hq/synapse/blob/release-v1.158/CHANGES.md)
```



### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
