### PR TITLE
Add upgrade notes to point out updated Debian package signing key (2026)

### DIFF
--- a/changelog.d/20066.doc
+++ b/changelog.d/20066.doc
@@ -1,0 +1,1 @@
+Add upgrade notes to point out updated Debian package signing key.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -117,6 +117,27 @@ each upgrade are complete before moving on to the next upgrade, to avoid
 stacking them up. You can monitor the currently running background updates with
 [the Admin API](usage/administration/admin_api/background_updates.html#status).
 
+
+# Upgrading to v1.159.0
+
+## Change of signing key expiry date for the Debian/Ubuntu package repository (2026)
+
+Administrators using the Debian/Ubuntu packages from `packages.matrix.org`,
+please be aware that we have recently updated the expiry date on the repository's GPG signing key,
+but this change must be imported into your keyring.
+
+If you have the `matrix-org-archive-keyring` package installed and it updates before the current key expires, this should
+happen automatically.
+
+Otherwise, if you see an error similar to `The following signatures were invalid: EXPKEYSIG F473DD4473365DE1`, you
+will need to get a fresh copy of the keys. You can do so with:
+
+```sh
+sudo wget -O /usr/share/keyrings/matrix-org-archive-keyring.gpg https://packages.matrix.org/debian/matrix-org-archive-keyring.gpg
+```
+
+The old version of the key will expire on `2027-03-15`.
+
 # Upgrading to v1.158.0
 
 ## Drop support for Ubuntu 25.10 'Questing Quokka', add support for Ubuntu 26.04 'Resolute Raccoon'


### PR DESCRIPTION
Add upgrade notes to point out updated Debian package signing key (2026)

Part of https://github.com/element-hq/synapse/issues/20038

Language based on the previous time we did this:

https://github.com/element-hq/synapse/blob/3cb6c3484daa59c56bbc3d8df295e011c9f0d2cf/docs/upgrade.md?plain=1#L415-L431

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
