### PR TITLE
Add CI that checks that old schemas are upgradable and give the same final schema.

### DIFF
--- a/.ci/scripts/check_schema_upgrade.sh
+++ b/.ci/scripts/check_schema_upgrade.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Checks that you get the same resultant database schema whether you
+# start at the latest Synapse version and set up a fresh database,
+# or whether you set up a fresh database on an old version and then
+# run the upgrade steps.
+#
+# Usage:
+#   PGUSER=postgres PGPASSWORD=postgres .ci/scripts/check_schema_upgrade.sh
+
+set -eu
+
+# The full schema version to upgrade from.
+BASE_SCHEMA="54"
+# A git ref (e.g. tag) to check out the full schema from.
+# Needed because old full schemas have since been removed.
+BASE_REF="v1.62.0"
+
+# Check Postgres env is set
+: "${PGUSER:?must be set}"
+: "${PGPASSWORD:?must be set}"
+
+# Change to repo root
+cd "$(dirname "$0")/../.."
+
+# Names of the database splits we have
+DATABASE_SPLITS=(common main state)
+
+if [ ! -z "$(git status --porcelain)" ]; then
+  echo "The repository has uncommitted changes. Refusing to run."
+  exit 1
+fi
+
+OUTPUT_DIR="$(mktemp -d)"
+
+echo "Checking out full schema $BASE_SCHEMA from $BASE_REF..."
+for db in "${DATABASE_SPLITS[@]}"; do
+  git checkout "$BASE_REF" -- "synapse/storage/schema/$db/full_schemas/$BASE_SCHEMA"
+done
+
+# Synapse will naturally set up a fresh database using the highest version full schema it can find.
+# To avoid that, remove all other full schema versions.
+echo "Removing other full schemas..."
+for db in "${DATABASE_SPLITS[@]}"; do
+  for dir in "synapse/storage/schema/$db/full_schemas"/*; do
+    [ -d "$dir" ] || continue
+    if [ "$(basename "$dir")" != "$BASE_SCHEMA" ]; then
+      echo "  $dir"
+      rm -rf "$dir"
+    fi
+  done
+done
+
+echo "Building the database as a new install..."
+echo "$PGPASSWORD" | scripts-dev/make_full_schema.sh \
+  -c -p "$PGUSER" -o "$OUTPUT_DIR/create"
+
+echo "Building the database as an upgrade from schema $BASE_SCHEMA..."
+echo "$PGPASSWORD" | scripts-dev/make_full_schema.sh \
+  --test-upgrade-from="$BASE_SCHEMA" \
+  -c -p "$PGUSER" -o "$OUTPUT_DIR/upgrade"
+
+# Give a generous 10 lines of context, hopefully enough to show the table name if it's
+# e.g. a column embedded within a CREATE TABLE statement.
+if diff --recursive --unified=10 "$OUTPUT_DIR/create" "$OUTPUT_DIR/upgrade"; then
+  echo "OK: a database upgraded from schema $BASE_SCHEMA matches a new install." >&2
+else
+  echo
+  echo "ERROR: upgrading a database from schema $BASE_SCHEMA does not produce the same" >&2
+  echo "schema as installing one at that version and applying the deltas." >&2
+  echo >&2
+  echo " Left (-): Fresh install     |     Right (+): Simulated upgraded install"
+  exit 1
+fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,7 @@ jobs:
       integration: ${{ !startsWith(github.ref, 'refs/pull/') || steps.filter.outputs.integration }}
       linting: ${{ !startsWith(github.ref, 'refs/pull/') || steps.filter.outputs.linting }}
       linting_readme: ${{ !startsWith(github.ref, 'refs/pull/') || steps.filter.outputs.linting_readme }}
+      schema_upgrade: ${{ !startsWith(github.ref, 'refs/pull/') || steps.filter.outputs.schema_upgrade }}
       golangci: ${{ !startsWith(github.ref, 'refs/pull/') || steps.filter.outputs.golangci }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -90,6 +91,12 @@ jobs:
               - 'poetry.lock'
               - '.github/workflows/tests.yml'
 
+            schema_upgrade:
+              - 'synapse/storage/**'
+              - 'scripts-dev/make_full_schema.sh'
+              - '.ci/scripts/check_schema_upgrade.sh'
+              - '.github/workflows/tests.yml'
+
             golangci:
               - 'complement/**/*.go'
               - 'complement/.golangci.yml'
