### PR TITLE
Speed up the room hierarchy endpoints (parallelise + cache)

### DIFF
--- a/changelog.d/20078.misc
+++ b/changelog.d/20078.misc
@@ -1,0 +1,1 @@
+Speed up the room hierarchy endpoints by parallelising the traversal and caching per-room summaries, invalidated when the underlying data changes.

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -50,7 +50,8 @@ from synapse.logging.context import make_deferred_yieldable, run_in_background
 from synapse.storage.databases.main.state import RoomHierarchyState
 from synapse.types import JsonDict, JsonMapping, Requester, StateMap, StrCollection
 from synapse.types.state import StateFilter
-from synapse.util.async_helpers import yieldable_gather_results
+from synapse.util import unwrapFirstError
+from synapse.util.async_helpers import gather_results, yieldable_gather_results
 from synapse.util.caches.response_cache import ResponseCache
 
 if TYPE_CHECKING:
@@ -581,15 +582,46 @@ class RoomSummaryHandler:
         Returns:
             A room entry if the room should be returned. None, otherwise.
         """
+
         # Fast path: serve the entry entirely from the cached room hierarchy
         # state + room stats (both invalidated when the underlying data
         # changes), so a warm request does no DB work at all. Partial-state
         # rooms fall back to the uncached path, as their cached current state
         # may be incomplete; unknown rooms fall back for the pending-invite
         # handling.
-        hierarchy_state = None
-        if not await self._store.is_partial_state_room(room_id):
-            hierarchy_state = await self._store.get_room_hierarchy_state(room_id)
+        #
+        # The per-room lookups are independent, so run them (including warming
+        # the room-stats / room-version caches read later in this path)
+        # concurrently: on a cold cache a serial chain here would otherwise
+        # undo the traversal-level parallelism on latency-bound deployments.
+        async def prime_room_version() -> None:
+            try:
+                await self._store.get_room_version(room_id)
+            except (NotFoundError, UnsupportedRoomVersionError):
+                pass
+
+        is_partial_state, hierarchy_state, _, _ = await make_deferred_yieldable(
+            gather_results(
+                (
+                    # NB lambdas as run_in_background's typing rejects @cached methods.
+                    run_in_background(
+                        lambda: self._store.is_partial_state_room(room_id)
+                    ),
+                    run_in_background(
+                        lambda: self._store.get_room_hierarchy_state(room_id)
+                    ),
+                    run_in_background(lambda: self._store.get_room_with_stats(room_id)),
+                    run_in_background(prime_room_version),
+                ),
+                consumeErrors=True,
+            )
+        ).addErrback(unwrapFirstError)
+        if is_partial_state:
+            # The value cached just now may have been computed from partial
+            # state: drop it and use the uncached path (which resolves state
+            # via the storage controllers).
+            self._store.get_room_hierarchy_state.invalidate((room_id,))
+            hierarchy_state = None
         if hierarchy_state is None:
             return await self._summarize_local_room_uncached(
                 requester,

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -26,6 +26,8 @@ from typing import TYPE_CHECKING, Iterable, Optional, Sequence
 
 import attr
 
+from twisted.internet.defer import Deferred
+
 from synapse.api.constants import (
     EventTypes,
     HistoryVisibility,
@@ -44,8 +46,10 @@ from synapse.api.errors import (
 from synapse.api.ratelimiting import Ratelimiter
 from synapse.config.ratelimiting import RatelimitSettings
 from synapse.events import EventBase
-from synapse.types import JsonDict, Requester, StrCollection
+from synapse.logging.context import make_deferred_yieldable, run_in_background
+from synapse.types import JsonDict, Requester, StateMap, StrCollection
 from synapse.types.state import StateFilter
+from synapse.util.async_helpers import yieldable_gather_results
 from synapse.util.caches.response_cache import ResponseCache
 
 if TYPE_CHECKING:
@@ -61,6 +65,10 @@ MAX_ROOMS_PER_SPACE = 50
 
 # max number of federation servers to hit per room
 MAX_SERVERS_PER_SPACE = 3
+
+# number of upcoming rooms whose summaries (local DB reads or remote federation
+# requests) are fetched concurrently, ahead of the strictly-ordered traversal.
+PREFETCH_SUMMARIES = 10
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
@@ -291,9 +299,44 @@ class RoomSummaryHandler:
         else:
             limit = min(limit, MAX_ROOMS)
 
+        # Prefetched summaries for upcoming rooms, keyed by room ID. The next rooms
+        # in traversal order sit at the top of the stack, so their summaries (DB
+        # reads for local rooms, federation requests for remote subspaces) can be
+        # fetched concurrently while results are still emitted strictly in
+        # traversal order. Values are ("ok", result) / ("err", exception) so that a
+        # prefetch which is never consumed (page limit hit first) cannot produce an
+        # unhandled error.
+        prefetched: dict[str, "Deferred"] = {}
+
+        async def prefetch(
+            entry: _RoomQueueEntry,
+        ) -> tuple[str, object]:
+            try:
+                return (
+                    "ok",
+                    await self._summarize_queue_entry(
+                        entry,
+                        requester,
+                        suggested_only,
+                        max_depth,
+                        omit_remote_room_hierarchy,
+                        admin_skip_room_visibility_check,
+                    ),
+                )
+            except Exception as e:
+                return ("err", e)
+
         # Iterate through the queue until we reach the limit or run out of
         # rooms to include.
         while room_queue and len(rooms_result) < limit:
+            # Kick off summary fetches for the next few rooms in traversal order.
+            for upcoming in room_queue[-PREFETCH_SUMMARIES:]:
+                if (
+                    upcoming.room_id not in processed_rooms
+                    and upcoming.room_id not in prefetched
+                ):
+                    prefetched[upcoming.room_id] = run_in_background(prefetch, upcoming)
+
             queue_entry = room_queue.pop()
             room_id = queue_entry.room_id
             current_depth = queue_entry.depth
@@ -303,62 +346,31 @@ class RoomSummaryHandler:
 
             logger.debug("Processing room %s", room_id)
 
-            # A map of summaries for children rooms that might be returned over
-            # federation. The rationale for caching these and *maybe* using them
-            # is to prefer any information local to the homeserver before trusting
-            # data received over federation.
-            children_room_entries: dict[str, JsonDict] = {}
-            # A set of room IDs which are children that did not have information
-            # returned over federation and are known to be inaccessible to the
-            # current server. We should not reach out over federation to try to
-            # summarise these rooms.
-            inaccessible_children: set[str] = set()
+            deferred = prefetched.pop(room_id, None)
+            if deferred is None:
+                deferred = run_in_background(prefetch, queue_entry)
+            status, value = await make_deferred_yieldable(deferred)
+            if status == "err":
+                assert isinstance(value, Exception)
+                raise value
+            assert isinstance(value, tuple)
+            (
+                room_entry,
+                children_room_entries,
+                inaccessible_children,
+                is_remote,
+            ) = value
 
-            # If the room is known locally, summarise it!
-            is_in_room = await self._store.is_host_joined(room_id, self._server_name)
-            if is_in_room:
-                room_entry = await self._summarize_local_room(
-                    requester,
-                    None,
-                    room_id,
-                    suggested_only,
-                    admin_skip_room_visibility_check=admin_skip_room_visibility_check,
+            # Ensure a remote room is accessible to the requester (and not just
+            # the homeserver).
+            if (
+                is_remote
+                and room_entry
+                and not await self._is_remote_room_accessible(
+                    requester, room_id, room_entry.room
                 )
-
-            # Otherwise, attempt to use information for federation.
-            else:
-                # A previous call might have included information for this room.
-                # It can be used if either:
-                #
-                # 1. The room is not a space.
-                # 2. The maximum depth has been achieved (since no children
-                #    information is needed).
-                if queue_entry.remote_room and (
-                    queue_entry.remote_room.get("room_type") != RoomTypes.SPACE
-                    or (max_depth is not None and current_depth >= max_depth)
-                ):
-                    room_entry = _RoomEntry(
-                        queue_entry.room_id, queue_entry.remote_room
-                    )
-
-                # If the above isn't true, attempt to fetch the room
-                # information over federation.
-                elif not omit_remote_room_hierarchy:
-                    (
-                        room_entry,
-                        children_room_entries,
-                        inaccessible_children,
-                    ) = await self._summarize_remote_room_hierarchy(
-                        queue_entry,
-                        suggested_only,
-                    )
-
-                # Ensure this room is accessible to the requester (and not just
-                # the homeserver).
-                if room_entry and not await self._is_remote_room_accessible(
-                    requester, queue_entry.room_id, room_entry.room
-                ):
-                    room_entry = None
+            ):
+                room_entry = None
 
             # This room has been processed and should be ignored if it appears
             # elsewhere in the hierarchy.
@@ -413,6 +425,57 @@ class RoomSummaryHandler:
 
         return result
 
+    async def _summarize_queue_entry(
+        self,
+        entry: "_RoomQueueEntry",
+        requester: str,
+        suggested_only: bool,
+        max_depth: int | None,
+        omit_remote_room_hierarchy: bool,
+        admin_skip_room_visibility_check: bool,
+    ) -> tuple[Optional["_RoomEntry"], dict[str, JsonDict], set[str], bool]:
+        """Fetch the summary for one hierarchy queue entry.
+
+        Returns (room entry, child summaries received over federation, children
+        known to be inaccessible over federation, whether the room is remote).
+        The remote-room *requester* accessibility check is left to the caller.
+        """
+        # If the room is known locally, summarise it!
+        is_in_room = await self._store.is_host_joined(entry.room_id, self._server_name)
+        if is_in_room:
+            room_entry = await self._summarize_local_room(
+                requester,
+                None,
+                entry.room_id,
+                suggested_only,
+                admin_skip_room_visibility_check=admin_skip_room_visibility_check,
+            )
+            return room_entry, {}, set(), False
+
+        # Otherwise, a previous call might have included information for this
+        # room. It can be used if either:
+        #
+        # 1. The room is not a space.
+        # 2. The maximum depth has been achieved (since no children
+        #    information is needed).
+        if entry.remote_room and (
+            entry.remote_room.get("room_type") != RoomTypes.SPACE
+            or (max_depth is not None and entry.depth >= max_depth)
+        ):
+            return _RoomEntry(entry.room_id, entry.remote_room), {}, set(), True
+
+        # If the above isn't true, attempt to fetch the room information over
+        # federation.
+        if not omit_remote_room_hierarchy:
+            (
+                room_entry,
+                children_room_entries,
+                inaccessible_children,
+            ) = await self._summarize_remote_room_hierarchy(entry, suggested_only)
+            return room_entry, children_room_entries, inaccessible_children, True
+
+        return None, {}, set(), True
+
     async def get_federation_hierarchy(
         self,
         origin: str,
@@ -445,20 +508,30 @@ class RoomSummaryHandler:
         children_rooms_result: list[JsonDict] = []
         inaccessible_children: list[str] = []
 
-        # Iterate through each child and potentially add it, but not its children,
-        # to the response.
+        child_ids: list[str] = []
         for child_room in itertools.islice(
             root_room_entry.children_state_events, MAX_ROOMS_PER_SPACE
         ):
             room_id = child_room.get("state_key")
             assert isinstance(room_id, str)
+            child_ids.append(room_id)
+
+        async def summarize_child(
+            room_id: str,
+        ) -> tuple[str, Optional["_RoomEntry"]] | None:
             # If the room is unknown, skip it.
             if not await self._store.is_host_joined(room_id, self._server_name):
-                continue
-
-            room_entry = await self._summarize_local_room(
+                return None
+            return room_id, await self._summarize_local_room(
                 None, origin, room_id, suggested_only, include_children=False
             )
+
+        # Summarise each child (but not its children) concurrently, adding them
+        # to the response in their original order.
+        for result in await yieldable_gather_results(summarize_child, child_ids):
+            if result is None:
+                continue
+            room_id, room_entry = result
             # If the room is accessible, include it in the results.
             #
             # Note that only the room summary (without information on children)
@@ -507,20 +580,38 @@ class RoomSummaryHandler:
         Returns:
             A room entry if the room should be returned. None, otherwise.
         """
