### PR TITLE
Implement MSC4494: Membership-based invite blocking

### DIFF
--- a/changelog.d/20056.feature
+++ b/changelog.d/20056.feature
@@ -1,0 +1,1 @@
+Add support for [MSC4494: Membership-based invite blocking](https://github.com/matrix-org/matrix-spec-proposals/pull/4494). Contributed by @timedoutuk.

--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -73,4 +73,5 @@ pub struct ExperimentalConfig {
     pub msc4491_enabled: bool,
     pub msc4143_enabled: bool,
     pub msc4446_enabled: bool,
+    pub msc4494_enabled: bool,
 }

--- a/rust/src/handlers/versions.rs
+++ b/rust/src/handlers/versions.rs
@@ -269,6 +269,9 @@ pub struct UnstableFeatureMap {
     /// MSC4446: Allow moving the fully read marker backwards.
     #[serde(rename = "com.beeper.msc4446")]
     msc4446_enabled: bool,
+    /// MSC4494: Membership-based invite blocking
+    #[serde(rename = "uk.timedout.msc4494")]
+    msc4494_enabled: bool,
 
     // Whether new rooms will be set to encrypted or not (based on presets).
     #[serde(rename = "io.element.e2ee_forced.public")]
@@ -320,6 +323,7 @@ pub fn synapse_config_to_global_unstable_feature_map(
         msc4491_enabled: config.experimental.msc4491_enabled,
         msc4143_enabled: config.experimental.msc4143_enabled,
         msc4446_enabled: config.experimental.msc4446_enabled,
+        msc4494_enabled: config.experimental.msc4494_enabled,
         e2ee_forced_public: config
             .room
             .encryption_enabled_by_default_for_room_presets

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -309,3 +309,6 @@ class ExperimentalConfig(Config):
 
         # MSC4491: Invite reasons in room creation
         self.msc4491_enabled: bool = experimental.get("msc4491_enabled", False)
+
+        # MSC4494: Membership-based invite blocking
+        self.msc4494_enabled: bool = experimental.get("msc4494_enabled", False)

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1179,10 +1179,10 @@ class FederationHandler:
                 frozenset((event.sender, event.state_key))
             )
             private = False
-            for room_id in mutual_rooms:
+            for mutual_room_id in mutual_rooms:
                 join_rule = JoinRules.INVITE
                 state = await self._storage_controllers.state.get_current_state_ids(
-                    room_id,
+                    mutual_room_id,
                     StateFilter.from_types([(EventTypes.JoinRules, "")]),
                 )
                 event_id = state.get((EventTypes.JoinRules, ""))

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1171,7 +1171,7 @@ class FederationHandler:
                 "You are not permitted to invite this user.",
                 errcode=Codes.INVITE_BLOCKED,
             )
-        elif rule == InviteRule.UNSTABLE_BLOCK_PUBLIC:
+        elif rule == InviteRule.UNSTABLE_BLOCK_PUBLIC and self.config.experimental.msc4494_enabled:
             mutual_rooms = await self.store.get_mutual_rooms_between_users(
                 frozenset((event.sender, event.state_key))
             )

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -40,7 +40,13 @@ from signedjson.sign import verify_signed_json
 from unpaddedbase64 import decode_base64
 
 from synapse import event_auth
-from synapse.api.constants import MAX_DEPTH, EventContentFields, EventTypes, Membership
+from synapse.api.constants import (
+    JoinRules,
+    MAX_DEPTH,
+    EventContentFields,
+    EventTypes,
+    Membership,
+)
 from synapse.api.errors import (
     AuthError,
     CodeMessageException,
@@ -1165,6 +1171,41 @@ class FederationHandler:
                 "You are not permitted to invite this user.",
                 errcode=Codes.INVITE_BLOCKED,
             )
+        elif rule == InviteRule.UNSTABLE_BLOCK_PUBLIC:
+            mutual_rooms = await self.store.get_mutual_rooms_between_users(
+                frozenset((event.sender, event.state_key))
+            )
+            private = False
+            for room_id in mutual_rooms:
+                join_rule = JoinRules.INVITE
+                state = await self._storage_controllers.state.get_current_state_ids(
+                    room_id,
+                    StateFilter.from_types([(EventTypes.JoinRules, "")]),
+                )
+                event_id = state.get((EventTypes.JoinRules, ""))
+                if event_id:
+                    join_rules_event = await self.store.get_event(
+                        event_id, allow_none=True
+                    )
+                    if join_rules_event:
+                        join_rule = join_rules_event.content.get(
+                            "join_rule", JoinRules.INVITE
+                        )
+                if join_rule != JoinRules.PUBLIC:
+                    private = True
+                    break
+            if not private:
+                logger.info(
+                    "Automatically rejecting invite from %s as they do not "
+                    "share a non-public room with %s",
+                    event.sender,
+                    event.state_key,
+                )
+                raise SynapseError(
+                    403,
+                    "You are not permitted to invite this user.",
+                    errcode=Codes.INVITE_BLOCKED,
+                )
         # InviteRule.IGNORE is handled at the sync layer
 
         # We retrieve the room member handler here as to not cause a cyclic dependency

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -41,10 +41,10 @@ from unpaddedbase64 import decode_base64
 
 from synapse import event_auth
 from synapse.api.constants import (
-    JoinRules,
     MAX_DEPTH,
     EventContentFields,
     EventTypes,
+    JoinRules,
     Membership,
 )
 from synapse.api.errors import (
@@ -1171,7 +1171,10 @@ class FederationHandler:
                 "You are not permitted to invite this user.",
                 errcode=Codes.INVITE_BLOCKED,
             )
-        elif rule == InviteRule.UNSTABLE_BLOCK_PUBLIC and self.config.experimental.msc4494_enabled:
+        elif (
+            rule == InviteRule.UNSTABLE_BLOCK_PUBLIC
+            and self.config.experimental.msc4494_enabled
+        ):
             mutual_rooms = await self.store.get_mutual_rooms_between_users(
                 frozenset((event.sender, event.state_key))
             )

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -950,11 +950,11 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                         frozenset((requester.user.to_string(), target_id))
                     )
                     private = False
