### PR TITLE
Allow specifying multiple `action_name` and `status` params in the scheduled tasks admin API

### DIFF
--- a/changelog.d/20067.feature
+++ b/changelog.d/20067.feature
@@ -1,0 +1,1 @@
+Allow specifying multiple `action_name` and `status` query parameters when listing scheduled tasks via the admin API.

--- a/docs/admin_api/scheduled_tasks.md
+++ b/docs/admin_api/scheduled_tasks.md
@@ -31,8 +31,10 @@ It returns a JSON body like the following:
 **Query parameters:**
 
 * `action_name`: string - Is optional. Returns only the scheduled tasks with the given action name.
+  May be given multiple times to return tasks matching any of the given action names.
 * `resource_id`: string - Is optional. Returns only the scheduled tasks with the given resource id.
-* `status`: string - Is optional. Returns only the scheduled tasks matching the given status, one of
+* `status`: string - Is optional. Returns only the scheduled tasks matching the given status.
+  May be given multiple times to return tasks matching any of the given statuses. The status must be one of
     - "scheduled" - Task is scheduled but not active
     - "active" - Task is active and probably running, and if not will be run on next scheduler loop run
     - "complete" - Task has completed successfully

--- a/synapse/rest/admin/scheduled_tasks.py
+++ b/synapse/rest/admin/scheduled_tasks.py
@@ -15,7 +15,12 @@
 #
 from typing import TYPE_CHECKING
 
-from synapse.http.servlet import RestServlet, parse_integer, parse_string
+from synapse.http.servlet import (
+    RestServlet,
+    parse_integer,
+    parse_string,
+    parse_strings_from_args,
+)
 from synapse.http.site import SynapseRequest
 from synapse.rest.admin import admin_patterns, assert_requester_is_admin
 from synapse.types import JsonDict, TaskStatus
@@ -38,19 +43,33 @@ class ScheduledTasksRestServlet(RestServlet):
     async def on_GET(self, request: SynapseRequest) -> tuple[int, JsonDict]:
         await assert_requester_is_admin(self._auth, request)
 
+        # twisted.web.server.Request.args is incorrectly defined as Any | None
+        args: dict[bytes, list[bytes]] = request.args  # type: ignore
+
         # extract query params
-        action_name = parse_string(request, "action_name")
+        actions = parse_strings_from_args(args, "action_name")
         resource_id = parse_string(request, "resource_id")
-        status = parse_string(request, "status")
+        status_strings = parse_strings_from_args(
+            args,
+            "status",
+            allowed_values=[status.value for status in TaskStatus],
+        )
         # This parameter was historically called `job_status`, while the Admin API docs
         # defined it as `status`. We now support both, as `status` is generally
         # a nicer name. A v2 of this endpoint should keep only `status`.
-        if status is None:
-            status = parse_string(request, "job_status")
+        if status_strings is None:
+            status_strings = parse_strings_from_args(
+                args,
+                "job_status",
+                allowed_values=[status.value for status in TaskStatus],
+            )
         max_timestamp = parse_integer(request, "max_timestamp")
 
-        actions = [action_name] if action_name else None
-        statuses = [TaskStatus(status)] if status else None
+        statuses = (
+            [TaskStatus(status) for status in status_strings]
+            if status_strings
+            else None
+        )
 
         tasks = await self._store.get_scheduled_tasks(
             actions=actions,

--- a/tests/rest/admin/test_scheduled_tasks.py
+++ b/tests/rest/admin/test_scheduled_tasks.py
@@ -190,3 +190,56 @@ class ScheduledTasksAdminApiTestCase(unittest.HomeserverTestCase):
         # only the task with the matching resource id should have been returned
         self.assertEqual(len(found_tasks), 1)
         self.assertEqual(found_tasks[0]["resource_id"], "failed_task")
+
+    def test_filtering_scheduled_tasks_multiple_values(self) -> None:
+        """
+        Test that the `action_name` and `status` filters can be given multiple
+        times, returning tasks matching any of the given values.
+        """
+        # filter via multiple statuses
+        channel = self.make_request(
+            "GET",
+            "/_synapse/admin/v1/scheduled_tasks?status=active&status=failed",
+            content={},
+            access_token=self.admin_user_tok,
+        )
+        self.assertEqual(200, channel.code, msg=channel.json_body)
+        found_tasks = self.check_scheduled_tasks_response(
+            channel.json_body["scheduled_tasks"]
+        )
+
+        # the active and failed tasks should have been returned
+        self.assertEqual(len(found_tasks), 2)
+        self.assertEqual({task["status"] for task in found_tasks}, {"active", "failed"})
+
+        # filter via multiple action names
+        channel = self.make_request(
+            "GET",
+            "/_synapse/admin/v1/scheduled_tasks?action_name=test_task&action_name=finished_test_task",
+            content={},
+            access_token=self.admin_user_tok,
+        )
+        self.assertEqual(200, channel.code, msg=channel.json_body)
+        found_tasks = self.check_scheduled_tasks_response(
+            channel.json_body["scheduled_tasks"]
+        )
+
+        # only the tasks with the given action names should have been returned
+        self.assertEqual(len(found_tasks), 2)
+        self.assertEqual(
+            {task["action"] for task in found_tasks},
+            {"test_task", "finished_test_task"},
+        )
+
+    def test_filtering_scheduled_tasks_invalid_status(self) -> None:
+        """
+        Test that an invalid `status` value is rejected with a 400 error.
+        """
+        channel = self.make_request(
+            "GET",
+            "/_synapse/admin/v1/scheduled_tasks?status=unknown_status",
+            content={},
+            access_token=self.admin_user_tok,
+        )
+        self.assertEqual(400, channel.code, msg=channel.json_body)
+        self.assertEqual(Codes.INVALID_PARAM, channel.json_body["errcode"])


### PR DESCRIPTION
We have an internal usage of `/scheduled_tasks` that would like to fetch multiple actions at once (janitor).

We also make it so that invalid `status` values now return a 400 rather than a 500.