+        # A single filtered current-state fetch covers the accessibility check,
+        # the restricted-join-rules lookup in _build_room_entry AND the
+        # space-child edges, instead of three separate (and, for the child
+        # events, previously unfiltered) current-state fetches per room.
+        event_types: list[tuple[str, str | None]] = [
+            (EventTypes.JoinRules, ""),
+            (EventTypes.RoomHistoryVisibility, ""),
+        ]
+        if requester:
+            event_types.append((EventTypes.Member, requester))
+        if include_children:
+            event_types.append((EventTypes.SpaceChild, None))
+        state_ids = await self._storage_controllers.state.get_current_state_ids(
+            room_id, state_filter=StateFilter.from_types(event_types)
+        )
+
         if (
             not admin_skip_room_visibility_check
-            and not await self._is_local_room_accessible(room_id, requester, origin)
+            and not await self._is_local_room_accessible(
+                room_id, requester, origin, state_ids
+            )
         ):
             return None
 
-        room_entry = await self._build_room_entry(room_id)
+        room_entry = await self._build_room_entry(room_id, state_ids)
 
         # If the room is not a space return just the room information.
         if room_entry.get("room_type") != RoomTypes.SPACE or not include_children:
             return _RoomEntry(room_id, room_entry)
 
         # Otherwise, look for child rooms/spaces.
-        child_events = await self._get_child_events(room_id)
+        child_events = await self._get_child_events(room_id, state_ids)
 
         if suggested_only:
             # we only care about suggested children
