### PR TITLE
Fix `quarantined_media` stream not being replicated

### DIFF
--- a/changelog.d/20085.bugfix
+++ b/changelog.d/20085.bugfix
@@ -1,0 +1,1 @@
+Fix the `quarantined_media` replication stream never being sent when the configured `quarantined_media_changes` stream writer is a worker. Introduced in v1.152.0.

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -517,6 +517,7 @@ def add_worker_roles_to_shared_config(
         "typing",
         "push_rules",
         "thread_subscriptions",
+        "quarantined_media_changes",
     }
 
     # Worker-type specific sharding config. Now a single worker can fulfill multiple

--- a/docs/development/synapse_architecture/streams.md
+++ b/docs/development/synapse_architecture/streams.md
@@ -164,6 +164,7 @@ necessary registration and event handling.
   - will need an [ID generator](https://github.com/element-hq/synapse/blob/4367fb2d078c52959aeca0fe6874539c53e8360d/synapse/storage/databases/main/thread_subscriptions.py#L75)
     - may need [writer configuration](https://github.com/element-hq/synapse/blob/4367fb2d078c52959aeca0fe6874539c53e8360d/synapse/config/workers.py#L177), if there isn't already an obvious source of configuration for which workers should be designated as writers to your new stream.
       - if adding new writer configuration, add Docker-worker configuration, which lets us configure the writer worker in Complement tests: [[1]](https://github.com/element-hq/synapse/blob/4367fb2d078c52959aeca0fe6874539c53e8360d/docker/configure_workers_and_start.py#L331), [[2]](https://github.com/element-hq/synapse/blob/4367fb2d078c52959aeca0fe6874539c53e8360d/docker/configure_workers_and_start.py#L440)
+    - Ensure that it's been correctly added to `synapse/replication/tcp/handler.py` and it's `streams_to_replicate` attribute to ensure that changes are actually replicated.
 - most of the time, you will likely introduce a new datastore class for the concept represented by the new stream, unless there is already an obvious datastore that covers it.
 - consider whether it may make sense to introduce a handler
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -572,10 +572,15 @@ configured as stream writer for the `device_lists` stream:
 ##### The `quarantined_media_changes` stream
 
 The `quarantined_media_changes` stream supports multiple writers. The following endpoints
-can be handled by any worker, but should be routed directly to one of the workers
-configured as stream writer for the `quarantined_media_changes` stream:
+must be routed directly to one of the workers configured as stream writer for the
+`quarantined_media_changes` stream (which must also be able to run the media
+repository, as these endpoints are only registered on media-capable workers):
 
     ^/_synapse/admin/v1/quarantine_media/.*$
+    ^/_synapse/admin/v1/room/.*/media/quarantine$
+    ^/_synapse/admin/v1/user/.*/media/quarantine$
+    ^/_synapse/admin/v1/media/quarantine/.*$
+    ^/_synapse/admin/v1/media/unquarantine/.*$
 
 #### Restrict outbound federation traffic to a specific set of workers
 

--- a/synapse/config/workers.py
+++ b/synapse/config/workers.py
@@ -375,6 +375,7 @@ class WorkerConfig(Config):
             "push_rules",
             "device_lists",
             "thread_subscriptions",
+            "quarantined_media_changes",
         ):
             instances = _instance_to_list_converter(getattr(self.writers, stream))
             for instance in instances:
@@ -428,6 +429,11 @@ class WorkerConfig(Config):
         if len(self.writers.thread_subscriptions) == 0:
             raise ConfigError(
                 "Must specify at least one instance to handle `thread_subscriptions` messages."
+            )
+
+        if len(self.writers.quarantined_media_changes) == 0:
+            raise ConfigError(
+                "Must specify at least one instance to handle `quarantined_media_changes` messages."
             )
 
         self.events_shard_config = RoutableShardedWorkerHandlingConfig(

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -68,6 +68,7 @@ from synapse.replication.tcp.streams import (
 from synapse.replication.tcp.streams._base import (
     DeviceListsStream,
     ProfileUpdatesStream,
+    QuarantinedMediaStream,
     StickyEventsStream,
     ThreadSubscriptionsStream,
 )
@@ -233,6 +234,15 @@ class ReplicationCommandHandler:
 
             if isinstance(stream, DeviceListsStream):
                 if hs.get_instance_name() in hs.config.worker.writers.device_lists:
+                    self._streams_to_replicate.append(stream)
+
+                continue
+
+            if isinstance(stream, QuarantinedMediaStream):
+                if (
+                    hs.get_instance_name()
+                    in hs.config.worker.writers.quarantined_media_changes
+                ):
                     self._streams_to_replicate.append(stream)
 
                 continue

--- a/tests/replication/tcp/streams/test_quarantined_media.py
+++ b/tests/replication/tcp/streams/test_quarantined_media.py
@@ -1,0 +1,86 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 Element Creations Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+
+from synapse.replication.tcp.streams import QuarantinedMediaStream
+from synapse.types import UserID
+
+from tests.replication._base import BaseMultiWorkerStreamTestCase
+
+
+class QuarantinedMediaWorkerWriterTestCase(BaseMultiWorkerStreamTestCase):
+    """Checks that the quarantined_media stream is replicated when the
+    configured stream writer is a worker rather than the main process.
+    """
+
+    def default_config(self) -> dict:
+        conf = super().default_config()
+        conf["stream_writers"] = {"quarantined_media_changes": ["worker1"]}
+        conf["instance_map"] = {
+            "main": {"host": "testserv", "port": 8765},
+            "worker1": {"host": "testserv", "port": 1001},
+        }
+        return conf
+
+    def test_quarantine_on_worker_writer_replicates_to_main(self) -> None:
+        main_store = self.hs.get_datastores().main
+
+        worker_hs = self.make_worker_hs(
+            "synapse.app.generic_worker", {"worker_name": "worker1"}
+        )
+        worker_store = worker_hs.get_datastores().main
+
+        # The worker must consider itself a source of the stream...
+        self.assertIn(
+            QuarantinedMediaStream.NAME,
+            {
+                stream.NAME
+                for stream in worker_hs.get_replication_command_handler().get_streams_to_replicate()
+            },
+        )
+        # ... and the main process must not, as it isn't a writer.
+        self.assertNotIn(
+            QuarantinedMediaStream.NAME,
+            {
+                stream.NAME
+                for stream in self.hs.get_replication_command_handler().get_streams_to_replicate()
+            },
+        )
+
+        # Quarantining only records a change for media that exists.
+        self.get_success(
+            main_store.store_local_media(
+                media_id="media_id1",
+                media_type="text/plain",
+                time_now_ms=self.clock.time_msec(),
+                upload_name=None,
+                media_length=100,
+                user_id=UserID.from_string("@user:test"),
+            )
+        )
+
+        initial_token = main_store.get_current_quarantined_media_stream_id()
+
+        # Quarantine the media on the worker, i.e. the configured writer.
+        self.get_success(
+            worker_store.quarantine_media_by_id("test", "media_id1", "@admin:test")
+        )
+
+        self.replicate()
+
+        # The main process only learns of the new stream ID over replication,
+        # even though the two instances share a database.
+        self.assertEqual(
+            main_store.get_current_quarantined_media_stream_id(),
+            initial_token + 1,
+        )


### PR DESCRIPTION
The registration of `QuarantinedMediaStream` in `ReplicationCommandHandler._streams_to_replicate` was missed when the stream was added, so an instance configured as the quarantined_media_changes stream writer never sent RDATA/POSITION for it unless it was the main process.

Also add the stream to the `instance_map` config validation.

Stream was introduced in https://github.com/element-hq/synapse/pull/19558

Fixes https://github.com/element-hq/synapse/issues/20080