### PR TITLE
Fix the documentation on the `federation_domain_whitelist` config option.

### DIFF
--- a/changelog.d/20089.doc
+++ b/changelog.d/20089.doc
@@ -1,0 +1,1 @@
+Fix the documentation on the `federation_domain_whitelist` config option.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1287,11 +1287,10 @@ Options related to federation.
 ---
 ### `federation_domain_whitelist`
 
-*(array)* Restrict federation to the given whitelist of domains. N.B. we recommend also firewalling your federation listener to limit inbound federation traffic as early as possible, rather than relying purely on this application-layer restriction. If not specified, the default is to whitelist everything.
-
-Note: this does not stop a server from joining rooms that servers not on the whitelist are in. As such, this option is really only useful to establish a "private federation", where a group of servers all whitelist each other and have the same whitelist.
-
-Defaults to `[]`.
+*(array)* Restrict federation to the given whitelist of domains. N.B. we recommend also firewalling your federation listener to limit inbound federation traffic as early as possible, rather than relying purely on this application-layer restriction.
+If specified as an empty list (`[]`), federation will be denied with all servers. Specifying an empty list (`[]`) here is the recommended way of disabling federation.
+If not specified, the default is to allow federation with all servers.
+Note: this does not stop a server from joining rooms that servers not on the whitelist are in. As such, this option is really only useful to establish a "private federation", where a group of servers all whitelist each other and have the same whitelist. There is no default for this option.
 
 Example configuration:
 ```yaml

--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -280,10 +280,10 @@ properties:
     description: >-
       Use this option to include updates of other users' profiles in sync responses,
       for users who share rooms.
-      
+
       Requires an [MSC4429](https://github.com/matrix-org/matrix-spec-proposals/pull/4429)
       compatible client, and is currently limited to legacy sync and local users only.
-      
+
       This feature is under development and should be used with caution on busy servers or
       servers which depend on `limit_profile_requests_to_users_who_share_rooms` for ensuring
       profile information doesn't leak across rooms.
@@ -1578,9 +1578,12 @@ properties:
       Restrict federation to the given whitelist of domains. N.B. we recommend
       also firewalling your federation listener to limit inbound federation
       traffic as early as possible, rather than relying purely on this
-      application-layer restriction. If not specified, the default is to
-      whitelist everything.
+      application-layer restriction.
 
+      If specified as an empty list (`[]`), federation will be denied with all servers.
+      Specifying an empty list (`[]`) here is the recommended way of disabling federation.
+
+      If not specified, the default is to allow federation with all servers.
 
       Note: this does not stop a server from joining rooms that servers not on
       the whitelist are in. As such, this option is really only useful to
@@ -1588,7 +1591,6 @@ properties:
       each other and have the same whitelist.
     items:
       type: string
-    default: []
     examples:
       - - lon.example.com
         - nyc.example.com


### PR DESCRIPTION
[As discussed in Backend Lobby](https://matrix.to/#/!SGNQGPGUwtcPBUotTL:matrix.org/$jz87yx9uFcwKYhwejCLiVlfRLKseUHRnRrz2jZcGvOs?via=jki.re&via=element.io&via=matrix.org)

As for justification for calling this the recommended way,

- from memory this is accurate
- a previous changelog implies this: https://github.com/element-hq/synapse/blob/287904c03ac8892407be960d475c4d25007e8917/docs/changelogs/CHANGES-2022.md?plain=1#L1296
- this is what we are doing internally ([Backend Lobby example](https://matrix.to/#/!SGNQGPGUwtcPBUotTL:matrix.org/$MTCVg5-D0k_jq9QZxVSSy1CeMGs8mbG6ld-BWOOy9JI?via=jki.re&via=element.io&via=matrix.org))

I can't find a definitive source though