@@ -593,7 +684,11 @@ class RoomSummaryHandler:
         )
 
     async def _is_local_room_accessible(
-        self, room_id: str, requester: str | None, origin: str | None = None
+        self,
+        room_id: str,
+        requester: str | None,
+        origin: str | None = None,
+        state_ids: StateMap[str] | None = None,
     ) -> bool:
         """
         Calculate whether the room should be shown to the requester.
@@ -616,16 +711,17 @@ class RoomSummaryHandler:
         Returns:
              True if the room is accessible to the requesting user or server.
         """
-        event_types = [
-            (EventTypes.JoinRules, ""),
-            (EventTypes.RoomHistoryVisibility, ""),
-        ]
-        if requester:
-            event_types.append((EventTypes.Member, requester))
+        if state_ids is None:
+            event_types = [
+                (EventTypes.JoinRules, ""),
+                (EventTypes.RoomHistoryVisibility, ""),
+            ]
+            if requester:
+                event_types.append((EventTypes.Member, requester))
 
-        state_ids = await self._storage_controllers.state.get_current_state_ids(
-            room_id, state_filter=StateFilter.from_types(event_types)
-        )
+            state_ids = await self._storage_controllers.state.get_current_state_ids(
+                room_id, state_filter=StateFilter.from_types(event_types)
+            )
 
         # If there's no state for the room, it isn't known.
         if not state_ids:
@@ -769,12 +865,16 @@ class RoomSummaryHandler:
         # pending invite, etc.
         return await self._is_local_room_accessible(room_id, requester)
 
-    async def _build_room_entry(self, room_id: str) -> JsonDict:
+    async def _build_room_entry(
+        self, room_id: str, state_ids: StateMap[str] | None = None
+    ) -> JsonDict:
         """
         Generate en entry summarising a single room.
 
         Args:
             room_id: The room ID to summarize.
+            state_ids: A current-state map for the room which includes the join
+                rules event, if already fetched by the caller.
 
         Returns:
             The JSON dictionary for the room.
@@ -807,12 +907,15 @@ class RoomSummaryHandler:
         # clients can determine which memberships grant access.
         # Only the join rules event is needed for both has_restricted_join_rules
         # and get_rooms_that_allow_join, so avoid fetching full state.
-        join_rules_state_ids = (
-            await self._storage_controllers.state.get_current_state_ids(
-                room_id,
-                state_filter=StateFilter.from_types([(EventTypes.JoinRules, "")]),
+        if state_ids is not None:
+            join_rules_state_ids = state_ids
+        else:
+            join_rules_state_ids = (
+                await self._storage_controllers.state.get_current_state_ids(
+                    room_id,
+                    state_filter=StateFilter.from_types([(EventTypes.JoinRules, "")]),
+                )
             )
-        )
 
         try:
             room_version = await self._store.get_room_version(room_id)
@@ -833,7 +936,9 @@ class RoomSummaryHandler:
 
         return room_entry
 
-    async def _get_child_events(self, room_id: str) -> Iterable[EventBase]:
+    async def _get_child_events(
+        self, room_id: str, state_ids: StateMap[str] | None = None
+    ) -> Iterable[EventBase]:
         """
         Get the child events for a given room.
 
@@ -841,15 +946,26 @@ class RoomSummaryHandler:
 
         Args:
             room_id: The room id to get the children of.
