### PR TITLE
Update release script to check more often for actions being completed (every 1m)

### DIFF
--- a/changelog.d/20093.misc
+++ b/changelog.d/20093.misc
@@ -1,0 +1,1 @@
+Update release script to check more often for actions being completed so you don't have to wait around as much.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -604,8 +604,10 @@ def _wait_for_actions(gh_token: str | None) -> None:
     # to check over and over when we know it won't be finished yet)
     time.sleep(10 * 60)
     while True:
-        # Then check once every minute (arbitrarily short enough to not have to wait
-        # around too long while not spamming the GitHub API)
+        # Then check once every minute. Short enough to not have to wait around too long
+        # while not spamming the GitHub API and running into the unauthenticated API
+        # request rate limit (60 requests per hour so 1 request/minute perfectly aligns
+        # to not run into any problems)
         time.sleep(1 * 60)
         response = urllib.request.urlopen(req)
         resp = json.loads(response.read())

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -600,9 +600,12 @@ def _wait_for_actions(gh_token: str | None) -> None:
         headers["authorization"] = f"token {gh_token}"
     req = urllib.request.Request(url, headers=headers)
 
+    # Initially, wait 10 minutes as we know the CI typically takes 15m+ anyway (no need
+    # to check over and over when we know it won't be finished yet)
     time.sleep(10 * 60)
     while True:
-        time.sleep(5 * 60)
+        # Then check once every minute
+        time.sleep(1 * 60)
         response = urllib.request.urlopen(req)
         resp = json.loads(response.read())
 

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -604,7 +604,8 @@ def _wait_for_actions(gh_token: str | None) -> None:
     # to check over and over when we know it won't be finished yet)
     time.sleep(10 * 60)
     while True:
-        # Then check once every minute
+        # Then check once every minute (arbitrarily short enough to not have to wait
+        # around too long while not spamming the GitHub API)
         time.sleep(1 * 60)
         response = urllib.request.urlopen(req)
         resp = json.loads(response.read())


### PR DESCRIPTION
Update release script to check more often for actions being completed (`_wait_for_actions`)

Spawning from seeing the release CI being complete but needing to wait up to 5 minutes longer to continue on.



### Dev notes

Originally the waiting was introduced in https://github.com/matrix-org/synapse/pull/13483

GitHub rate limit:

> The primary rate limit for unauthenticated requests is 60 requests per hour.
>
> *-- https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10#primary-rate-limit-for-unauthenticated-users*



### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