-                    for room_id in mutual_rooms:
+                    for mutual_room_id in mutual_rooms:
                         join_rule = JoinRules.INVITE
                         state = (
                             await self._storage_controllers.state.get_current_state_ids(
-                                room_id,
+                                mutual_room_id,
                                 StateFilter.from_types([(EventTypes.JoinRules, "")]),
                             )
                         )

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -942,7 +942,10 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                         "You are not permitted to invite this user.",
                         errcode=Codes.INVITE_BLOCKED,
                     )
-                elif rule == InviteRule.UNSTABLE_BLOCK_PUBLIC and self.config.experimental.msc4494_enabled:
+                elif (
+                    rule == InviteRule.UNSTABLE_BLOCK_PUBLIC
+                    and self.config.experimental.msc4494_enabled
+                ):
                     mutual_rooms = await self.store.get_mutual_rooms_between_users(
                         frozenset((requester.user.to_string(), target_id))
                     )

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -31,6 +31,7 @@ from synapse.api.constants import (
     EventContentFields,
     EventTypes,
     GuestAccess,
+    JoinRules,
     Membership,
 )
 from synapse.api.errors import (
@@ -941,6 +942,43 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                         "You are not permitted to invite this user.",
                         errcode=Codes.INVITE_BLOCKED,
                     )
+                elif rule == InviteRule.UNSTABLE_BLOCK_PUBLIC:
+                    mutual_rooms = await self.store.get_mutual_rooms_between_users(
+                        frozenset((requester.user.to_string(), target_id))
+                    )
+                    private = False
+                    for room_id in mutual_rooms:
+                        join_rule = JoinRules.INVITE
+                        state = (
+                            await self._storage_controllers.state.get_current_state_ids(
+                                room_id,
+                                StateFilter.from_types([(EventTypes.JoinRules, "")]),
+                            )
+                        )
+                        event_id = state.get((EventTypes.JoinRules, ""))
+                        if event_id:
+                            join_rules_event = await self.store.get_event(
+                                event_id, allow_none=True
+                            )
+                            if join_rules_event:
+                                join_rule = join_rules_event.content.get(
+                                    "join_rule", JoinRules.INVITE
+                                )
+                        if join_rule != JoinRules.PUBLIC:
+                            private = True
+                            break
+                    if not private:
+                        logger.info(
+                            "Automatically rejecting invite from %s as they do not "
+                            "share a non-public room with %s",
+                            requester.user,
+                            target_id,
+                        )
+                        raise SynapseError(
+                            403,
+                            "You are not permitted to invite this user.",
+                            errcode=Codes.INVITE_BLOCKED,
+                        )
                 # InviteRule.IGNORE is handled at the sync layer.
 
         if prev_event_ids is not None:

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -942,7 +942,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                         "You are not permitted to invite this user.",
                         errcode=Codes.INVITE_BLOCKED,
                     )
-                elif rule == InviteRule.UNSTABLE_BLOCK_PUBLIC:
+                elif rule == InviteRule.UNSTABLE_BLOCK_PUBLIC and self.config.experimental.msc4494_enabled:
                     mutual_rooms = await self.store.get_mutual_rooms_between_users(
                         frozenset((requester.user.to_string(), target_id))
                     )

--- a/synapse/storage/invite_rule.py
+++ b/synapse/storage/invite_rule.py
@@ -17,6 +17,7 @@ class InviteRule(Enum):
     ALLOW = "allow"
     BLOCK = "block"
     IGNORE = "ignore"
+    UNSTABLE_BLOCK_PUBLIC = "uk.timedout.msc4494.deny_public"
 
 
 class InviteRulesConfig:
@@ -143,9 +144,14 @@ class MSC4380InviteRulesConfig(InviteRulesConfig):
     def from_account_data(cls, data: JsonMapping) -> "MSC4380InviteRulesConfig":
         default = data.get("default_action")
 
-        default_invite_rule = (
-            InviteRule.BLOCK if default == "block" else InviteRule.ALLOW
-        )
+        match default:
+            case "block":
+                default_invite_rule = InviteRule.BLOCK
+            case "uk.timedout.msc4494.deny_public":
+                default_invite_rule = InviteRule.UNSTABLE_BLOCK_PUBLIC
+            case _:
+                # Unrecognized actions default to allow.
+                default_invite_rule = InviteRule.ALLOW
         return cls(default_invite_rule=default_invite_rule)
 
     def get_invite_rule(self, inviter_user_id: str) -> InviteRule:


### PR DESCRIPTION
Implements [MSC4494: Membership-based invite blocking](https://github.com/matrix-org/matrix-spec-proposals/pull/4494). No clients currently support this, however the action can be manually set through Element devtools (or some other account data editor).

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
