### PR TITLE
Drop support for Ubuntu 25.10 'Questing Quokka', add support for Ubuntu 26.04 'Resolute Raccoon'

### DIFF
--- a/changelog.d/20039.misc
+++ b/changelog.d/20039.misc
@@ -1,0 +1,1 @@
+Add package build targets for Ubuntu 26.04 'Resolute Raccoon'.

--- a/changelog.d/20039.removal
+++ b/changelog.d/20039.removal
@@ -1,0 +1,1 @@
+Remove package build targets for Ubuntu 25.10 'Questing Quokka' (end-of-life 2026-07-01).

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -117,6 +117,14 @@ each upgrade are complete before moving on to the next upgrade, to avoid
 stacking them up. You can monitor the currently running background updates with
 [the Admin API](usage/administration/admin_api/background_updates.html#status).
 
+# Upgrading to v1.158.0
+
+## Drop support for Ubuntu 25.10 'Questing Quokka', add support for Ubuntu 26.04 'Resolute Raccoon'
+
+Ubuntu 25.10 'Questing Quokka' [is end-of-life as of
+2026-07-01](https://endoflife.date/ubuntu). This release drops support for Ubuntu 25.10,
+and in its place adds support for Ubuntu 26.04 'Resolute Raccoon'.
+
 # Upgrading to v1.157.0
 
 ## MSC3861 Auth Delegation must be migrated to stable Matrix Authentication Service integration

--- a/scripts-dev/build_debian_packages.py
+++ b/scripts-dev/build_debian_packages.py
@@ -27,11 +27,11 @@ from typing import Collection, Sequence
 # to remove references to the distibution across Synapse (search for "bookworm" for
 # example)
 DISTS = (
-    "debian:bookworm",  # (EOL 2026-06) (our EOL forced by Python 3.11 is 2027-10-31)
+    "debian:bookworm",  # (EOL 2028-06-30) (our EOL forced by Python 3.11 is 2027-10-31)
     "debian:sid",  # (rolling distro, no EOL)
-    "ubuntu:jammy",  # 22.04 LTS (EOL 2027-04) (our EOL forced by Python 3.10 is 2026-10-31)
-    "ubuntu:noble",  # 24.04 LTS (EOL 2029-06) (our EOL forced by Python 3.12 is 2028-10-31)
-    "debian:trixie",  # (EOL not specified yet) (our EOL forced by Python 3.13 is 2029-10-31)
+    "ubuntu:jammy",  # 22.04 LTS (EOL 2027-04-01) (our EOL forced by Python 3.10 is 2026-10-31)
+    "ubuntu:noble",  # 24.04 LTS (EOL 2029-05-31) (our EOL forced by Python 3.12 is 2028-10-31)
+    "debian:trixie",  # (EOL 2030-06-30) (our EOL forced by Python 3.13 is 2029-10-31)
     "ubuntu:resolute",  # 26.04 (EOL 2031-04-30) (our EOL forced by Python 3.14 is 2030-10-31)
 )
 

--- a/scripts-dev/build_debian_packages.py
+++ b/scripts-dev/build_debian_packages.py
@@ -31,7 +31,6 @@ DISTS = (
     "debian:sid",  # (rolling distro, no EOL)
     "ubuntu:jammy",  # 22.04 LTS (EOL 2027-04) (our EOL forced by Python 3.10 is 2026-10-04)
     "ubuntu:noble",  # 24.04 LTS (EOL 2029-06)
-    "ubuntu:questing",  # 25.10 (EOL 2026-07)
     "debian:trixie",  # (EOL not specified yet)
 )
 

--- a/scripts-dev/build_debian_packages.py
+++ b/scripts-dev/build_debian_packages.py
@@ -27,11 +27,12 @@ from typing import Collection, Sequence
 # to remove references to the distibution across Synapse (search for "bookworm" for
 # example)
 DISTS = (
-    "debian:bookworm",  # (EOL 2026-06) (our EOL forced by Python 3.11 is 2027-10-24)
+    "debian:bookworm",  # (EOL 2026-06) (our EOL forced by Python 3.11 is 2027-10-31)
     "debian:sid",  # (rolling distro, no EOL)
-    "ubuntu:jammy",  # 22.04 LTS (EOL 2027-04) (our EOL forced by Python 3.10 is 2026-10-04)
-    "ubuntu:noble",  # 24.04 LTS (EOL 2029-06)
-    "debian:trixie",  # (EOL not specified yet)
+    "ubuntu:jammy",  # 22.04 LTS (EOL 2027-04) (our EOL forced by Python 3.10 is 2026-10-31)
+    "ubuntu:noble",  # 24.04 LTS (EOL 2029-06) (our EOL forced by Python 3.12 is 2028-10-31)
+    "debian:trixie",  # (EOL not specified yet) (our EOL forced by Python 3.13 is 2029-10-31)
+    "ubuntu:resolute",  # 26.04 (EOL 2031-04-30) (our EOL forced by Python 3.14 is 2030-10-31)
 )
 
 DESC = """\


### PR DESCRIPTION
Drop support for Ubuntu 25.10 'Questing Quokka' (EOL 2026-07-01), add support for Ubuntu 26.04 'Resolute Raccoon'

Fix https://github.com/element-hq/synapse/issues/20031

### Dev notes

 - https://endoflife.date/ubuntu
 - https://endoflife.date/debian
 - https://endoflife.date/python

Finding Python version on distros:

 - https://packages.debian.org/trixie/python3
 - https://packages.ubuntu.com/resolute/python3


### Todo

 - [x] Add upgrade notes

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