@@ -132,6 +139,67 @@ jobs:
           python-version: "3.x"
       - run: "pip install 'click==8.1.1' 'GitPython>=3.1.20' 'sqlglot>=28.0.0'"
       - run: scripts-dev/check_schema_delta.py --force-colors
+
+  # Checks that a schema upgrade is possible and that it produces the same schema as
+  # a fresh database.
+  check-schema-upgrade:
+    name: Check Schema Upgrade
+    runs-on: ubuntu-latest
+    needs: [changes, linting-done]
+    if: ${{ !cancelled() && !failure() && needs.changes.outputs.schema_upgrade == 'true' }} # Allow previous steps to be skipped, but not fail
+
+    steps:
+      - name: Start postgres with a frozen clock
+        # Use faketime here for schema deltas that are wall-clock sensitive under Postgres
+        run: |
+          mkdir /tmp/postgres-faketime
+          cat > /tmp/postgres-faketime/Dockerfile <<'EOF'
+            FROM postgres:14-alpine
+            RUN apk add --no-cache libfaketime
+
+            # It seems like it could be harmful to fake the monotonic timer
+            # as it might prevent deadlock detection, etc.
+            # But not sure, just doing out of precaution.
+            ENV FAKETIME_DONT_FAKE_MONOTONIC=1
+            ENTRYPOINT ["faketime", "-f", "2001-05-25 12:42:42", "docker-entrypoint.sh"]
+            CMD ["postgres"]
+          EOF
+          docker build -t localhost/postgres-faketime /tmp/postgres-faketime
+
+          docker run -d --name postgres -p 5432:5432 \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_INITDB_ARGS="--lc-collate C --lc-ctype C --encoding UTF8" \
+            --health-cmd pg_isready --health-interval 10s \
+            --health-timeout 5s --health-retries 5 \
+            localhost/postgres-faketime
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # We need a deep clone so we can check out the old full schema version
+          fetch-depth: 0
+
+      - name: Install PostgreSQL client and faketime
+        run: sudo apt-get -qq install postgresql-client faketime
+
+      - uses: matrix-org/setup-python-poetry@5bbf6603c5c930615ec8a29f1b5d7d258d905aa4 # v2.0.0
+        with:
+          poetry-version: "2.4.1"
+          extras: "postgres"
+          python-version: "3.x"
+
+      - name: Wait for Postgres to be up
+        run: |
+          until [ "$(docker inspect -f '{{.State.Health.Status}}' postgres)" = healthy ]; do sleep 2; done
+
+      - name: Check that an old database still upgrades cleanly
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+        # Use faketime here for schema deltas that are wall-clock sensitive under SQLite
+        run: |
+          faketime -f "2001-05-25 12:42:42" \
+            poetry run .ci/scripts/check_schema_upgrade.sh
 
   check-lockfile:
     runs-on: ubuntu-latest
@@ -770,6 +838,7 @@ jobs:
       - cargo-test
       - cargo-bench
       - linting-done
+      - check-schema-upgrade
     runs-on: ubuntu-latest
     steps:
       - uses: matrix-org/done-action@3409aa904e8a2aaf2220f09bc954d3d0b0a2ee67 # v3
@@ -788,3 +857,4 @@ jobs:
             lint-newsfile
             cargo-test
             cargo-bench
+            check-schema-upgrade

--- a/changelog.d/20100.bugfix
+++ b/changelog.d/20100.bugfix
@@ -1,0 +1,1 @@
+Fix schema deltas and background updates containing a literal `%` failing on PostgreSQL. Broken since Synapse v1.82.0.

