### PR TITLE
Remove broken `DROP` statements for SQLite in `make_full_schema` script.

### DIFF
--- a/changelog.d/20028.misc
+++ b/changelog.d/20028.misc
@@ -1,0 +1,1 @@
+Remove broken `DROP` statements for SQLite in `make_full_schema` script.

--- a/scripts-dev/make_full_schema.sh
+++ b/scripts-dev/make_full_schema.sh
@@ -232,20 +232,10 @@ psql "$POSTGRES_MAIN_DB_NAME" -w <<< "$DROP_COMMON_TABLES"
 psql "$POSTGRES_STATE_DB_NAME" -w <<< "$DROP_COMMON_TABLES"
 
 # For Reasons(TM), SQLite's `.schema` also dumps out "shadow tables", the implementation
-# details behind full text search tables. Omit these from the dumps.
-
-sqlite3 "$SQLITE_MAIN_DB" <<< "
-DROP TABLE event_search_content;
-DROP TABLE event_search_segments;
-DROP TABLE event_search_segdir;
-DROP TABLE event_search_docsize;
-DROP TABLE event_search_stat;
-DROP TABLE user_directory_search_content;
-DROP TABLE user_directory_search_segments;
-DROP TABLE user_directory_search_segdir;
-DROP TABLE user_directory_search_docsize;
-DROP TABLE user_directory_search_stat;
-"
+# details behind full text search tables.
+# Previously we omitted these from the dumps by dropping them beforehand,
+# but nowadays it seems to be forbidden to drop those.
+# The emitted dump adds `IF NOT EXISTS` text for them, so it's harmless.
 
 echo "Dumping SQLite3 schema..."
 


### PR DESCRIPTION
Broken out of #20027 because I'd like to have it land first.

> It seems a lot of time in our trial tests goes towards setting up the database. (The same is probably true of Complement too)
> 
> We haven't done a full schema for about 20 schema versions, so no surprise!
> 
> As a result, I want to produce a full schema soon.

When running `make_full_schema.sh`, these drop statements now cause the error:

```
Parse error near line 2: table event_search_content may not be dropped
Parse error near line 3: table event_search_segments may not be dropped
Parse error near line 4: table event_search_segdir may not be dropped
Parse error near line 5: table event_search_docsize may not be dropped
Parse error near line 6: table event_search_stat may not be dropped
Parse error near line 7: table user_directory_search_content may not be dropped
Parse error near line 8: table user_directory_search_segments may not be dropped
Parse error near line 9: table user_directory_search_segdir may not be dropped
Parse error near line 10: table user_directory_search_docsize may not be dropped
Parse error near line 11: table user_directory_search_stat may not be dropped
```

It seems SQLite has cracked down on code that edits the internal tables.

Because SQLite dumps the schema with `CREATE TABLE IF NOT EXISTS` for these virtual tables, it's harmless to leave them in the schema dump.

<ol>
<li>

make_full_schema: no longer drop sqlite internal tables 

</li>
</ol>