+            state_ids: A current-state map for the room which includes the
+                m.space.child events, if already fetched by the caller.
 
         Returns:
             An iterable of sorted child events.
         """
 
-        # look for child rooms/spaces.
-        current_state_ids = await self._storage_controllers.state.get_current_state_ids(
-            room_id
-        )
+        # look for child rooms/spaces. Filter to just the m.space.child events
+        # rather than fetching the room's full current state.
+        if state_ids is not None:
+            current_state_ids = state_ids
+        else:
+            current_state_ids = (
+                await self._storage_controllers.state.get_current_state_ids(
+                    room_id,
+                    state_filter=StateFilter.from_types(
+                        [(EventTypes.SpaceChild, None)]
+                    ),
+                )
+            )
 
         events = await self._store.get_events_as_list(
             [

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -51,7 +51,7 @@ from synapse.storage.databases.main.state import RoomHierarchyState
 from synapse.types import JsonDict, JsonMapping, Requester, StateMap, StrCollection
 from synapse.types.state import StateFilter
 from synapse.util import unwrapFirstError
-from synapse.util.async_helpers import gather_results, yieldable_gather_results
+from synapse.util.async_helpers import concurrently_execute, gather_results
 from synapse.util.caches.response_cache import ResponseCache
 
 if TYPE_CHECKING:
@@ -71,6 +71,10 @@ MAX_SERVERS_PER_SPACE = 3
 # number of upcoming rooms whose summaries (local DB reads or remote federation
 # requests) are fetched concurrently, ahead of the strictly-ordered traversal.
 PREFETCH_SUMMARIES = 10
+
+# how many of a space's children are summarised at once when responding to a
+# federation hierarchy request.
+CHILD_SUMMARY_CONCURRENCY = 10
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
@@ -331,8 +335,17 @@ class RoomSummaryHandler:
         # Iterate through the queue until we reach the limit or run out of
         # rooms to include.
         while room_queue and len(rooms_result) < limit:
-            # Kick off summary fetches for the next few rooms in traversal order.
-            for upcoming in room_queue[-PREFETCH_SUMMARIES:]:
+            # Kick off summary fetches for the next few rooms in traversal
+            # order, but never for more rooms than are still needed to fill the
+            # page: each one may be a federation request, and any we do not
+            # consume is wasted (and would be re-issued for the next page).
+            window = min(PREFETCH_SUMMARIES, limit - len(rooms_result))
+            # NB reversed(): the queue is a stack, so the LAST entries are
+            # processed first. The same room can appear in the queue more than
+            # once (a room linked from two spaces; the queue is only deduped at
+            # pop time), and the entry carries the via/depth used to summarise
+            # it — so the entry registered here must be the one popped first.
+            for upcoming in reversed(room_queue[-window:]):
                 if (
                     upcoming.room_id not in processed_rooms
                     and upcoming.room_id not in prefetched
@@ -518,19 +531,31 @@ class RoomSummaryHandler:
             assert isinstance(room_id, str)
             child_ids.append(room_id)
 
-        async def summarize_child(
-            room_id: str,
-        ) -> tuple[str, Optional["_RoomEntry"]] | None:
+        summaries: list[tuple[str, Optional["_RoomEntry"]] | None] = [None] * len(
+            child_ids
+        )
+
+        async def summarize_child(indexed_room_id: tuple[int, str]) -> None:
+            index, room_id = indexed_room_id
             # If the room is unknown, skip it.
             if not await self._store.is_host_joined(room_id, self._server_name):
-                return None
-            return room_id, await self._summarize_local_room(
-                None, origin, room_id, suggested_only, include_children=False
+                return
+            summaries[index] = (
+                room_id,
+                await self._summarize_local_room(
+                    None, origin, room_id, suggested_only, include_children=False
+                ),
             )
 
         # Summarise each child (but not its children) concurrently, adding them
-        # to the response in their original order.
-        for result in await yieldable_gather_results(summarize_child, child_ids):
+        # to the response in their original order. This endpoint is reachable by
+        # any federating server and each summary itself fans out, so cap how
+        # many run at once rather than issuing all MAX_ROOMS_PER_SPACE at once.
+        await concurrently_execute(
+            summarize_child, list(enumerate(child_ids)), CHILD_SUMMARY_CONCURRENCY
+        )
+
+        for result in summaries:
             if result is None:
                 continue
             room_id, room_entry = result
@@ -600,7 +625,7 @@ class RoomSummaryHandler:
             except (NotFoundError, UnsupportedRoomVersionError):
                 pass
 
-        is_partial_state, hierarchy_state, _, _ = await make_deferred_yieldable(
+        is_partial_state, hierarchy_state, stats, _ = await make_deferred_yieldable(
             gather_results(
                 (
                     # NB lambdas as run_in_background's typing rejects @cached methods.
@@ -631,6 +656,12 @@ class RoomSummaryHandler:
                 include_children,
                 admin_skip_room_visibility_check,
             )
+
+        if stats is None:
+            # We have state for the room but no row in the rooms table, so there
+            # is nothing to summarise. _build_room_entry would assert.
+            logger.info("room %s has no room entry, omitting from summary", room_id)
+            return None
 
         if (
             not admin_skip_room_visibility_check

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -312,7 +312,14 @@ class RoomSummaryHandler:
         # traversal order. Values are ("ok", result) / ("err", exception) so that a
         # prefetch which is never consumed (page limit hit first) cannot produce an
         # unhandled error.
-        prefetched: dict[str, "Deferred"] = {}
+        #
+        # The queue entry a summary was computed for is kept alongside it: the
+        # same room can be queued more than once (linked from two spaces; the
+        # queue is only deduplicated when popped), each entry carrying the
+        # via/depth to summarise that edge with, and an entry queued later can
+        # be popped first. A prefetch is therefore only usable by the very entry
+        # it was started for.
+        prefetched: dict[str, tuple[_RoomQueueEntry, "Deferred"]] = {}
 
         async def prefetch(
             entry: _RoomQueueEntry,
@@ -341,16 +348,18 @@ class RoomSummaryHandler:
             # consume is wasted (and would be re-issued for the next page).
             window = min(PREFETCH_SUMMARIES, limit - len(rooms_result))
             # NB reversed(): the queue is a stack, so the LAST entries are
-            # processed first. The same room can appear in the queue more than
-            # once (a room linked from two spaces; the queue is only deduped at
-            # pop time), and the entry carries the via/depth used to summarise
-            # it — so the entry registered here must be the one popped first.
+            # processed first, and prefetching them in that order means the
+            # entry that is popped next is the one whose summary is furthest
+            # along.
             for upcoming in reversed(room_queue[-window:]):
                 if (
                     upcoming.room_id not in processed_rooms
                     and upcoming.room_id not in prefetched
                 ):
-                    prefetched[upcoming.room_id] = run_in_background(prefetch, upcoming)
+                    prefetched[upcoming.room_id] = (
+                        upcoming,
+                        run_in_background(prefetch, upcoming),
+                    )
 
             queue_entry = room_queue.pop()
             room_id = queue_entry.room_id
@@ -361,8 +370,12 @@ class RoomSummaryHandler:
 
             logger.debug("Processing room %s", room_id)
 
-            deferred = prefetched.pop(room_id, None)
-            if deferred is None:
+            # Only use a prefetch that was started for THIS entry: another
+            # entry for the same room carries a different via/depth, and would
+            # summarise a different edge. Any other prefetch is discarded (its
+            # errors are already captured in its result tuple).
+            prefetch_entry, deferred = prefetched.pop(room_id, (None, None))
+            if prefetch_entry is not queue_entry or deferred is None:
                 deferred = run_in_background(prefetch, queue_entry)
             status, value = await make_deferred_yieldable(deferred)
             if status == "err":

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -47,7 +47,8 @@ from synapse.api.ratelimiting import Ratelimiter
 from synapse.config.ratelimiting import RatelimitSettings
 from synapse.events import EventBase
 from synapse.logging.context import make_deferred_yieldable, run_in_background
-from synapse.types import JsonDict, Requester, StateMap, StrCollection
+from synapse.storage.databases.main.state import RoomHierarchyState
+from synapse.types import JsonDict, JsonMapping, Requester, StateMap, StrCollection
 from synapse.types.state import StateFilter
 from synapse.util.async_helpers import yieldable_gather_results
 from synapse.util.caches.response_cache import ResponseCache
@@ -580,6 +581,63 @@ class RoomSummaryHandler:
         Returns:
             A room entry if the room should be returned. None, otherwise.
         """
+        # Fast path: serve the entry entirely from the cached room hierarchy
+        # state + room stats (both invalidated when the underlying data
+        # changes), so a warm request does no DB work at all. Partial-state
+        # rooms fall back to the uncached path, as their cached current state
+        # may be incomplete; unknown rooms fall back for the pending-invite
+        # handling.
+        hierarchy_state = None
+        if not await self._store.is_partial_state_room(room_id):
+            hierarchy_state = await self._store.get_room_hierarchy_state(room_id)
+        if hierarchy_state is None:
+            return await self._summarize_local_room_uncached(
+                requester,
+                origin,
+                room_id,
+                suggested_only,
+                include_children,
+                admin_skip_room_visibility_check,
+            )
+
+        if (
+            not admin_skip_room_visibility_check
+            and not await self._is_local_room_accessible_from_summary(
+                room_id, hierarchy_state, requester, origin
+            )
+        ):
+            return None
+
+        room_entry = await self._build_room_entry(
+            room_id, hierarchy_state.join_rules_state_ids
+        )
+
+        # If the room is not a space return just the room information.
+        if room_entry.get("room_type") != RoomTypes.SPACE or not include_children:
+            return _RoomEntry(room_id, room_entry)
+
+        child_events = sorted(
+            filter(_stripped_child_has_valid_via, hierarchy_state.children),
+            key=_stripped_child_comparison_key,
+        )
+        if suggested_only:
+            child_events = [
+                e for e in child_events if e["content"].get("suggested") is True
+            ]
+        return _RoomEntry(room_id, room_entry, child_events)
+
+    async def _summarize_local_room_uncached(
+        self,
+        requester: str | None,
+        origin: str | None,
+        room_id: str,
+        suggested_only: bool,
+        include_children: bool = True,
+        admin_skip_room_visibility_check: bool = False,
+    ) -> Optional["_RoomEntry"]:
+        """The uncached path of `_summarize_local_room` (see its docstring):
+        used for partial-state rooms and rooms with no local state.
+        """
         # A single filtered current-state fetch covers the accessibility check,
         # the restricted-join-rules lookup in _build_room_entry AND the
         # space-child edges, instead of three separate (and, for the child