--- a/changelog.d/20101.bugfix
+++ b/changelog.d/20101.bugfix
@@ -1,0 +1,1 @@
+Fix the `stream_ordering` bigint migration being unable to complete on PostgreSQL databases created before schema version 60.

--- a/changelog.d/20102.bugfix
+++ b/changelog.d/20102.bugfix
@@ -1,0 +1,1 @@
+Make `update_synapse_database.py --run-background-updates` exit with an error instead of hanging when a background update fails.

--- a/changelog.d/20102.misc
+++ b/changelog.d/20102.misc
@@ -1,0 +1,1 @@
+Add CI that checks that old schemas are upgradable and give the same final schema.

--- a/changelog.d/20104.bugfix
+++ b/changelog.d/20104.bugfix
@@ -1,0 +1,1 @@
+Fix `profiles` and `user_filters` having a different schema on SQLite depending on whether the server was installed before or after Synapse v1.88.0, and restore the `user_filters_unique` index lost on upgrade.

--- a/scripts-dev/make_full_schema.sh
+++ b/scripts-dev/make_full_schema.sh
@@ -33,6 +33,11 @@ usage() {
   echo "        temporarily deleted (as well as homeserver code temporarily tweaked"
   echo "        not to rely on any of those changes when applying background updates)"
   echo "  Defaults to 9999."
+  echo "--test-upgrade-from=<full schema number>"
+  echo "  Applies the given full schema snapshot, then uses the 'upgrade an existing database' migration path"
+  echo "  instead of the 'set up a new/fresh database' migration path."
+  echo "  This mainly influences the use of \`run_create\` vs \`run_upgrade\` in schema deltas."
+  echo "  This option is intended for testing that both paths lead to the same final schema."
   echo "-h"
   echo "  Display this help text."
   echo ""
@@ -46,7 +51,15 @@ usage() {
 }
 
 SCHEMA_NUMBER="9999"
-while getopts "p:co:hn:" opt; do
+TEST_UPGRADE_FROM=""
+
+while getopts "p:co:hn:-:" opt; do
+  # Process long options (https://stackoverflow.com/a/28466267)
+  if [ "$opt" = "-" ]; then   # long option: reformulate OPT and OPTARG
+    opt="${OPTARG%%=*}"       # extract long option name
+    OPTARG="${OPTARG#"$opt"}" # extract long option argument (may be empty)
+    OPTARG="${OPTARG#=}"      # if long option argument, remove assigning `=`
+  fi
   case $opt in
     p)
       export PGUSER=$OPTARG
@@ -65,6 +78,9 @@ while getopts "p:co:hn:" opt; do
       ;;
     n)
       SCHEMA_NUMBER="$OPTARG"
+      ;;
+    test-upgrade-from)
+      TEST_UPGRADE_FROM="$OPTARG"
       ;;
     \?)
       echo "ERROR: Invalid option: -$OPTARG" >&2
@@ -197,8 +213,49 @@ databases:
 trusted_key_servers: []
 EOF
 
+
+# Create the SQL text needed to set up a database at a specific full schema version,
+# without applying any further upgrades.
+# This bypasses Synapse's database setup logic and is only suitable for testing.
+#
+# Usage: make_preapplied_full_schema_text <sqlite/postgres> <main/state/common>
+make_preapplied_full_schema_text() {
+  local engine="$1" database="$2"
+
+  # If a glob doesn't match, don't fail. Just expand to empty result.
+  shopt -s nullglob
+
+  # Apply all .sql and .sql.{engine} files from the common schema.
+  for file in synapse/storage/schema/common/full_schemas/$TEST_UPGRADE_FROM/*.sql{,$engine} ; do
+    cat $file
+  done
+
+  # Then apply all .sql and .sql.{engine} files from the per-database schema.
+  if [ "$database" != "common" ]; then
+    for file in synapse/storage/schema/$database/full_schemas/$TEST_UPGRADE_FROM/*.sql{,$engine} ; do
+      cat $file
+    done
+  fi
+
+  # Put the nullglob flag back, just in case.
+  shopt -u nullglob
+
+  # We need the schema_version table, defined here
+  cat "synapse/storage/schema/common/schema_version.sql"
+
+  # Then we need to set the applied schema_version manually,
+  # since we bypassed Synapse's own logic that does this.
+  echo "INSERT INTO schema_version (version, upgraded) VALUES ($TEST_UPGRADE_FROM, false);"
+}
+
 # Generate the server's signing key.
 echo "Generating SQLite3 db schema..."
+if [ -n "$TEST_UPGRADE_FROM" ]; then
+  echo "Pre-applying old full schema to SQLite3 databases..."
+  make_preapplied_full_schema_text sqlite common | sqlite3 -bail "$SQLITE_COMMON_DB"
+  make_preapplied_full_schema_text sqlite main | sqlite3 -bail "$SQLITE_MAIN_DB"
+  make_preapplied_full_schema_text sqlite state | sqlite3 -bail "$SQLITE_STATE_DB"
+fi
 python -m synapse.app.homeserver --generate-keys -c "$SQLITE_CONFIG"
 
 # Make sure the SQLite3 database is using the latest schema and has no pending background update.
@@ -210,6 +267,12 @@ echo "Creating postgres databases..."
 createdb --lc-collate=C --lc-ctype=C --template=template0 "$POSTGRES_COMMON_DB_NAME"
 createdb --lc-collate=C --lc-ctype=C --template=template0 "$POSTGRES_MAIN_DB_NAME"
 createdb --lc-collate=C --lc-ctype=C --template=template0 "$POSTGRES_STATE_DB_NAME"
+if [ -n "$TEST_UPGRADE_FROM" ]; then
+  echo "Pre-applying old full schema to Postgres databases..."
+  make_preapplied_full_schema_text postgres common | psql -w "$POSTGRES_COMMON_DB_NAME"
+  make_preapplied_full_schema_text postgres main | psql -w "$POSTGRES_MAIN_DB_NAME"
+  make_preapplied_full_schema_text postgres state | psql -w "$POSTGRES_STATE_DB_NAME"
+fi
 
 echo "Running db background jobs..."
 poetry run python synapse/_scripts/update_synapse_database.py --database-config "$POSTGRES_CONFIG" --run-background-updates

--- a/synapse/_scripts/update_synapse_database.py
+++ b/synapse/_scripts/update_synapse_database.py
@@ -21,6 +21,7 @@
 
 import argparse
 import logging
+import sys
 from typing import cast
 
 import yaml
@@ -49,16 +50,28 @@ class MockHomeserver(HomeServer):
         )
 
 
-def run_background_updates(hs: HomeServer) -> None:
+def run_background_updates(hs: HomeServer) -> bool:
+    """Run all pending background updates. Returns True if they all succeeded."""
     main = hs.get_datastores().main
     state = hs.get_datastores().state
+    succeeded = True
 
     async def run_background_updates() -> None:
-        await main.db_pool.updates.run_background_updates(sleep=False)
-        if state:
-            await state.db_pool.updates.run_background_updates(sleep=False)
-        # Stop the reactor to exit the script once every background update is run.
-        reactor.stop()
+        nonlocal succeeded
+        try:
+            await main.db_pool.updates.run_background_updates(sleep=False)
+            if state:
+                await state.db_pool.updates.run_background_updates(sleep=False)
+        except Exception:
+            # `run_background_updates` gives up after repeated failures. Without
+            # this the exception would be swallowed by the background process
+            # wrapper, the reactor would never be stopped and the script would
+            # hang rather than report the failure.
+            logger.exception("Background updates failed")
+            succeeded = False
+        finally:
+            # Stop the reactor to exit the script once every background update is run.
+            reactor.stop()
 
     def run() -> None:
         # Apply all background updates on the database.
@@ -72,6 +85,8 @@ def run_background_updates(hs: HomeServer) -> None:
     hs.get_clock().call_when_running(run)
 
     reactor.run()
+
+    return succeeded
 
 
 def main() -> None:
@@ -123,7 +138,8 @@ def main() -> None:
     hs.get_storage_controllers()
 
     if args.run_background_updates:
-        run_background_updates(hs)
+        if not run_background_updates(hs):
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -462,6 +462,17 @@ class LoggingTransaction:
         )
 
     def execute(self, sql: str, parameters: SQLQueryParameters = ()) -> None:
+        if not parameters:
+            # Don't hand an empty parameter collection to the driver.
+            #
+            # psycopg2 performs `%`-substitution on the SQL whenever it is given
+            # *any* parameters, including an empty collection, so a statement
+            # containing a literal `%` (e.g. `LIKE 'foo%'`) fails with
+            # `IndexError: tuple index out of range`. Omitting the parameters
+            # altogether disables the substitution.
+            self._do_execute(self.txn.execute, sql)
+            return
+
         self._do_execute(self.txn.execute, sql, parameters)
 
     def executemany(self, sql: str, *args: Any) -> None:

--- a/synapse/storage/databases/main/events_bg_updates.py
+++ b/synapse/storage/databases/main/events_bg_updates.py
@@ -90,6 +90,28 @@ _REPLACE_STREAM_ORDERING_SQL_COMMANDS = (
     "ALTER INDEX events_ts2 RENAME TO events_ts",
 )
 
+# Postgres refuses to drop a column that a foreign key depends on, so any foreign key
+# referencing `events.stream_ordering` has to be dropped before the swap above and
+# recreated afterwards (by which point `stream_ordering2` has been renamed into place,
+# so the saved definitions still name the right column).
+#
+# We look these up rather than hardcoding them, because the set has grown over time:
+# delta 74/03 added three on the membership tables, and the sliding sync tables later
+# added two more.
+#
+# Foreign keys which already reference `stream_ordering2` — because delta
+# 79/04 repointed them — are deliberately not matched here: the rename carries
+# those over on its own.
+_SELECT_STREAM_ORDERING_FOREIGN_KEYS_SQL = """
+    SELECT c.conrelid::regclass::text, quote_ident(c.conname), pg_get_constraintdef(c.oid)
+    FROM pg_constraint c
+    JOIN pg_attribute a
+        ON a.attrelid = c.confrelid AND a.attnum = ANY (c.confkey)
+    WHERE c.contype = 'f'
+        AND c.confrelid = 'events'::regclass
+        AND a.attname = 'stream_ordering'
+"""
+
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
 class _CalculateChainCover:
@@ -1476,9 +1498,30 @@ class EventsBackgroundUpdatesStore(
         """Drop the old 'stream_ordering' column and rename 'stream_ordering2' into its place."""
 
         def process(txn: Cursor) -> None:
+            txn.execute(_SELECT_STREAM_ORDERING_FOREIGN_KEYS_SQL)
+            foreign_keys = txn.fetchall()
+
+            for table, constraint, _definition in foreign_keys:
+                logger.info(
+                    "dropping %s on %s so that stream_ordering can be replaced",
+                    constraint,
+                    table,
+                )
+                txn.execute(f"ALTER TABLE {table} DROP CONSTRAINT {constraint}")
+
             for sql in _REPLACE_STREAM_ORDERING_SQL_COMMANDS:
                 logger.info("completing stream_ordering migration: %s", sql)
                 txn.execute(sql)
+
+            for table, constraint, definition in foreign_keys:
+                logger.info("restoring %s on %s", constraint, table)
+                # Constraints which were not `NOT VALID` are validated as they are
+                # added, which scans the table. That is acceptable here: a database
+                # still running this migration predates every table that holds such a
+                # constraint, so those tables are empty at this point.
+                txn.execute(
+                    f"ALTER TABLE {table} ADD CONSTRAINT {constraint} {definition}"
+                )
 
         # ANALYZE the new column to build stats on it, to encourage PostgreSQL to use the
         # indexes on it.

--- a/synapse/storage/schema/main/delta/79/04_mitigate_stream_ordering_update_race.py
+++ b/synapse/storage/schema/main/delta/79/04_mitigate_stream_ordering_update_race.py
@@ -8,7 +8,7 @@
 
 
 from synapse.storage.database import LoggingTransaction
-from synapse.storage.engines import BaseDatabaseEngine, PostgresEngine
+from synapse.storage.engines import BaseDatabaseEngine
 
 
 def run_create(
@@ -16,55 +16,24 @@ def run_create(
     database_engine: BaseDatabaseEngine,
 ) -> None:
     """
-    An attempt to mitigate a painful race between foreground and background updates
-    touching the `stream_ordering` column of the events table. More info can be found
+    This delta used to repoint the `event_stream_ordering_fkey` foreign keys added by
+    delta 74/03 at `events.stream_ordering2`, so that they would survive the column
+    swap performed by the `replace_stream_ordering_column` background update. It was an
+    attempt to mitigate a painful race between foreground and background updates
+    touching the `stream_ordering` column of the events table; more info can be found
     at https://github.com/matrix-org/synapse/issues/15677.
+
+    It could never do so successfully, because the unique index that a foreign key on
+    `stream_ordering2` requires is itself built by a background update
+    (`index_stream_ordering2`), and every delta runs before any background update does.
+    Whenever this delta had work to do it therefore failed with
+
+        psycopg2.errors.InvalidForeignKey: there is no unique constraint matching
+        given keys for referenced table "events"
+
+    which left any Postgres database older than schema version 60 unable to upgrade.
+
+    `replace_stream_ordering_column` now drops and recreates these foreign keys itself,
+    which works no matter which column they currently reference, so there is nothing
+    left for this delta to do.
     """
-
-    # technically the bg update we're concerned with below should only have been added in
-    # postgres but it doesn't hurt to be extra careful
-    if isinstance(database_engine, PostgresEngine):
-        select_sql = """
-            SELECT 1 FROM background_updates
-                WHERE update_name = 'replace_stream_ordering_column'
-        """
-        cur.execute(select_sql)
-        res = cur.fetchone()
-
-        # if the background update `replace_stream_ordering_column` is still pending, we need
-        # to drop the indexes added in 7403, and re-add them to the column `stream_ordering2`
-        # with the idea that they will be preserved when the column is renamed `stream_ordering`
-        # after the background update has finished
-        if res:
-            drop_cse_sql = """
-            ALTER TABLE current_state_events DROP CONSTRAINT IF EXISTS event_stream_ordering_fkey
-            """
-            cur.execute(drop_cse_sql)
-
-            drop_lcm_sql = """
-            ALTER TABLE local_current_membership DROP CONSTRAINT IF EXISTS event_stream_ordering_fkey
-            """
-            cur.execute(drop_lcm_sql)
-
-            drop_rm_sql = """
-            ALTER TABLE room_memberships DROP CONSTRAINT IF EXISTS event_stream_ordering_fkey
-            """
-            cur.execute(drop_rm_sql)
-
-            add_cse_sql = """
-            ALTER TABLE current_state_events ADD CONSTRAINT event_stream_ordering_fkey
-            FOREIGN KEY (event_stream_ordering) REFERENCES events(stream_ordering2) NOT VALID;
-            """
-            cur.execute(add_cse_sql)
-
-            add_lcm_sql = """
-            ALTER TABLE local_current_membership ADD CONSTRAINT event_stream_ordering_fkey
-            FOREIGN KEY (event_stream_ordering) REFERENCES events(stream_ordering2) NOT VALID;
-            """
-            cur.execute(add_lcm_sql)
-
-            add_rm_sql = """
-            ALTER TABLE room_memberships ADD CONSTRAINT event_stream_ordering_fkey
-            FOREIGN KEY (event_stream_ordering) REFERENCES events(stream_ordering2) NOT VALID;
-            """
-            cur.execute(add_rm_sql)

--- a/synapse/storage/schema/main/delta/94/08_sqlite_profiles_user_filters_shape.py
+++ b/synapse/storage/schema/main/delta/94/08_sqlite_profiles_user_filters_shape.py
@@ -1,0 +1,133 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 New Vector, Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+
+import logging
+
+from synapse.storage.database import LoggingTransaction
+from synapse.storage.engines import BaseDatabaseEngine, PostgresEngine
+
+logger = logging.getLogger(__name__)
+
+# The shape delta 78 was trying to leave these two tables in, plus the columns added
+# since. Both code paths through `prepare_database` end up here, so that a server that
+# upgraded into delta 78 and one that installed after it agree.
+_CREATE_TEMP_PROFILES = """
+CREATE TABLE temp_profiles (
+    full_user_id text NOT NULL,
+    user_id text,
+    displayname text,
+    avatar_url text,
+    fields JSONB,
+    UNIQUE (full_user_id),
+    UNIQUE (user_id)
+)
+"""
+
+_CREATE_TEMP_USER_FILTERS = """
+CREATE TABLE temp_user_filters (
+    full_user_id text NOT NULL,
+    user_id text NOT NULL,
+    filter_id bigint NOT NULL,
+    filter_json bytea NOT NULL
+)
+"""
+
+
+def _has_null_full_user_ids(cur: LoggingTransaction, table: str) -> bool:
+    cur.execute(f"SELECT 1 FROM {table} WHERE full_user_id IS NULL LIMIT 1")
+    return cur.fetchone() is not None
+
+
+def run_create(
+    cur: LoggingTransaction,
+    database_engine: BaseDatabaseEngine,
+) -> None:
+    """Give `profiles` and `user_filters` the same shape on every SQLite database.
+
+    Deltas 78/01 and 78/02 rebuilt these two tables to make `full_user_id` `NOT NULL`,
+    but they only define `run_upgrade`, so the rebuild is skipped by the "initialise a
+    new database" code path. The newest full schema snapshot (72) predates them, so
+    every SQLite server installed since has been left with the old shape: `full_user_id`
+    nullable and not unique, and `user_id` `NOT NULL` instead.
+
+    Delta 78/02 also lost the `user_filters_unique` index. It created the index on its
+    temporary table under a name the original table still held, so `IF NOT EXISTS` made
+    it a no-op, and dropping the original table then took the only copy of the index
+    with it. Delta 78/03 was written to repair precisely that, but it defines
+    `run_update`, which Synapse never calls, so it has never run on any database.
+
+    The rebuild is unconditional because SQLite stores `CREATE TABLE` statements
+    verbatim: rebuilding only where the shape looks wrong would leave the two code paths
+    with the same columns but different stored text, which still counts as a difference.
+
+    Postgres needs none of this. Its half of delta 78 only validates a constraint that
+    an earlier `.sql` delta added, and `.sql` deltas run on both code paths, so both
+    already agree.
+    """
+    if isinstance(database_engine, PostgresEngine):
+        return
+
+    # By this point `full_user_id` is populated: on an upgrading database delta 78 filled
+    # it in, and a database that skipped delta 78 has only ever been written to by code
+    # that sets it. Check anyway rather than risk failing an upgrade on the `NOT NULL`,
+    # which would stop the server from starting.
+    for table in ("profiles", "user_filters"):
+        if _has_null_full_user_ids(cur, table):
+            logger.warning(
+                "Not reshaping `%s`: it has rows with no `full_user_id`, which the "
+                "rebuilt table would not allow. This is not expected; please report it.",
+                table,
+            )
+            return
+
+    logger.info("Rebuilding profiles and user_filters to make full_user_id NOT NULL")
+
+    cur.execute("DROP TABLE IF EXISTS temp_profiles")
+    cur.execute(_CREATE_TEMP_PROFILES)
+    cur.execute(
+        """
+        INSERT INTO temp_profiles (full_user_id, user_id, displayname, avatar_url, fields)
+            SELECT full_user_id, user_id, displayname, avatar_url, fields FROM profiles
+        """
+    )
+    cur.execute("DROP TABLE profiles")
+    cur.execute("ALTER TABLE temp_profiles RENAME TO profiles")
+
+    cur.execute("DROP TABLE IF EXISTS temp_user_filters")
+    cur.execute(_CREATE_TEMP_USER_FILTERS)
+    cur.execute(
+        """
+        INSERT INTO temp_user_filters (full_user_id, user_id, filter_id, filter_json)
+            SELECT full_user_id, user_id, filter_id, filter_json FROM user_filters
+        """
+    )
+    cur.execute("DROP TABLE user_filters")
+    cur.execute("ALTER TABLE temp_user_filters RENAME TO user_filters")
+
+    # Recreate the indexes the rebuilds dropped. These have to come after the renames,
+    # or they would be created against the temporary tables and then thrown away with
+    # the originals — which is the mistake delta 78/02 made.
+    #
+    # `profiles_full_user_id_key` and `full_users_unique_idx` are otherwise created by
+    # background updates registered in delta 76, which use `IF NOT EXISTS` and so become
+    # no-ops if they have not run yet.
+    cur.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS profiles_full_user_id_key ON profiles (full_user_id)"
+    )
+    cur.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS user_filters_unique ON user_filters (user_id, filter_id)"
+    )
+    cur.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS full_users_unique_idx ON user_filters (full_user_id, filter_id)"
+    )

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -142,6 +142,42 @@ class ExecuteScriptTestCase(unittest.HomeserverTestCase):
         )
 
 
+class LiteralPercentTestCase(unittest.HomeserverTestCase):
+    """Tests that SQL containing a literal `%` can be run without parameters.
+
+    psycopg2 `%`-substitutes the SQL it is given whenever any parameters are
+    supplied, so passing it an empty collection of parameters makes it choke on
+    statements like `LIKE 'foo%'`. Several schema deltas and background updates
+    contain such statements.
+    """
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.db_pool: DatabasePool = hs.get_datastores().main.db_pool
+
+    def test_execute(self) -> None:
+        """A literal `%` survives `LoggingTransaction.execute`."""
+
+        def run(txn: LoggingTransaction) -> None:
+            txn.execute("SELECT 'a/b' LIKE 'a/%'")
+            self.assertEqual(txn.fetchall(), [(True,)])
+
+        self.get_success(self.db_pool.runInteraction("test_execute", run))
+
+    def test_executescript(self) -> None:
+        """A literal `%` survives `BaseDatabaseEngine.executescript`.
+
+        This is the path taken by `.sql` schema deltas.
+        """
+
+        def run(conn: LoggingDatabaseConnection) -> None:
+            cur = conn.cursor(txn_name="test_executescript")
+            self.db_pool.engine.executescript(
+                cur, "CREATE TABLE percent_test (name TEXT); SELECT 'a/b' LIKE 'a/%';"
+            )
+
+        self.get_success(self.db_pool.runWithConnection(run))
+
+
 @attr.s(slots=True, auto_attribs=True)
 class TransactionMocks:
     after_callback: Mock


### PR DESCRIPTION
We have a couple of sad problems with our database schema:

- Some old versions can't be upgraded to new versions currently, as we broke the deltas
- Some old versions, when upgraded, are different (e.g. missing indexes) to a fresh schema.

Both these issues are footgunsome.

Related: #20084

Follows: #20027 (loosely)

---

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

<ol>
<li>

make_full_schema: Allow testing upgrade from a specified full schema 

</li>
<li>

Add CI check that upgrades old schema and checks its identical

</li>
</ol>