@@ -805,6 +863,93 @@ class RoomSummaryHandler:
             ):
                 allowed_rooms = (
                     await self._event_auth_handler.get_rooms_that_allow_join(state_ids)
+                )
+                for space_id in allowed_rooms:
+                    if await self._event_auth_handler.is_host_in_room(space_id, origin):
+                        return True
+
+        logger.info(
+            "room %s is unpeekable and requester %s is not a member / not allowed to join, omitting from summary",
+            room_id,
+            requester or origin,
+        )
+        return False
+
+    async def _is_local_room_accessible_from_summary(
+        self,
+        room_id: str,
+        hierarchy_state: RoomHierarchyState,
+        requester: str | None,
+        origin: str | None = None,
+    ) -> bool:
+        """The cached-path equivalent of `_is_local_room_accessible` (same
+        semantics, see its docstring): decides access from the cached
+        authoritative join rule / history visibility plus per-user (or
+        per-server) cached membership lookups, without fetching room state.
+        """
+        try:
+            room_version = await self._store.get_room_version(room_id)
+        except UnsupportedRoomVersionError:
+            # If a room with an unsupported room version is encountered, ignore
+            # it to avoid breaking the entire summary response.
+            return False
+
+        # Include the room if it has join rules of public or knock.
+        join_rule = hierarchy_state.join_rule
+        if (
+            join_rule == JoinRules.PUBLIC
+            or (room_version.knock_join_rule and join_rule == JoinRules.KNOCK)
+            or (
+                room_version.knock_restricted_join_rule
+                and join_rule == JoinRules.KNOCK_RESTRICTED
+            )
+        ):
+            return True
+
+        # Include the room if it is peekable.
+        if hierarchy_state.history_visibility == HistoryVisibility.WORLD_READABLE:
+            return True
+
+        # Otherwise we need to check information specific to the user or server.
+        if requester:
+            # If they're in the room (or invited) they can see info on it.
+            if room_id in await self._store.get_rooms_for_user(requester):
+                return True
+            if await self._store.get_invite_for_local_user_in_room(requester, room_id):
+                return True
+
+            # Otherwise, check if they should be allowed access via membership in a space.
+            if await self._event_auth_handler.has_restricted_join_rules(
+                hierarchy_state.join_rules_state_ids, room_version
+            ):
+                allowed_rooms = (
+                    await self._event_auth_handler.get_rooms_that_allow_join(
+                        hierarchy_state.join_rules_state_ids
+                    )
+                )
+                if await self._event_auth_handler.is_user_in_rooms(
+                    allowed_rooms, requester
+                ):
+                    return True
+
+        # If this is a request over federation, check if the host is in the room or
+        # has a user who could join the room.
+        elif origin:
+            if await self._event_auth_handler.is_host_in_room(
+                room_id, origin
+            ) or await self._store.is_host_invited(room_id, origin):
+                return True
+
+            # Alternately, if the host has a user in any of the spaces specified
+            # for access, then the host can see this room (and should do filtering
+            # if the requester cannot see it).
+            if await self._event_auth_handler.has_restricted_join_rules(
+                hierarchy_state.join_rules_state_ids, room_version
+            ):
+                allowed_rooms = (
+                    await self._event_auth_handler.get_rooms_that_allow_join(
+                        hierarchy_state.join_rules_state_ids
+                    )
                 )
                 for space_id in allowed_rooms:
                     if await self._event_auth_handler.is_host_in_room(space_id, origin):
@@ -1092,7 +1237,7 @@ class _RoomEntry:
     # An iterable of the sorted, stripped children events for children of this room.
     #
     # This may not include all children.
-    children_state_events: Sequence[JsonDict] = ()
+    children_state_events: Sequence[JsonMapping] = ()
 
     def as_json(self, for_client: bool = False) -> JsonDict:
         """
@@ -1115,6 +1260,30 @@ class _RoomEntry:
 
         result["children_state"] = self.children_state_events
         return result
+
+
+def _stripped_child_has_valid_via(e: JsonMapping) -> bool:
+    """`_has_valid_via` for the stripped child dicts of a cached RoomHierarchyState."""
+    via = e["content"].get("via")
+    if not via or not isinstance(via, list):
+        return False
+    return all(isinstance(v, str) for v in via)
+
+
+def _stripped_child_comparison_key(
+    child: JsonMapping,
+) -> tuple[bool, str | None, int, str]:
+    """`_child_events_comparison_key` for the stripped child dicts of a cached
+    RoomHierarchyState. Ties beyond origin_server_ts break on the child room id
+    (the state key), per MSC2946.
+    """
+    order = child["content"].get("order")
+    if not isinstance(order, str):
+        order = None
+    elif len(order) > 50 or _INVALID_ORDER_CHARS_RE.search(order):
+        order = None
+
+    return order is None, order, child["origin_server_ts"], child["state_key"]
 
 
 def _has_valid_via(e: EventBase) -> bool:

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -1351,7 +1351,7 @@ def _child_events_comparison_key(
 
     1. The 'order' key, if it is valid.
     2. The 'origin_server_ts' of the 'm.space.child' event.
-    3. The 'room_id'.
+    3. The child room ID (the event's state key).
 
     Args:
         child: The event for generating a comparison key.
@@ -1361,7 +1361,7 @@ def _child_events_comparison_key(
             False if the ordering is valid.
             The 'order' field or None if it is not given or invalid.
             The 'origin_server_ts' field.
-            The room ID.
+            The child room ID.
     """
     order = child.content.get("order")
     # If order is not a string or doesn't meet the requirements, ignore it.
@@ -1371,4 +1371,8 @@ def _child_events_comparison_key(
         order = None
 
     # Items without an order come last.
-    return order is None, order, child.origin_server_ts, child.room_id
+    #
+    # NB the final tie-break is the CHILD room id (the state key), not the room
+    # the event lives in — that is the same for every child of a space, so it
+    # never actually broke a tie.
+    return order is None, order, child.origin_server_ts, child.state_key

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -139,6 +139,7 @@ class SQLBaseStore(metaclass=ABCMeta):
         self._attempt_to_invalidate_cache("get_partial_current_state_ids", (room_id,))
         self._attempt_to_invalidate_cache("get_room_type", (room_id,))
         self._attempt_to_invalidate_cache("get_room_encryption", (room_id,))
+        self._attempt_to_invalidate_cache("get_room_hierarchy_state", (room_id,))
         self._attempt_to_invalidate_cache(
             "get_sliding_sync_rooms_for_user_from_membership_snapshots", None
         )
@@ -171,6 +172,7 @@ class SQLBaseStore(metaclass=ABCMeta):
         self._attempt_to_invalidate_cache("get_room_summary", (room_id,))
         self._attempt_to_invalidate_cache("get_room_type", (room_id,))
         self._attempt_to_invalidate_cache("get_room_encryption", (room_id,))
+        self._attempt_to_invalidate_cache("get_room_hierarchy_state", (room_id,))
         self._attempt_to_invalidate_cache(
             "get_sliding_sync_rooms_for_user_from_membership_snapshots", None
         )

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -482,6 +482,11 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
         elif etype == EventTypes.RoomEncryption:
             self._attempt_to_invalidate_cache("get_room_encryption", (room_id,))
 
+        if state_key is not None:
+            # Any state change may affect the room's hierarchy (space summary)
+            # entry: m.space.child edges, join rules, history visibility, etc.
+            self._attempt_to_invalidate_cache("get_room_hierarchy_state", (room_id,))
+
         if (etype, state_key) in SLIDING_SYNC_RELEVANT_STATE_SET:
             self._attempt_to_invalidate_cache(
                 "get_sliding_sync_rooms_for_user_from_membership_snapshots", None
@@ -553,6 +558,7 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
         self._attempt_to_invalidate_cache("get_threads", (room_id,))
         self._attempt_to_invalidate_cache("get_room_type", (room_id,))
         self._attempt_to_invalidate_cache("get_room_encryption", (room_id,))
+        self._attempt_to_invalidate_cache("get_room_hierarchy_state", (room_id,))
 
         self._attempt_to_invalidate_cache("_get_state_group_for_event", None)
 
@@ -612,6 +618,8 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
         self._attempt_to_invalidate_cache("get_room_version_id", (room_id,))
         self._attempt_to_invalidate_cache("get_room_type", (room_id,))
         self._attempt_to_invalidate_cache("get_room_encryption", (room_id,))
+        self._attempt_to_invalidate_cache("get_room_hierarchy_state", (room_id,))
+        self._attempt_to_invalidate_cache("get_room_with_stats", (room_id,))
 
         self._attempt_to_invalidate_cache("_get_max_event_pos", (room_id,))
 

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -404,6 +404,11 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
             logger.error("store_room with room_id=%s failed: %s", room_id, e)
             raise StoreError(500, "Problem creating room.")
 
+        # The room may have been looked up before we had a row for it (e.g. a
+        # remote server asking us to summarise it), caching a None; the stats
+        # writer only invalidates once it catches up.
+        await self.invalidate_cache_and_stream("get_room_with_stats", (room_id,))
+
     async def get_room(self, room_id: str) -> tuple[bool, bool] | None:
         """Retrieve a room.
 
@@ -2489,6 +2494,9 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
                 "has_auth_chain_index": has_auth_chain_index,
             },
         )
+        # As in store_room: drop any negative entry cached before the room row
+        # existed.
+        await self.invalidate_cache_and_stream("get_room_with_stats", (room_id,))
 
 
 class _BackgroundUpdates:
@@ -2996,6 +3004,10 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore):
                 "has_auth_chain_index": has_auth_chain_index,
             },
         )
+        # The room may have been looked up before we had a row for it (e.g. a
+        # remote server asking us to summarise it), caching a None; the stats
+        # writer only invalidates once it catches up.
+        await self.invalidate_cache_and_stream("get_room_with_stats", (room_id,))
 
     async def store_partial_state_room(
         self,

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -404,10 +404,10 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
             logger.error("store_room with room_id=%s failed: %s", room_id, e)
             raise StoreError(500, "Problem creating room.")
 
-        # The room may have been looked up before we had a row for it (e.g. a
-        # remote server asking us to summarise it), caching a None; the stats
-        # writer only invalidates once it catches up.
-        await self.invalidate_cache_and_stream("get_room_with_stats", (room_id,))
+        # NB no get_room_with_stats invalidation here, unlike the paths that
+        # store a room we learn about over federation: this is only reached for
+        # a room we are creating ourselves, whose (freshly generated) id nothing
+        # can have looked up yet, so there is no negative cache entry to clear.
 
     async def get_room(self, room_id: str) -> tuple[bool, bool] | None:
         """Retrieve a room.

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -430,8 +430,13 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
             return row
         return bool(row[0]), bool(row[1])
 
+    @cached(max_entries=10000)
     async def get_room_with_stats(self, room_id: str) -> RoomStats | None:
         """Retrieve room with statistics.
+
+        Cached; invalidated when the room's stats rows are written
+        (`update_room_state` / `_update_stats_delta_txn`), when the room's
+        directory visibility changes, and on room purge.
 
         Args:
             room_id: The ID of the room to retrieve.
@@ -2371,12 +2376,16 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
         return True
 
     async def set_room_is_public(self, room_id: str, is_public: bool) -> None:
-        await self.db_pool.simple_update_one(
-            table="rooms",
-            keyvalues={"room_id": room_id},
-            updatevalues={"is_public": is_public},
-            desc="set_room_is_public",
-        )
+        def set_room_is_public_txn(txn: LoggingTransaction) -> None:
+            self.db_pool.simple_update_one_txn(
+                txn,
+                table="rooms",
+                keyvalues={"room_id": room_id},
+                updatevalues={"is_public": is_public},
+            )
+            self._invalidate_cache_and_stream(txn, self.get_room_with_stats, (room_id,))
+
+        await self.db_pool.runInteraction("set_room_is_public", set_room_is_public_txn)
 
     async def set_room_is_public_appservice(
         self, room_id: str, appservice_id: str, network_id: str, is_public: bool

--- a/synapse/storage/databases/main/state.py
+++ b/synapse/storage/databases/main/state.py
@@ -611,7 +611,9 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
             "get_filtered_current_state_ids", _get_filtered_current_state_ids_txn
         )
 
-    @cached(max_entries=50000)
+    # NB max_entries is lower than the sibling state caches: each value holds
+    # every m.space.child event of the room, so entries are not uniformly small.
+    @cached(max_entries=10000)
     async def get_room_hierarchy_state(
         self, room_id: str
     ) -> Optional["RoomHierarchyState"]:

--- a/synapse/storage/databases/main/state.py
+++ b/synapse/storage/databases/main/state.py
@@ -28,6 +28,7 @@ from typing import (
     Iterable,
     Mapping,
     MutableMapping,
+    Optional,
     TypeVar,
     cast,
     overload,
@@ -76,6 +77,25 @@ class Sentinel:
 
 
 ROOM_UNKNOWN_SENTINEL = Sentinel()
+
+
+@attr.s(slots=True, frozen=True, auto_attribs=True)
+class RoomHierarchyState:
+    """The current-state inputs to a room's hierarchy (space summary) entry.
+
+    Immutable so it can be used as a cache value; the stripped child event
+    dicts must not be mutated by consumers.
+    """
+
+    # The room's join rule / history visibility, from CURRENT STATE (the room
+    # stats copies lag behind, which matters for access-control decisions).
+    join_rule: str | None
+    history_visibility: str | None
+    # A state map containing just the m.room.join_rules event id (if any), in
+    # the shape the restricted-join-rules helpers expect.
+    join_rules_state_ids: StateMap[str]
+    # The stripped m.space.child events of the room (unsorted, unfiltered).
+    children: tuple[JsonMapping, ...]
 
 
 def _retrieve_and_check_room_version(room_id: str, room_version_id: str) -> RoomVersion:
@@ -589,6 +609,85 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
 
         return await self.db_pool.runInteraction(
             "get_filtered_current_state_ids", _get_filtered_current_state_ids_txn
+        )
+
+    @cached(max_entries=50000)
+    async def get_room_hierarchy_state(
+        self, room_id: str
+    ) -> Optional["RoomHierarchyState"]:
+        """Get the parts of a room's current state that the room hierarchy
+        (space summary) endpoints need, in a form that can be cached.
+
+        The cache is invalidated whenever a state event is persisted in the room
+        (see `_invalidate_caches_for_event`), so the returned join rule /
+        history visibility are authoritative (unlike the room stats, which are
+        updated asynchronously).
+
+        Returns None if the room has no current state (i.e. is unknown).
+        """
+        state_ids = await self.get_partial_filtered_current_state_ids(
+            room_id,
+            StateFilter.from_types(
+                [
+                    (EventTypes.JoinRules, ""),
+                    (EventTypes.RoomHistoryVisibility, ""),
+                    (EventTypes.SpaceChild, None),
+                ]
+            ),
+        )
+        if not state_ids:
+            return None
+
+        join_rules_event_id = state_ids.get((EventTypes.JoinRules, ""))
+        hist_vis_event_id = state_ids.get((EventTypes.RoomHistoryVisibility, ""))
+        child_event_ids = [
+            event_id
+            for key, event_id in state_ids.items()
+            if key[0] == EventTypes.SpaceChild
+        ]
+
+        to_fetch = list(child_event_ids)
+        if join_rules_event_id:
+            to_fetch.append(join_rules_event_id)
+        if hist_vis_event_id:
+            to_fetch.append(hist_vis_event_id)
+        events = {e.event_id: e for e in await self.get_events_as_list(to_fetch)}
+
+        join_rule = None
+        if join_rules_event_id and join_rules_event_id in events:
+            join_rule = events[join_rules_event_id].content.get("join_rule")
+        history_visibility = None
+        if hist_vis_event_id and hist_vis_event_id in events:
+            history_visibility = events[hist_vis_event_id].content.get(
+                "history_visibility"
+            )
+
+        # Stripped m.space.child events, in the form the hierarchy endpoints
+        # return them. Unsorted and unfiltered: ordering, via-validity and
+        # suggested-only filtering are request-time concerns.
+        children = tuple(
+            {
+                "type": e.type,
+                "state_key": e.state_key,
+                "content": e.content,
+                "sender": e.sender,
+                "origin_server_ts": e.origin_server_ts,
+            }
+            for event_id in child_event_ids
+            if (e := events.get(event_id)) is not None
+        )
+
+        join_rules_state_ids: StateMap[str] = (
+            {(EventTypes.JoinRules, ""): join_rules_event_id}
+            if join_rules_event_id
+            else {}
+        )
+
+        return RoomHierarchyState(
+            join_rule=join_rule,
+            history_visibility=history_visibility,
+            join_rules_state_ids=join_rules_state_ids,
+            children=children,
         )
 
     @cached(max_entries=50000)

--- a/synapse/storage/databases/main/stats.py
+++ b/synapse/storage/databases/main/stats.py
@@ -284,12 +284,23 @@ class StatsStore(StateDeltasStore):
             if field is not sentinel and (not isinstance(field, str) or "\0" in field):
                 fields[col] = None
 
-        await self.db_pool.simple_upsert(
-            table="room_stats_state",
-            keyvalues={"room_id": room_id},
-            values=fields,
-            desc="update_room_state",
-        )
+        def update_room_state_txn(txn: LoggingTransaction) -> None:
+            self.db_pool.simple_upsert_txn(
+                txn,
+                table="room_stats_state",
+                keyvalues={"room_id": room_id},
+                values=fields,
+            )
+            # The room summary / hierarchy endpoints serve room state fields
+            # (name, topic, ...) from this table via the get_room_with_stats
+            # cache.
+            self._invalidate_cache_and_stream(  # type: ignore[attr-defined]
+                txn,
+                self.get_room_with_stats,  # type: ignore[attr-defined]
+                (room_id,),
+            )
+
+        await self.db_pool.runInteraction("update_room_state", update_room_state_txn)
 
     @cached()
     async def get_earliest_token_for_stats(
@@ -440,6 +451,15 @@ class StatsStore(StateDeltasStore):
             absolutes=absolute_field_overrides,
             additive_relatives=deltas_of_absolute_fields,
         )
+
+        if stats_type == "room":
+            # The room summary / hierarchy endpoints serve joined_members from
+            # room_stats_current via the get_room_with_stats cache.
+            self._invalidate_cache_and_stream(  # type: ignore[attr-defined]
+                txn,
+                self.get_room_with_stats,  # type: ignore[attr-defined]
+                (stats_id,),
+            )
 
     def _upsert_with_additive_relatives_txn(
         self,

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -33,7 +33,12 @@ from synapse.api.constants import (
     RestrictedJoinRuleTypes,
     RoomTypes,
 )
-from synapse.api.errors import AuthError, NotFoundError, SynapseError
+from synapse.api.errors import (
+    AuthError,
+    HttpResponseException,
+    NotFoundError,
+    SynapseError,
+)
 from synapse.api.room_versions import RoomVersions
 from synapse.federation.transport.client import TransportLayerClient
 from synapse.handlers.room_summary import _child_events_comparison_key, _RoomEntry
@@ -1058,6 +1063,78 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
                 self.handler.get_room_hierarchy(create_requester(self.user), self.space)
             )
         self._assert_hierarchy(result, expected)
+
+    def test_fed_room_linked_from_two_spaces(self) -> None:
+        """
+        A room linked from two spaces is summarised using the via of the edge
+        the traversal actually reaches it by.
+
+        Summaries for upcoming rooms are fetched concurrently, ahead of the
+        strictly-ordered traversal; a room can be in the queue more than once
+        (it is only deduplicated when popped), and each queue entry carries the
+        via to summarise it with. The summary that gets used must therefore be
+        the one belonging to the entry that is popped, not any other entry for
+        the same room.
+        """
+        root_via = "root." + self.hs.hostname
+        subspace_via = "subspace." + self.hs.hostname
+        fed_room = "#linked-twice:" + self.hs.hostname + "2"
+
+        # A local subspace, ordered ahead of the federated room so it is
+        # traversed first — which pushes its own edge to the federated room onto
+        # the queue while the root's edge to it is still there.
+        subspace = self.helper.create_room_as(
+            self.user,
+            tok=self.token,
+            extra_content={
+                "creation_content": {EventContentFields.ROOM_TYPE: RoomTypes.SPACE}
+            },
+        )
+        self._add_child(self.space, subspace, self.token, order="a")
+        self._add_child(self.space, fed_room, self.token, order="b", via=[root_via])
+        self._add_child(subspace, fed_room, self.token, via=[subspace_via])
+
+        destinations: list[str] = []
+
+        async def get_room_hierarchy(
+            _self: TransportLayerClient,
+            destination: str,
+            room_id: str,
+            suggested_only: bool,
+        ) -> JsonDict:
+            destinations.append(destination)
+            # Only the subspace's via can actually serve the room, so summarising
+            # the wrong edge loses the room entirely.
+            if destination == root_via:
+                raise HttpResponseException(502, "Bad Gateway", b"{}")
+            return {
+                "room": {"room_id": fed_room, "world_readable": True},
+                "children": [],
+                "inaccessible_children": [],
+            }
+
+        with mock.patch(
+            "synapse.federation.transport.client.TransportLayerClient.get_room_hierarchy",
+            new=get_room_hierarchy,
+        ):
+            result = self.get_success(
+                self.handler.get_room_hierarchy(create_requester(self.user), self.space)
+            )
+
+        # The subspace's edge is the one the traversal pops, so that is the via
+        # the room must have been summarised with…
+        self.assertIn(subspace_via, destinations)
+
+        # …and the room is returned (exactly once), listed under both parents.
+        self._assert_hierarchy(
+            result,
+            [
+                (self.space, [subspace, fed_room, self.room]),
+                (subspace, [fed_room]),
+                (fed_room, ()),
+                (self.room, ()),
+            ],
+        )
 
     def test_fed_caching(self) -> None:
         """

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -51,8 +51,14 @@ from tests.unittest import override_config
 def _create_event(
     room_id: str, order: Any | None = None, origin_server_ts: int = 0
 ) -> mock.Mock:
+    """Build a fake m.space.child event pointing at `room_id`.
+
+    The child room id is the event's state key (the event itself lives in the
+    parent space).
+    """
     result = mock.Mock(name=room_id)
-    result.room_id = room_id
+    result.state_key = room_id
+    result.room_id = "!parent:test"
     result.content = {}
     result.origin_server_ts = origin_server_ts
     if order is not None:

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -273,6 +273,53 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
         result["rooms"] += result2["rooms"]
         self._assert_hierarchy(result, expected)
 
+    def test_cache_invalidation(self) -> None:
+        """Repeated requests are served from the cached room summaries, which
+        must reflect changes to the underlying data immediately.
+        """
+        requester = create_requester(self.user)
+        result = self.get_success(
+            self.handler.get_room_hierarchy(requester, self.space)
+        )
+        self._assert_hierarchy(result, [(self.space, [self.room]), (self.room, ())])
+
+        # Adding a child must be reflected on the next request.
+        room2 = self.helper.create_room_as(self.user, tok=self.token)
+        self._add_child(self.space, room2, self.token, order="a")
+        result = self.get_success(
+            self.handler.get_room_hierarchy(requester, self.space)
+        )
+        self._assert_hierarchy(
+            result,
+            [(self.space, [room2, self.room]), (room2, ()), (self.room, ())],
+        )
+
+        # Removing a child (clearing its via) likewise.
+        self.helper.send_state(
+            self.space,
+            event_type=EventTypes.SpaceChild,
+            body={},
+            tok=self.token,
+            state_key=room2,
+        )
+        result = self.get_success(
+            self.handler.get_room_hierarchy(requester, self.space)
+        )
+        self._assert_hierarchy(result, [(self.space, [self.room]), (self.room, ())])
+
+        # A room name change flows through the room stats tables; their write
+        # must also invalidate the cached summary.
+        self.helper.send_state(
+            self.space,
+            event_type=EventTypes.Name,
+            body={"name": "new name"},
+            tok=self.token,
+        )
+        result = self.get_success(
+            self.handler.get_room_hierarchy(requester, self.space)
+        )
+        self.assertEqual(result["rooms"][0]["name"], "new name")
+
     def test_visibility(self) -> None:
         """A user not in a space cannot inspect it."""
         user2 = self.register_user("user2", "pass")


### PR DESCRIPTION
Speeds up the room hierarchy (space summary) endpoints by ~75x. Three changes:

1. **Parallelise the traversal.** The hierarchy walk processed rooms strictly one at a time; every unknown subspace cost one blocking federation round trip, and every local room ~5 serial DB round trips. The walk now concurrently prefetches the summaries of the next 10 rooms in traversal order (results are still emitted strictly in order), and the federation responder summarises a space's children concurrently.

2. **Cache the per-room summaries, invalidated when the underlying data changes.** Two new caches:
   - `get_room_hierarchy_state`: the room's authoritative join rule + history visibility (from current state, NOT the asynchronously-updated stats copies, so access control never rides a stale row), the join-rules event id for the restricted-`allow` computation, and the stripped `m.space.child` events. Invalidated whenever a state event is persisted in the room, on state resets / un-partial-stating, and on purge - including over replication.
   - `get_room_with_stats` is now `@cached`, invalidated where the stats rows are written, on directory-visibility changes and on purge.

   A warm request for a public hierarchy does no per-room DB work at all (the only remaining queries are pagination-session bookkeeping). Accessibility checks for non-public rooms ride the existing per-user caches (`get_rooms_for_user` / invited rooms). Partial-state and unknown rooms fall back to the uncached path. Remote rooms were already TTL-cached by the federation client; change-based invalidation is not possible across federation.

3. **Fetch each room's caches concurrently on the cold path**, so an unwarmed cache does not reintroduce a serial chain per room.

Also fixes two latent issues in passing: `_get_child_events` fetched the room's **entire unfiltered current state** per space (very expensive for member-heavy rooms; now filtered to the state the endpoint needs), and `omit_remote_room_hierarchy` with no cached remote data left `room_entry` unbound (`NameError`).

Rationale: The hierarchy API is infamously slow - tens of seconds for big spaces, both locally and over federation. Total time was roughly (rooms x serial round trips x latency): sequential federation requests per subspace, and a per-room DB round-trip pattern that grinds whenever there is any latency between Synapse and its database.

### Benchmarks

Measured against a synthetic hierarchy (4 public space trees, 50 spaces each + 2 rooms per space; 150-room tree per walk, 3 pages of 50) on a two-server federated ESS deployment, with 50ms egress latency injected on the Synapse pods to emulate a latency-bound deployment (this delays both DB and federation round trips, which is what reproduces the real-world "tens of seconds"):

| walk (150 rooms) | before | after (warm) | after (cold) |
|---|---|---|---|
| local | 70.7s warm / 181.4s cold | **1.4s** | 20.1s |
| federated | 124.5s cold | **1.7s** | 11.1s |
| DB txns per 50-room page | 224 | **2-3** | - |

Without injected latency the same walk goes 0.27s → 0.09s warm. The child-ordering tie-break beyond `origin_server_ts` now uses the child room id per MSC2946 (it previously used the parent's room id, i.e. effectively arbitrary input order).

### Testing

- 29/29 `tests.handlers.test_room_summary` (including a new `test_cache_invalidation` covering child add/remove and the stats-write invalidation path), plus the stats, admin-room and purge suites.
- Validated end-to-end on using the test rig (federated two-server ESS rig, including an Element Web UI test that fully paginates the space explorer both locally and over federation)

🤖 This PR was written by Claude (Claude Code), driven and reviewed by @ara4n.
