### PR TITLE
Introduce `LaxJsonDict` type and use it in tests where `JsonDict` is relied upon being lax.

### DIFF
--- a/changelog.d/20105.misc
+++ b/changelog.d/20105.misc
@@ -1,0 +1,1 @@
+Introduce `LaxJsonDict` type and use it in tests where `JsonDict` is relied upon being lax.

--- a/synapse/types/__init__.py
+++ b/synapse/types/__init__.py
@@ -94,8 +94,19 @@ MutableStateMap = MutableMapping[StateKey, T]
 # A "simple" (canonical) JSON value.
 SimpleJsonValue = str | int | bool | None
 JsonValue = list[SimpleJsonValue] | tuple[SimpleJsonValue, ...] | SimpleJsonValue
-# A JSON-serialisable dict.
+
+LaxJsonDict = dict[str, Any]
+"""
+A JSON-serialisable dict, without strong type enforcement.
+"""
+
 JsonDict = dict[str, Any]
+"""
+A JSON-serialisable dict.
+
+NOTE: Will be updated to point at `StrictJsonDict` in the future.
+"""
+
 # A JSON-serialisable mapping; roughly speaking an immutable JSONDict.
 # Useful when you have a TypedDict which isn't going to be mutated and you don't want
 # to cast to JsonDict everywhere.

--- a/tests/appservice/test_api.py
+++ b/tests/appservice/test_api.py
@@ -25,7 +25,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.appservice import ApplicationService
 from synapse.server import HomeServer
-from synapse.types import JsonDict, UserID
+from synapse.types import JsonDict, LaxJsonDict, UserID
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -81,7 +81,7 @@ class ApplicationServiceApiTestCase(unittest.HomeserverTestCase):
             url: str,
             args: Mapping[Any, Any],
             headers: Mapping[str | bytes, Sequence[str | bytes]],
-        ) -> list[JsonDict]:
+        ) -> list[LaxJsonDict]:
             # Ensure the access token is passed as a header.
             if not headers or not headers.get(b"Authorization"):
                 raise RuntimeError("Access token not provided")
@@ -155,7 +155,7 @@ class ApplicationServiceApiTestCase(unittest.HomeserverTestCase):
             url: str,
             args: Mapping[Any, Any],
             headers: Mapping[str | bytes, Sequence[str | bytes]] | None = None,
-        ) -> list[JsonDict]:
+        ) -> list[LaxJsonDict]:
             # Ensure the access token is passed as a both a query param and in the headers.
             if not args.get(b"access_token"):
                 raise RuntimeError("Access token should be provided in query params.")

--- a/tests/config/test_oauth_delegation.py
+++ b/tests/config/test_oauth_delegation.py
@@ -27,7 +27,7 @@ from unittest.mock import Mock
 from synapse.config import ConfigError
 from synapse.config.homeserver import HomeServerConfig
 from synapse.module_api import ModuleApi
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 
 from tests.server import get_clock, setup_test_homeserver
 from tests.unittest import TestCase, skip_unless
@@ -58,7 +58,7 @@ class MasAuthDelegation(TestCase):
     """Test that the Homeserver fails to initialize if the config is invalid."""
 
     def setUp(self) -> None:
-        self.config_dict: JsonDict = {
+        self.config_dict: LaxJsonDict = {
             **default_config(server_name="test"),
             "public_baseurl": BASE_URL,
             "enable_registration": False,

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -48,7 +48,7 @@ from synapse.logging.context import (
 )
 from synapse.server import HomeServer
 from synapse.storage.keys import FetchKeyResult
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -64,7 +64,7 @@ class MockPerspectiveServer:
         vk = signedjson.key.get_verify_key(self.key)
         return {"%s:%s" % (vk.alg, vk.version): encode_verify_key_base64(vk)}
 
-    def get_signed_key(self, server_name: str, verify_key: VerifyKey) -> JsonDict:
+    def get_signed_key(self, server_name: str, verify_key: VerifyKey) -> LaxJsonDict:
         key_id = "%s:%s" % (verify_key.alg, verify_key.version)
         res = {
             "server_name": server_name,
@@ -75,7 +75,7 @@ class MockPerspectiveServer:
         self.sign_response(res)
         return res
 
-    def sign_response(self, res: JsonDict) -> None:
+    def sign_response(self, res: LaxJsonDict) -> None:
         signedjson.sign.sign_json(res, self.server_name, self.key)
 
 
@@ -476,7 +476,7 @@ class ServerKeyFetcherTestCase(unittest.HomeserverTestCase):
         }
         signedjson.sign.sign_json(response, SERVER_NAME, testkey)
 
-        async def get_json(destination: str, path: str, **kwargs: Any) -> JsonDict:
+        async def get_json(destination: str, path: str, **kwargs: Any) -> LaxJsonDict:
             self.assertEqual(destination, SERVER_NAME)
             self.assertEqual(path, "/_matrix/key/v2/server")
             return response
@@ -565,7 +565,7 @@ class PerspectivesKeyFetcherTestCase(unittest.HomeserverTestCase):
         """
 
         async def post_json(
-            destination: str, path: str, data: JsonDict, **kwargs: Any
+            destination: str, path: str, data: LaxJsonDict, **kwargs: Any
         ) -> JsonDict:
             self.assertEqual(destination, self.mock_perspective_server.server_name)
             self.assertEqual(path, "/_matrix/key/v2/query")
@@ -648,7 +648,7 @@ class PerspectivesKeyFetcherTestCase(unittest.HomeserverTestCase):
         )
 
         async def post_json(
-            destination: str, path: str, data: JsonDict, **kwargs: str
+            destination: str, path: str, data: LaxJsonDict, **kwargs: str
         ) -> JsonDict:
             self.assertEqual(destination, self.mock_perspective_server.server_name)
             self.assertEqual(path, "/_matrix/key/v2/query")

--- a/tests/events/test_utils.py
+++ b/tests/events/test_utils.py
@@ -37,7 +37,7 @@ from synapse.events.utils import (
     maybe_upsert_event_field,
     prune_event,
 )
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.frozenutils import freeze
 
 from tests.test_utils.event_builders import make_test_event
@@ -92,7 +92,9 @@ class PruneEventTestCase(stdlib_unittest.TestCase):
         "prev_events": [],
     }
 
-    def run_test(self, evdict: JsonDict, matchdict: JsonDict, **kwargs: Any) -> None:
+    def run_test(
+        self, evdict: LaxJsonDict, matchdict: LaxJsonDict, **kwargs: Any
+    ) -> None:
         """
         Asserts that a new event constructed with `evdict` will look like
         `matchdict` when it is redacted.

--- a/tests/federation/_remote_join.py
+++ b/tests/federation/_remote_join.py
@@ -28,7 +28,7 @@ from synapse.events.utils import strip_event
 from synapse.federation.transport.client import SendJoinResponse
 from synapse.http.matrixfederationclient import ByteParser
 from synapse.http.types import QueryParams
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 
 from tests.test_utils.event_builders import make_test_event, make_test_pdu_event
 from tests.unittest import FederatingHomeserverTestCase
@@ -307,7 +307,7 @@ class RemoteJoinHelper:
             destination: str,
             path: str,
             args: QueryParams | None = None,
-            data: JsonDict | None = None,
+            data: LaxJsonDict | None = None,
             json_data_callback: Callable[[], JsonDict] | None = None,
             long_retries: bool = False,
             timeout: int | None = None,

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -15,7 +15,7 @@ from synapse.federation.units import Edu, Transaction
 from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 from synapse.util.retryutils import NotRetryingDestination
 
@@ -55,8 +55,8 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
         )
 
         # whenever send_transaction is called, record the pdu data
-        self.pdus: list[JsonDict] = []
-        self.failed_pdus: list[JsonDict] = []
+        self.pdus: list[LaxJsonDict] = []
+        self.failed_pdus: list[LaxJsonDict] = []
         self.is_online = True
         self.federation_transport_client.send_transaction.side_effect = (
             self.record_transaction
@@ -72,7 +72,7 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
         return config
 
     async def record_transaction(
-        self, txn: Transaction, json_cb: Callable[[], JsonDict] | None
+        self, txn: Transaction, json_cb: Callable[[], LaxJsonDict] | None
     ) -> JsonDict:
         if json_cb is None:
             # The tests seem to expect that this method raises in this situation.

--- a/tests/federation/test_federation_out_of_band_membership.py
+++ b/tests/federation/test_federation_out_of_band_membership.py
@@ -43,7 +43,7 @@ from synapse.http.types import QueryParams
 from synapse.rest import admin
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
-from synapse.types import JsonDict, MutableStateMap, StateMap
+from synapse.types import JsonDict, LaxJsonDict, MutableStateMap, StateMap
 from synapse.types.handlers.sliding_sync import (
     StateValues,
 )
@@ -142,8 +142,8 @@ class OutOfBandMembershipTests(unittest.FederatingHomeserverTestCase):
         self.storage_controllers = hs.get_storage_controllers()
 
     def do_sync(
-        self, sync_body: JsonDict, *, since: str | None = None, tok: str
-    ) -> tuple[JsonDict, str]:
+        self, sync_body: LaxJsonDict, *, since: str | None = None, tok: str
+    ) -> tuple[LaxJsonDict, str]:
         """Do a sliding sync request with given body.
 
         Asserts the request was successful.
@@ -349,7 +349,7 @@ class OutOfBandMembershipTests(unittest.FederatingHomeserverTestCase):
             destination: str,
             path: str,
             args: QueryParams | None = None,
-            data: JsonDict | None = None,
+            data: LaxJsonDict | None = None,
             json_data_callback: Callable[[], JsonDict] | None = None,
             long_retries: bool = False,
             timeout: int | None = None,
@@ -502,7 +502,7 @@ class OutOfBandMembershipTests(unittest.FederatingHomeserverTestCase):
             destination: str,
             path: str,
             args: QueryParams | None = None,
-            data: JsonDict | None = None,
+            data: LaxJsonDict | None = None,
             json_data_callback: Callable[[], JsonDict] | None = None,
             long_retries: bool = False,
             timeout: int | None = None,

--- a/tests/federation/test_federation_sender.py
+++ b/tests/federation/test_federation_sender.py
@@ -35,7 +35,7 @@ from synapse.rest import admin
 from synapse.rest.client import login
 from synapse.server import HomeServer
 from synapse.storage.databases.main.events_worker import EventMetadata
-from synapse.types import JsonDict, ReadReceipt
+from synapse.types import JsonDict, LaxJsonDict, ReadReceipt
 from synapse.util.clock import Clock
 from synapse.util.duration import Duration
 
@@ -505,13 +505,13 @@ class FederationSenderDevicesTestCases(HomeserverTestCase):
         self.device_handler = device_handler
 
         # whenever send_transaction is called, record the edu data
-        self.edus: list[JsonDict] = []
+        self.edus: list[LaxJsonDict] = []
         self.federation_transport_client.send_transaction.side_effect = (
             self.record_transaction
         )
 
     async def record_transaction(
-        self, txn: Transaction, json_cb: Callable[[], JsonDict] | None = None
+        self, txn: Transaction, json_cb: Callable[[], LaxJsonDict] | None = None
     ) -> JsonDict:
         assert json_cb is not None
         data = json_cb()
@@ -885,7 +885,7 @@ class FederationSenderDevicesTestCases(HomeserverTestCase):
 
     def check_device_update_edu(
         self,
-        edu: JsonDict,
+        edu: LaxJsonDict,
         user_id: str,
         device_id: str,
         prev_stream_id: int | None,
@@ -909,7 +909,7 @@ class FederationSenderDevicesTestCases(HomeserverTestCase):
 
     def check_signing_key_update_txn(
         self,
-        txn: JsonDict,
+        txn: LaxJsonDict,
     ) -> None:
         """Check that the txn has an EDU with a signing key update."""
         edus = txn["edus"]

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -38,7 +38,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
 from synapse.storage.controllers.state import server_acl_evaluator_from_event
-from synapse.types import JsonDict, UserID
+from synapse.types import JsonDict, LaxJsonDict, UserID
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -135,7 +135,7 @@ class GetMissingEventsRoomCheckTests(unittest.FederatingHomeserverTestCase):
             self.room_blocked, num_events=5, tok=self.local_user_token
         )
 
-    def _extract_returned_event_ids(self, json_body: JsonDict) -> set[str]:
+    def _extract_returned_event_ids(self, json_body: LaxJsonDict) -> set[str]:
         """
         Given the response body of `/get_missing_events`, return the event IDs
         of the events that were returned in the response.
@@ -951,7 +951,7 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
         tok2 = self.login("fozzie", "bear")
         self.helper.join(self._room_id, second_member_user_id, tok=tok2)
 
-    def _make_join(self, user_id: str) -> JsonDict:
+    def _make_join(self, user_id: str) -> LaxJsonDict:
         channel = self.make_signed_federation_request(
             "GET",
             f"/_matrix/federation/v1/make_join/{self._room_id}/{user_id}"

--- a/tests/handlers/test_e2e_keys.py
+++ b/tests/handlers/test_e2e_keys.py
@@ -34,7 +34,7 @@ from synapse.appservice import ApplicationService
 from synapse.handlers.device import DeviceWriterHandler
 from synapse.server import HomeServer
 from synapse.storage.databases.main.appservice import _make_exclusive_regex
-from synapse.types import JsonDict, UserID
+from synapse.types import JsonDict, LaxJsonDict, UserID
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -61,7 +61,7 @@ class E2eKeysHandlerTestCase(unittest.HomeserverTestCase):
         """we should be able to re-upload the same keys"""
         local_user = "@boris:" + self.hs.hostname
         device_id = "xyz"
-        keys: JsonDict = {
+        keys: LaxJsonDict = {
             "alg1:k1": "key1",
             "alg2:k2": {"key": "key2", "signatures": {"k1": "sig1"}},
             "alg2:k3": {"key": "key3"},
@@ -747,7 +747,7 @@ class E2eKeysHandlerTestCase(unittest.HomeserverTestCase):
         self.get_success(self.handler.upload_signing_keys_for_user(local_user, keys1))
 
         # upload two device keys, which will be signed later by the self-signing key
-        device_key_1: JsonDict = {
+        device_key_1: LaxJsonDict = {
             "user_id": local_user,
             "device_id": "abc",
             "algorithms": [
@@ -760,7 +760,7 @@ class E2eKeysHandlerTestCase(unittest.HomeserverTestCase):
             },
             "signatures": {local_user: {"ed25519:abc": "base64+signature"}},
         }
-        device_key_2: JsonDict = {
+        device_key_2: LaxJsonDict = {
             "user_id": local_user,
             "device_id": "def",
             "algorithms": [
@@ -858,7 +858,7 @@ class E2eKeysHandlerTestCase(unittest.HomeserverTestCase):
         device_id = "xyz"
         # private key: OMkooTr76ega06xNvXIGPbgvvxAOzmQncN8VObS7aBA
         device_pubkey = "NnHhnqiMFQkq969szYkooLaBAXW244ZOxgukCvm2ZeY"
-        device_key: JsonDict = {
+        device_key: LaxJsonDict = {
             "user_id": local_user,
             "device_id": device_id,
             "algorithms": [
@@ -880,7 +880,7 @@ class E2eKeysHandlerTestCase(unittest.HomeserverTestCase):
 
         # private key: 2lonYOM6xYKdEsO+6KrC766xBcHnYnim1x/4LFGF8B0
         master_pubkey = "nqOvzeuGWT/sRx3h7+MHoInYj3Uk2LD/unI9kDYcHwk"
-        master_key: JsonDict = {
+        master_key: LaxJsonDict = {
             "user_id": local_user,
             "usage": ["master"],
             "keys": {"ed25519:" + master_pubkey: master_pubkey},
@@ -923,7 +923,7 @@ class E2eKeysHandlerTestCase(unittest.HomeserverTestCase):
         # the first user
         other_user = "@otherboris:" + self.hs.hostname
         other_master_pubkey = "fHZ3NPiKxoLQm5OoZbKa99SYxprOjNs4TwJUKP+twCM"
-        other_master_key: JsonDict = {
+        other_master_key: LaxJsonDict = {
             # private key: oyw2ZUx0O4GifbfFYM0nQvj9CL0b8B7cyN4FprtK8OI
             "user_id": other_user,
             "usage": ["master"],
@@ -1510,7 +1510,7 @@ class E2eKeysHandlerTestCase(unittest.HomeserverTestCase):
         )
 
         # Setup a response.
-        response: dict[str, dict[str, dict[str, JsonDict]]] = {
+        response: dict[str, dict[str, dict[str, LaxJsonDict]]] = {
             local_user: {device_id_1: {**as_otk, **as_fallback_key}}
         }
         self.appservice_api.claim_client_keys.return_value = (response, [])

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -34,7 +34,7 @@ from synapse.handlers.account import AccountHandler
 from synapse.module_api import ModuleApi
 from synapse.rest.client import account, devices, login, logout, register
 from synapse.server import HomeServer
-from synapse.types import JsonDict, UserID
+from synapse.types import JsonDict, LaxJsonDict, UserID
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -895,7 +895,7 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         client is trying to register.
         """
 
-        async def callback(uia_results: JsonDict, params: JsonDict) -> str:
+        async def callback(uia_results: JsonDict, params: LaxJsonDict) -> str:
             self.assertIn(LoginType.DUMMY, uia_results)
             username = params["username"]
             return username + "-foo"
@@ -907,7 +907,7 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
 
         return m
 
-    def _do_uia_assert_mock_not_called(self, username: str, m: Mock) -> JsonDict:
+    def _do_uia_assert_mock_not_called(self, username: str, m: Mock) -> LaxJsonDict:
         # Initiate the UIA flow.
         channel = self.make_request(
             "POST",
@@ -978,7 +978,7 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         self,
         access_token: str,
         device: str,
-        body: JsonDict | bytes = b"",
+        body: LaxJsonDict | bytes = b"",
     ) -> FakeChannel:
         """Delete an individual device."""
         channel = self.make_request(

--- a/tests/handlers/test_receipts.py
+++ b/tests/handlers/test_receipts.py
@@ -25,7 +25,7 @@ from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import EduTypes, ReceiptTypes
 from synapse.server import HomeServer
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -333,7 +333,7 @@ class ReceiptsTestCase(unittest.HomeserverTestCase):
         self.assertEqual(events, original_events)
 
     def _test_filters_private(
-        self, events: list[JsonDict], expected_output: list[JsonDict]
+        self, events: list[LaxJsonDict], expected_output: list[JsonDict]
     ) -> None:
         """Tests that the _filter_out_private returns the expected output"""
         filtered_events = self.event_source.filter_out_private_receipts(

--- a/tests/handlers/test_room_list.py
+++ b/tests/handlers/test_room_list.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 
 from synapse.rest import admin
 from synapse.rest.client import directory, login, room
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 
 from tests import unittest
 from tests.utils import default_config
@@ -30,7 +30,7 @@ class RoomListHandlerTestCase(unittest.HomeserverTestCase):
         assert channel.code == HTTPStatus.OK, f"couldn't publish room: {channel.result}"
         return room_id
 
-    def default_config(self) -> JsonDict:
+    def default_config(self) -> LaxJsonDict:
         config = default_config(server_name="test")
         config["room_list_publication_rules"] = [{"action": "allow"}]
         return config

--- a/tests/handlers/test_room_policy.py
+++ b/tests/handlers/test_room_policy.py
@@ -32,7 +32,7 @@ from synapse.handlers.room_policy import POLICY_SERVER_KEY_ID
 from synapse.rest import admin
 from synapse.rest.client import filter, login, room, sync
 from synapse.server import HomeServer
-from synapse.types import JsonDict, UserID
+from synapse.types import JsonDict, LaxJsonDict, UserID
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -130,7 +130,7 @@ class RoomPolicyTestCase(unittest.FederatingHomeserverTestCase):
 
         async def policy_server_signs_event_with_wrong_key(
             destination: str, pdu: EventBase, timeout: int | None = None
-        ) -> JsonDict | None:
+        ) -> LaxJsonDict | None:
             sk = signedjson.key.generate_signing_key("policy_server")
             sigs = compute_event_signature(
                 pdu.room_version,
@@ -526,7 +526,7 @@ class RoomPolicyTestCase(unittest.FederatingHomeserverTestCase):
             f"event did not include policy server signature, signature block = {ev.get('signatures', None)}",
         )
 
-    def _fetch_federation_event(self, event_id: str) -> JsonDict | None:
+    def _fetch_federation_event(self, event_id: str) -> LaxJsonDict | None:
         # Request federation events to see the signatures
         channel = self.make_request(
             "POST",

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -40,7 +40,7 @@ from synapse.handlers.room_summary import _child_events_comparison_key, _RoomEnt
 from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
-from synapse.types import JsonDict, UserID, create_requester
+from synapse.types import JsonDict, LaxJsonDict, UserID, create_requester
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -170,7 +170,9 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
         )
 
     def _assert_hierarchy(
-        self, result: JsonDict, rooms_and_children: Iterable[tuple[str, Iterable[str]]]
+        self,
+        result: LaxJsonDict,
+        rooms_and_children: Iterable[tuple[str, Iterable[str]]],
     ) -> None:
         """
         Assert that the expected room IDs are in the response.
@@ -740,7 +742,7 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
 
         async def summarize_remote_room_hierarchy(
             _self: Any, room: Any, suggested_only: bool
-        ) -> tuple[_RoomEntry | None, dict[str, JsonDict], set[str]]:
+        ) -> tuple[_RoomEntry | None, dict[str, LaxJsonDict], set[str]]:
             return requested_room_entry, {subroom: child_room}, set()
 
         # Add a room to the space which is on another server.
@@ -793,7 +795,7 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
 
         async def summarize_remote_room_hierarchy(
             _self: Any, room: Any, suggested_only: bool
-        ) -> tuple[_RoomEntry | None, dict[str, JsonDict], set[str]]:
+        ) -> tuple[_RoomEntry | None, dict[str, LaxJsonDict], set[str]]:
             return requested_room_entry, {fed_subroom: child_room}, set()
 
         expected = [
@@ -921,7 +923,7 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
 
         async def summarize_remote_room_hierarchy(
             _self: Any, room: Any, suggested_only: bool
-        ) -> tuple[_RoomEntry | None, dict[str, JsonDict], set[str]]:
+        ) -> tuple[_RoomEntry | None, dict[str, LaxJsonDict], set[str]]:
             return subspace_room_entry, dict(children_rooms), set()
 
         # Add a room to the space which is on another server.
@@ -1120,7 +1122,7 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
 
         async def summarize_remote_room_hierarchy(
             _self: Any, room: Any, suggested_only: bool
-        ) -> tuple[_RoomEntry | None, dict[str, JsonDict], set[str]]:
+        ) -> tuple[_RoomEntry | None, dict[str, LaxJsonDict], set[str]]:
             return requested_room_entry, {fed_subroom: child_room}, set()
 
         expected = [

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -43,8 +43,8 @@ from synapse.rest import admin
 from synapse.rest.client import knock, login, room
 from synapse.server import HomeServer
 from synapse.types import (
-    JsonDict,
     JsonValue,
+    LaxJsonDict,
     MultiWriterStreamToken,
     RoomStreamToken,
     StreamKeyType,
@@ -837,7 +837,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         ]
 
         # And now, Bob resyncs.
-        filter_dict: JsonDict = {"room": {"include_leave": True}}
+        filter_dict: LaxJsonDict = {"room": {"include_leave": True}}
         if empty_timeline:
             filter_dict["room"]["timeline"] = {"limit": 0}
         sync_room_result = self.get_success(

--- a/tests/http/server/_base.py
+++ b/tests/http/server/_base.py
@@ -48,7 +48,7 @@ from synapse.logging.context import (
     LoggingContext,
     make_deferred_yieldable,
 )
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 
 from tests.server import FakeChannel, make_request
 from tests.unittest import logcontext_clean
@@ -144,7 +144,7 @@ def make_request_with_cancellation_test(
     site: Site,
     method: str,
     path: str,
-    content: bytes | str | JsonDict = b"",
+    content: bytes | str | LaxJsonDict = b"",
     *,
     token: str | None = None,
 ) -> FakeChannel:

--- a/tests/http/test_servlet.py
+++ b/tests/http/test_servlet.py
@@ -32,7 +32,7 @@ from synapse.http.servlet import (
 from synapse.http.site import SynapseRequest
 from synapse.rest.client._base import client_patterns
 from synapse.server import HomeServer
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.cancellation import cancellable
 from synapse.util.duration import Duration
 
@@ -40,7 +40,7 @@ from tests import unittest
 from tests.http.server._base import disconnect_and_assert
 
 
-def make_request(content: bytes | JsonDict) -> Mock:
+def make_request(content: bytes | LaxJsonDict) -> Mock:
     """Make an object that acts enough like a request."""
     request = Mock(spec=["method", "uri", "content"])
 

--- a/tests/logging/test_terse_json.py
+++ b/tests/logging/test_terse_json.py
@@ -34,7 +34,7 @@ from synapse.logging._terse_json import (
     TerseJsonFormatter,
 )
 from synapse.logging.context import LoggingContext, LoggingContextFilter
-from synapse.types import JsonDict
+from synapse.types import LaxJsonDict
 
 from tests.logging import LoggerCleanupMixin
 from tests.server import FakeChannel, get_clock
@@ -46,7 +46,7 @@ class TerseJsonTestCase(LoggerCleanupMixin, TestCase):
         self.output = StringIO()
         self.reactor, _ = get_clock()
 
-    def get_log_line(self) -> JsonDict:
+    def get_log_line(self) -> LaxJsonDict:
         # One log message, with a single trailing newline.
         data = self.output.getvalue()
         logs = data.splitlines()
@@ -261,7 +261,7 @@ class GcpJsonFormatterTestCase(LoggerCleanupMixin, TestCase):
     def setUp(self) -> None:
         self.output = StringIO()
 
-    def get_log_line(self) -> JsonDict:
+    def get_log_line(self) -> LaxJsonDict:
         data = self.output.getvalue()
         logs = data.splitlines()
         self.assertEqual(len(logs), 1)

--- a/tests/module_api/test_federation_callbacks.py
+++ b/tests/module_api/test_federation_callbacks.py
@@ -29,7 +29,7 @@ from synapse.module_api.callbacks.federation import (
 from synapse.rest import admin
 from synapse.rest.client import login, room
 from synapse.server import HomeServer
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -314,7 +314,7 @@ class FederationDeliveryCallbackTests(unittest.FederatingHomeserverTestCase):
 
         async def _acknowledge_pdus(
             transaction: Transaction,
-            json_data_cb: Callable[[], JsonDict],
+            json_data_cb: Callable[[], LaxJsonDict],
         ) -> JsonDict:
             """
             Acknowledge the PDUs.
@@ -352,7 +352,7 @@ class FederationDeliveryCallbackTests(unittest.FederatingHomeserverTestCase):
 
         async def _error_pdus(
             transaction: Transaction,
-            json_data_cb: Callable[[], JsonDict],
+            json_data_cb: Callable[[], LaxJsonDict],
         ) -> JsonDict:
             """
             Return an error for the PDUs.

--- a/tests/module_api/test_spamchecker.py
+++ b/tests/module_api/test_spamchecker.py
@@ -28,7 +28,7 @@ from synapse.events import make_event_from_dict
 from synapse.module_api import EventBase
 from synapse.rest import admin, login, room, room_upgrade_rest_servlet
 from synapse.server import HomeServer
-from synapse.types import Codes, JsonDict
+from synapse.types import Codes, JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -53,7 +53,7 @@ class SpamCheckerTestCase(HomeserverTestCase):
         self.user_id = self.register_user("user", "password")
         self.token = self.login("user", "password")
 
-    def create_room(self, content: JsonDict) -> FakeChannel:
+    def create_room(self, content: LaxJsonDict) -> FakeChannel:
         channel = self.make_request(
             "POST",
             "/_matrix/client/r0/createRoom",
@@ -69,7 +69,7 @@ class SpamCheckerTestCase(HomeserverTestCase):
         """
 
         async def user_may_create_room(
-            user_id: str, room_config: JsonDict
+            user_id: str, room_config: LaxJsonDict
         ) -> Literal["NOT_SPAM"] | Codes:
             self.last_room_config = room_config
             self.last_user_id = user_id

--- a/tests/push/test_push_rule_evaluator.py
+++ b/tests/push/test_push_rule_evaluator.py
@@ -34,7 +34,7 @@ from synapse.rest.client import login, register, room
 from synapse.server import HomeServer
 from synapse.storage.databases.main.appservice import _make_exclusive_regex
 from synapse.synapse_rust.push import PushRuleEvaluator
-from synapse.types import JsonDict, JsonMapping, UserID
+from synapse.types import JsonDict, JsonMapping, LaxJsonDict, UserID
 from synapse.util.clock import Clock
 from synapse.util.frozenutils import freeze
 
@@ -160,7 +160,7 @@ class PushRuleEvaluatorTestCase(unittest.TestCase):
         self,
         content: JsonMapping,
         *,
-        related_events: JsonDict | None = None,
+        related_events: LaxJsonDict | None = None,
         msc4210: bool = False,
         msc4306: bool = False,
     ) -> PushRuleEvaluator:
@@ -217,13 +217,13 @@ class PushRuleEvaluatorTestCase(unittest.TestCase):
         self.assertTrue(evaluator.matches(condition, "@user:test", "foo bar"))
 
     def _assert_matches(
-        self, condition: JsonDict, content: JsonMapping, msg: str | None = None
+        self, condition: LaxJsonDict, content: JsonMapping, msg: str | None = None
     ) -> None:
         evaluator = self._get_evaluator(content)
         self.assertTrue(evaluator.matches(condition, "@user:test", "display_name"), msg)
 
     def _assert_not_matches(
-        self, condition: JsonDict, content: JsonDict, msg: str | None = None
+        self, condition: LaxJsonDict, content: JsonDict, msg: str | None = None
     ) -> None:
         evaluator = self._get_evaluator(content)
         self.assertFalse(

--- a/tests/rest/admin/test_server_notice.py
+++ b/tests/rest/admin/test_server_notice.py
@@ -27,7 +27,7 @@ from synapse.api.errors import Codes
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
 from synapse.storage.roommember import RoomsForUser
-from synapse.types import JsonDict
+from synapse.types import LaxJsonDict
 from synapse.util.clock import Clock
 from synapse.util.stringutils import random_string
 
@@ -729,7 +729,7 @@ class ServerNoticeTestCase(unittest.HomeserverTestCase):
 
         return invited_rooms
 
-    def _sync_and_get_messages(self, room_id: str, token: str) -> list[JsonDict]:
+    def _sync_and_get_messages(self, room_id: str, token: str) -> list[LaxJsonDict]:
         """
         Do a sync and get messages of a room.
 

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -59,7 +59,7 @@ from synapse.rest.client import (
 )
 from synapse.server import HomeServer
 from synapse.storage.databases.main.client_ips import LAST_SEEN_GRANULARITY
-from synapse.types import JsonDict, UserID, create_requester
+from synapse.types import JsonDict, LaxJsonDict, UserID, create_requester
 from synapse.util.clock import CLOCK_SCHEDULE_EPSILON, Clock
 
 from tests import unittest
@@ -1519,7 +1519,7 @@ class UserDevicesTestCase(unittest.HomeserverTestCase):
         # Check that all the attributes of the device reported are as expected.
         self._validate_attributes_of_device_response(channel.json_body)
 
-    def _validate_attributes_of_device_response(self, response: JsonDict) -> None:
+    def _validate_attributes_of_device_response(self, response: LaxJsonDict) -> None:
         # Check that all device expected attributes are present
         self.assertEqual(response["user_id"], self.other_user_id)
         self.assertEqual(response["device_id"], self.other_user_device_id)

--- a/tests/rest/client/sliding_sync/test_extension_sticky_events.py
+++ b/tests/rest/client/sliding_sync/test_extension_sticky_events.py
@@ -21,7 +21,7 @@ import synapse.rest.client.account_data
 from synapse.api.constants import EventTypes, EventUnsignedContentFields
 from synapse.rest.client import account_data, login, register, room, sync
 from synapse.server import HomeServer
-from synapse.types import JsonDict, StreamKeyType
+from synapse.types import JsonDict, LaxJsonDict, StreamKeyType
 from synapse.util.clock import Clock
 from synapse.util.duration import Duration
 
@@ -88,7 +88,7 @@ class SlidingSyncStickyEventsExtensionTestCase(SlidingSyncBase):
 
     def _assert_sticky_events_response(
         self,
-        response_body: JsonDict,
+        response_body: LaxJsonDict,
         expected_events_by_room: dict[str, list[str]] | None,
     ) -> str | None:
         """Assert the sliding sync response was successful and has the expected
@@ -182,7 +182,7 @@ class SlidingSyncStickyEventsExtensionTestCase(SlidingSyncBase):
         )["event_id"]
 
         # Initial sync should return the sticky event
-        sync_body: JsonDict = {
+        sync_body: LaxJsonDict = {
             "lists": DUMMY_LISTS,
             "extensions": {
                 "org.matrix.msc4354.sticky_events": {

--- a/tests/rest/client/sliding_sync/test_extension_to_device.py
+++ b/tests/rest/client/sliding_sync/test_extension_to_device.py
@@ -20,7 +20,7 @@ from twisted.internet.testing import MemoryReactor
 import synapse.rest.admin
 from synapse.rest.client import login, sendtodevice, sync
 from synapse.server import HomeServer
-from synapse.types import JsonDict, StreamKeyType
+from synapse.types import JsonDict, LaxJsonDict, StreamKeyType
 from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
@@ -58,7 +58,7 @@ class SlidingSyncToDeviceExtensionTestCase(SlidingSyncBase):
         super().prepare(reactor, clock, hs)
 
     def _assert_to_device_response(
-        self, response_body: JsonDict, expected_messages: list[JsonDict]
+        self, response_body: LaxJsonDict, expected_messages: list[JsonDict]
     ) -> str:
         """Assert the sliding sync response was successful and has the expected
         to-device messages.

--- a/tests/rest/client/sliding_sync/test_lists_filters.py
+++ b/tests/rest/client/sliding_sync/test_lists_filters.py
@@ -27,7 +27,7 @@ from synapse.api.room_versions import RoomVersions
 from synapse.events import StrippedStateEvent
 from synapse.rest.client import login, room, sync, tags
 from synapse.server import HomeServer
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
@@ -1320,7 +1320,7 @@ class SlidingSyncFiltersTestCase(SlidingSyncBase):
         user1_tok = self.login(user1_id, "pass")
 
         # Get a token before we create any rooms
-        sync_body: JsonDict = {
+        sync_body: LaxJsonDict = {
             "lists": {},
         }
         response_body, before_rooms_token = self.do_sync(sync_body, tok=user1_tok)
@@ -1402,7 +1402,7 @@ class SlidingSyncFiltersTestCase(SlidingSyncBase):
         _user2_tok = self.login(user2_id, "pass")
 
         # Get a token before we create any rooms
-        sync_body: JsonDict = {
+        sync_body: LaxJsonDict = {
             "lists": {},
         }
         response_body, before_rooms_token = self.do_sync(sync_body, tok=user1_tok)

--- a/tests/rest/client/sliding_sync/test_room_subscriptions.py
+++ b/tests/rest/client/sliding_sync/test_room_subscriptions.py
@@ -22,7 +22,7 @@ import synapse.rest.admin
 from synapse.api.constants import EventTypes, HistoryVisibility
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 
 from tests.rest.client.sliding_sync.test_sliding_sync import SlidingSyncBase
@@ -196,7 +196,7 @@ class SlidingSyncRoomSubscriptionsTestCase(SlidingSyncBase):
             user1_id, tok=user1_tok, extra_content={"name": "Foo"}
         )
 
-        sync_body: JsonDict = {
+        sync_body: LaxJsonDict = {
             "room_subscriptions": {
                 room_id1: {
                     "required_state": [

--- a/tests/rest/client/sliding_sync/test_sliding_sync.py
+++ b/tests/rest/client/sliding_sync/test_sliding_sync.py
@@ -37,7 +37,7 @@ from synapse.handlers.sliding_sync import StateValues
 from synapse.rest.client import account_data, devices, login, receipts, room, sync
 from synapse.server import HomeServer
 from synapse.types import (
-    JsonDict,
+    LaxJsonDict,
     RoomStreamToken,
     SlidingSyncStreamToken,
     StreamKeyType,
@@ -77,7 +77,7 @@ class SlidingSyncBase(unittest.HomeserverTestCase):
             return_value=self.use_new_tables
         )
 
-    def default_config(self) -> JsonDict:
+    def default_config(self) -> LaxJsonDict:
         config = super().default_config()
         # Enable sliding sync
         config["experimental_features"] = {"msc3575_enabled": True}
@@ -85,7 +85,7 @@ class SlidingSyncBase(unittest.HomeserverTestCase):
 
     def make_sync_request(
         self,
-        sync_body: JsonDict,
+        sync_body: LaxJsonDict,
         *,
         since: str | None = None,
         tok: str,
@@ -127,12 +127,12 @@ class SlidingSyncBase(unittest.HomeserverTestCase):
 
     def do_sync(
         self,
-        sync_body: JsonDict,
+        sync_body: LaxJsonDict,
         *,
         since: str | None = None,
         tok: str,
         timeout: Duration | None = None,
-    ) -> tuple[JsonDict, str]:
+    ) -> tuple[LaxJsonDict, str]:
         """Do a sliding sync request with given body.
 
         Asserts the request was successful.

--- a/tests/rest/client/test_delayed_events.py
+++ b/tests/rest/client/test_delayed_events.py
@@ -25,7 +25,7 @@ from synapse.rest import admin
 from synapse.rest.client import delayed_events, login, room, sync, versions
 from synapse.server import HomeServer
 from synapse.synapse_rust.http_client import HttpClient
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 from synapse.util.duration import Duration
 
@@ -686,7 +686,7 @@ class DelayedEventsTestCase(HomeserverTestCase):
 
         return events
 
-    def _get_delayed_event_content(self, event: JsonDict) -> JsonDict:
+    def _get_delayed_event_content(self, event: LaxJsonDict) -> JsonDict:
         key = "content"
         self.assertIn(key, event)
 

--- a/tests/rest/client/test_devices.py
+++ b/tests/rest/client/test_devices.py
@@ -26,7 +26,7 @@ from synapse.appservice import ApplicationService
 from synapse.rest import admin, devices, sync
 from synapse.rest.client import keys, login, register
 from synapse.server import HomeServer
-from synapse.types import JsonDict, UserID, create_requester
+from synapse.types import LaxJsonDict, UserID, create_requester
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -87,7 +87,7 @@ class DehydratedDeviceTestCase(unittest.HomeserverTestCase):
     def test_dehydrate_msc3814(self) -> None:
         user = self.register_user("mikey", "pass")
         token = self.login(user, "pass", device_id="device1")
-        content: JsonDict = {
+        content: LaxJsonDict = {
             "device_data": {
                 "algorithm": "m.dehydration.v1.olm",
             },
@@ -290,7 +290,7 @@ class DehydratedDeviceTestCase(unittest.HomeserverTestCase):
 
         user = self.register_user("mikey", "pass")
         token = self.login(user, "pass", device_id="device1")
-        content: JsonDict = {
+        content: LaxJsonDict = {
             "device_data": {
                 "algorithm": "m.dehydration.v1.olm",
             },
@@ -487,7 +487,7 @@ class DehydratedDeviceTestCase(unittest.HomeserverTestCase):
     def test_msc3814_dehydrated_device_delete_works(self) -> None:
         user = self.register_user("mikey", "pass")
         token = self.login(user, "pass", device_id="device1")
-        content: JsonDict = {
+        content: LaxJsonDict = {
             "device_data": {
                 "algorithm": "m.dehydration.v1.olm",
             },

--- a/tests/rest/client/test_media.py
+++ b/tests/rest/client/test_media.py
@@ -64,7 +64,7 @@ from synapse.rest.synapse.client.media_upload_limit_exceeded import (
     MEDIA_UPLOAD_LIMIT_EXCEEDED_PATH,
 )
 from synapse.server import HomeServer
-from synapse.types import JsonDict, UserID
+from synapse.types import JsonDict, LaxJsonDict, UserID
 from synapse.util.clock import Clock
 from synapse.util.stringutils import parse_and_validate_mxc_uri
 
@@ -294,7 +294,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         self.reactor.nameResolver = Resolver()  # type: ignore[assignment]
 
-    def _assert_small_png(self, json_body: JsonDict) -> None:
+    def _assert_small_png(self, json_body: LaxJsonDict) -> None:
         """Assert properties from the SMALL_PNG test image."""
         self.assertTrue(json_body["og:image"].startswith("mxc://"))
         self.assertEqual(json_body["og:image:height"], 1)

--- a/tests/rest/client/test_redactions.py
+++ b/tests/rest/client/test_redactions.py
@@ -30,7 +30,7 @@ from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
 from synapse.storage._base import db_to_json
 from synapse.storage.database import LoggingTransaction
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 
 from tests.unittest import HomeserverTestCase, override_config
@@ -91,7 +91,7 @@ class RedactionsTestCase(HomeserverTestCase):
         expect_code: int = 200,
         with_relations: list[str] | None = None,
         content: JsonDict | None = None,
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         """Helper function to send a redaction event.
 
         Returns the json body.
@@ -108,7 +108,7 @@ class RedactionsTestCase(HomeserverTestCase):
         self.assertEqual(channel.code, expect_code)
         return channel.json_body
 
-    def _sync_room_timeline(self, access_token: str, room_id: str) -> list[JsonDict]:
+    def _sync_room_timeline(self, access_token: str, room_id: str) -> list[LaxJsonDict]:
         channel = self.make_request("GET", "sync", access_token=access_token)
         self.assertEqual(channel.code, 200)
         room_sync = channel.json_body["rooms"]["join"][room_id]
@@ -642,7 +642,7 @@ class RedactionsTestCase(HomeserverTestCase):
         self.assertEqual(redact_event["redacts"], event_id)
 
         # But it isn't actually part of the event.
-        def get_event(txn: LoggingTransaction) -> JsonDict:
+        def get_event(txn: LoggingTransaction) -> LaxJsonDict:
             return db_to_json(
                 main_datastore._fetch_event_rows(txn, [redaction_event_id])[
                     redaction_event_id

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -38,7 +38,7 @@ from synapse.appservice import ApplicationService
 from synapse.rest.client import account, account_validity, login, logout, register, sync
 from synapse.server import HomeServer
 from synapse.storage._base import db_to_json
-from synapse.types import JsonDict, UserID
+from synapse.types import JsonDict, LaxJsonDict, UserID
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -364,7 +364,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
 
     @override_config({"registration_requires_token": True})
     def test_POST_registration_token_invalid(self) -> None:
-        params: JsonDict = {
+        params: LaxJsonDict = {
             "username": "kermit",
             "password": "monkey",
         }
@@ -413,7 +413,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
                 },
             )
         )
-        params1: JsonDict = {"username": "bert", "password": "monkey"}
+        params1: LaxJsonDict = {"username": "bert", "password": "monkey"}
         params2: JsonDict = {"username": "ernie", "password": "monkey"}
         # Do 2 requests without auth to get two session IDs
         channel1 = self.make_request(b"POST", self.url, params1)
@@ -537,7 +537,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
         )
 
         # Do 2 requests without auth to get two session IDs
-        params1: JsonDict = {"username": "bert", "password": "monkey"}
+        params1: LaxJsonDict = {"username": "bert", "password": "monkey"}
         params2: JsonDict = {"username": "ernie", "password": "monkey"}
         channel1 = self.make_request(b"POST", self.url, params1)
         session1 = channel1.json_body["session"]

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -29,7 +29,7 @@ from synapse.api.constants import AccountDataTypes, EventTypes, RelationTypes
 from synapse.rest import admin
 from synapse.rest.client import login, register, relations, room, sync
 from synapse.server import HomeServer
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -136,7 +136,7 @@ class BaseRelationsTestCase(unittest.HomeserverTestCase):
         self.assertEqual(200, channel.code, channel.json_body)
         return [ev["event_id"] for ev in channel.json_body["chunk"]]
 
-    def _get_bundled_aggregations(self) -> JsonDict:
+    def _get_bundled_aggregations(self) -> LaxJsonDict:
         """
         Requests /event on the parent ID and returns the m.relations field (from unsigned), if it exists.
         """
@@ -149,7 +149,7 @@ class BaseRelationsTestCase(unittest.HomeserverTestCase):
         self.assertEqual(200, channel.code, channel.json_body)
         return channel.json_body["unsigned"].get("m.relations", {})
 
-    def _find_event_in_chunk(self, events: list[JsonDict]) -> JsonDict:
+    def _find_event_in_chunk(self, events: list[JsonDict]) -> LaxJsonDict:
         """
         Find the parent event in a chunk of events and assert that it has the proper bundled aggregations.
         """
@@ -362,7 +362,10 @@ class RelationsTestCase(BaseRelationsTestCase):
         self.assertNotIn("m.relations", channel.json_body["unsigned"])
 
     def _assert_edit_bundle(
-        self, event_json: JsonDict, edit_event_id: str, edit_event_content: JsonDict
+        self,
+        event_json: LaxJsonDict,
+        edit_event_id: str,
+        edit_event_content: LaxJsonDict,
     ) -> None:
         """
         Assert that the given event has a correctly-serialised edit event in its
@@ -1101,7 +1104,7 @@ class BundledAggregationsTestCase(BaseRelationsTestCase):
         """
         access_token = access_token or self.user_token
 
-        def assert_bundle(event_json: JsonDict) -> None:
+        def assert_bundle(event_json: LaxJsonDict) -> None:
             """Assert the expected values of the bundled aggregations."""
             relations_dict = event_json["unsigned"].get("m.relations")
 
@@ -1200,7 +1203,7 @@ class BundledAggregationsTestCase(BaseRelationsTestCase):
         # the current_user_participated flag is True, create a factory for the
         # two versions.
         def _gen_assert(participated: bool) -> Callable[[JsonDict], None]:
-            def assert_thread(bundled_aggregations: JsonDict) -> None:
+            def assert_thread(bundled_aggregations: LaxJsonDict) -> None:
                 self.assertEqual(2, bundled_aggregations.get("count"))
                 self.assertEqual(
                     participated, bundled_aggregations.get("current_user_participated")
@@ -1256,7 +1259,7 @@ class BundledAggregationsTestCase(BaseRelationsTestCase):
         )
         reference_event_id = channel.json_body["event_id"]
 
-        def assert_thread(bundled_aggregations: JsonDict) -> None:
+        def assert_thread(bundled_aggregations: LaxJsonDict) -> None:
             self.assertEqual(2, bundled_aggregations.get("count"))
             self.assertTrue(bundled_aggregations.get("current_user_participated"))
             # The latest thread event has some fields that don't matter.
@@ -1486,7 +1489,7 @@ class RelationIgnoredUserTestCase(BaseRelationsTestCase):
         relation_type: str,
         allowed_event_ids: list[str],
         ignored_event_ids: list[str],
-    ) -> tuple[JsonDict, JsonDict]:
+    ) -> tuple[LaxJsonDict, LaxJsonDict]:
         """
         Fetch the relations and ensure they're all there, then ignore user2, and
         repeat.
@@ -1793,7 +1796,7 @@ class RelationRedactionTestCase(BaseRelationsTestCase):
 
 
 class ThreadsTestCase(BaseRelationsTestCase):
-    def _get_threads(self, body: JsonDict) -> list[tuple[str, str]]:
+    def _get_threads(self, body: LaxJsonDict) -> list[tuple[str, str]]:
         return [
             (
                 ev["event_id"],

--- a/tests/rest/client/test_reporting.py
+++ b/tests/rest/client/test_reporting.py
@@ -24,7 +24,7 @@ from twisted.internet.testing import MemoryReactor
 import synapse.rest.admin
 from synapse.rest.client import login, reporting, room
 from synapse.server import HomeServer
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -153,7 +153,7 @@ class ReportEventTestCase(unittest.HomeserverTestCase):
             msg=channel.result["body"],
         )
 
-    def _assert_status(self, response_status: int, data: JsonDict) -> None:
+    def _assert_status(self, response_status: int, data: LaxJsonDict) -> None:
         channel = self.make_request(
             "POST", self.report_path, data, access_token=self.other_user_tok
         )
@@ -225,7 +225,7 @@ class ReportRoomTestCase(unittest.HomeserverTestCase):
         )
         self.assertEqual(200, channel.code, msg=channel.result["body"])
 
-    def _assert_status(self, response_status: int, data: JsonDict) -> None:
+    def _assert_status(self, response_status: int, data: LaxJsonDict) -> None:
         channel = self.make_request(
             "POST",
             self.report_path,
@@ -310,7 +310,7 @@ class ReportUserTestCase(unittest.HomeserverTestCase):
         self.assertEqual(len(rows), 0)
 
     def _assert_status(
-        self, response_status: int, data: JsonDict, user_id: str | None = None
+        self, response_status: int, data: LaxJsonDict, user_id: str | None = None
     ) -> None:
         if user_id is None:
             user_id = self.target_user_id

--- a/tests/rest/client/test_retention.py
+++ b/tests/rest/client/test_retention.py
@@ -28,7 +28,7 @@ from synapse.events.utils import FilteredEvent
 from synapse.rest import admin
 from synapse.rest.client import login, retention, room
 from synapse.server import HomeServer
-from synapse.types import JsonDict, create_requester
+from synapse.types import LaxJsonDict, create_requester
 from synapse.util.clock import Clock
 from synapse.visibility import filter_and_transform_events_for_client
 
@@ -247,7 +247,7 @@ class RetentionTestCase(unittest.HomeserverTestCase):
         # has been purged.
         self.get_event(room_id, bool(create_event))
 
-    def get_event(self, event_id: str, expect_none: bool = False) -> JsonDict:
+    def get_event(self, event_id: str, expect_none: bool = False) -> LaxJsonDict:
         event = self.get_success(self.store.get_event(event_id, allow_none=True))
 
         if expect_none:
@@ -387,7 +387,7 @@ class RetentionNoDefaultPolicyTestCase(unittest.HomeserverTestCase):
 
     def get_event(
         self, room_id: str, event_id: str, expected_code: int = 200
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         url = "/_matrix/client/r0/rooms/%s/event/%s" % (room_id, event_id)
 
         channel = self.make_request("GET", url, access_token=self.token)

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -61,7 +61,14 @@ from synapse.rest.client import (
     sync,
 )
 from synapse.server import HomeServer
-from synapse.types import JsonDict, JsonMapping, RoomAlias, UserID, create_requester
+from synapse.types import (
+    JsonDict,
+    JsonMapping,
+    LaxJsonDict,
+    RoomAlias,
+    UserID,
+    create_requester,
+)
 from synapse.util.clock import Clock
 from synapse.util.duration import Duration
 from synapse.util.stringutils import random_string
@@ -1855,12 +1862,12 @@ class RoomMessagesTestCase(RoomBase):
     def test_spam_checker_check_event_for_spam(
         self,
         name: str,
-        value: str | bool | Codes | tuple[Codes, JsonDict],
+        value: str | bool | Codes | tuple[Codes, LaxJsonDict],
         expected_code: int,
         expected_fields: dict,
     ) -> None:
         class SpamCheck:
-            mock_return_value: str | bool | Codes | tuple[Codes, JsonDict] | bool = (
+            mock_return_value: str | bool | Codes | tuple[Codes, LaxJsonDict] | bool = (
                 "NOT_SPAM"
             )
             mock_content: JsonMapping | None = None
@@ -2219,7 +2226,7 @@ class RoomInitialSyncTestCase(RoomBase):
         self.assertEqual("join", channel.json_body["membership"])
 
         # Room state is easier to assert on if we unpack it into a dict
-        state: JsonDict = {}
+        state: LaxJsonDict = {}
         for event in channel.json_body["state"]:
             if "state_key" not in event:
                 continue
@@ -2983,7 +2990,7 @@ class PublicRoomsRoomTypeFilterTestCase(unittest.HomeserverTestCase):
             tok=self.token,
         )
 
-    def default_config(self) -> JsonDict:
+    def default_config(self) -> LaxJsonDict:
         config = default_config(server_name="test")
         config["room_list_publication_rules"] = [{"action": "allow"}]
         return config
@@ -3985,7 +3992,7 @@ class RoomAliasListTestCase(unittest.HomeserverTestCase):
         res = self._get_aliases(user_tok)
         self.assertEqual(res["aliases"], [alias1])
 
-    def _get_aliases(self, access_token: str, expected_code: int = 200) -> JsonDict:
+    def _get_aliases(self, access_token: str, expected_code: int = 200) -> LaxJsonDict:
         """Calls the endpoint under test. returns the json response object."""
         channel = self.make_request(
             "GET",
@@ -4040,7 +4047,7 @@ class RoomCanonicalAliasTestCase(unittest.HomeserverTestCase):
         )
         self.assertEqual(channel.code, expected_code, channel.result)
 
-    def _get_canonical_alias(self, expected_code: int = 200) -> JsonDict:
+    def _get_canonical_alias(self, expected_code: int = 200) -> LaxJsonDict:
         """Calls the endpoint under test. returns the json response object."""
         channel = self.make_request(
             "GET",
@@ -4053,8 +4060,8 @@ class RoomCanonicalAliasTestCase(unittest.HomeserverTestCase):
         return res
 
     def _set_canonical_alias(
-        self, content: JsonDict, expected_code: int = 200
-    ) -> JsonDict:
+        self, content: LaxJsonDict, expected_code: int = 200
+    ) -> LaxJsonDict:
         """Calls the endpoint under test. returns the json response object."""
         channel = self.make_request(
             "PUT",
@@ -4815,7 +4822,7 @@ class MSC4293RedactOnBanKickTestCase(unittest.FederatingHomeserverTestCase):
     def _check_redactions(
         self,
         original_events: list[EventBase],
-        pulled_events: list[JsonDict],
+        pulled_events: list[LaxJsonDict],
         expect_redaction: bool,
         reason: str | None = None,
     ) -> None:

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -35,7 +35,7 @@ from synapse.api.constants import (
 )
 from synapse.rest.client import devices, knock, login, read_marker, receipts, room, sync
 from synapse.server import HomeServer
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -132,7 +132,7 @@ class SyncFilterTestCase(unittest.HomeserverTestCase):
         self.assertEqual(len(events), 1, [event["content"] for event in events])
         self.assertEqual(events[0]["content"]["body"], "with wrong label", events[0])
 
-    def _test_sync_filter_labels(self, sync_filter: str) -> list[JsonDict]:
+    def _test_sync_filter_labels(self, sync_filter: str) -> list[LaxJsonDict]:
         user_id = self.register_user("kermit", "test")
         tok = self.login("kermit", "test")
 

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -35,7 +35,7 @@ from synapse.module_api.callbacks.third_party_event_rules_callbacks import (
 from synapse.rest import admin
 from synapse.rest.client import account, login, profile, room
 from synapse.server import HomeServer
-from synapse.types import JsonDict, Requester, StateMap
+from synapse.types import JsonDict, LaxJsonDict, Requester, StateMap
 from synapse.util.clock import Clock
 from synapse.util.frozenutils import unfreeze
 
@@ -298,7 +298,7 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
         # first patch the event checker so that it will modify the event
         async def check(
             ev: EventBase, state: StateMap[EventBase]
-        ) -> tuple[bool, JsonDict | None]:
+        ) -> tuple[bool, LaxJsonDict | None]:
             d = ev.get_dict()
             d["content"] = {
                 "msgtype": "m.text",
@@ -446,7 +446,7 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
         # Define a callback that sends a custom event on power levels update.
         async def test_fn(
             event: EventBase, state_events: StateMap[EventBase]
-        ) -> tuple[bool, JsonDict | None]:
+        ) -> tuple[bool, LaxJsonDict | None]:
             if event.is_state() and event.type == EventTypes.PowerLevels:
                 await api.create_and_send_event_into_room(
                     {

--- a/tests/rest/client/test_transactions.py
+++ b/tests/rest/client/test_transactions.py
@@ -27,7 +27,7 @@ from twisted.internet import defer, reactor as _reactor
 
 from synapse.logging.context import SENTINEL_CONTEXT, LoggingContext, current_context
 from synapse.rest.client.transactions import CLEANUP_PERIOD, HttpTransactionCache
-from synapse.types import ISynapseReactor, JsonDict
+from synapse.types import ISynapseReactor, JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 from synapse.util.duration import Duration
 
@@ -122,7 +122,7 @@ class HttpTransactionCacheTestCase(unittest.TestCase):
         """
         called = [False]
 
-        def cb() -> "defer.Deferred[tuple[int, JsonDict]]":
+        def cb() -> "defer.Deferred[tuple[int, LaxJsonDict]]":
             if called[0]:
                 # return a valid result the second time
                 return defer.succeed(self.mock_http_response)
@@ -154,7 +154,7 @@ class HttpTransactionCacheTestCase(unittest.TestCase):
         """
         called = [False]
 
-        def cb() -> "defer.Deferred[tuple[int, JsonDict]]":
+        def cb() -> "defer.Deferred[tuple[int, LaxJsonDict]]":
             if called[0]:
                 # return a valid result the second time
                 return defer.succeed(self.mock_http_response)

--- a/tests/rest/client/utils.py
+++ b/tests/rest/client/utils.py
@@ -47,7 +47,7 @@ from twisted.web.server import Site
 from synapse.api.constants import EventTypes, Membership, ReceiptTypes
 from synapse.api.errors import Codes
 from synapse.server import HomeServer
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.duration import Duration
 
 from tests.server import FakeChannel, make_request
@@ -171,7 +171,7 @@ class RestHelper:
         expect_code: int = HTTPStatus.OK,
         tok: str | None = None,
         extra_data: dict | None = None,
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         return self.change_membership(
             room=room,
             src=src,
@@ -191,7 +191,7 @@ class RestHelper:
         appservice_user_id: str | None = None,
         expect_errcode: Codes | None = None,
         expect_additional_fields: dict | None = None,
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         return self.change_membership(
             room=room,
             src=user,
@@ -244,7 +244,7 @@ class RestHelper:
         user: str | None = None,
         expect_code: int = HTTPStatus.OK,
         tok: str | None = None,
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         return self.change_membership(
             room=room,
             src=user,
@@ -261,7 +261,7 @@ class RestHelper:
         targ: str,
         expect_code: int = HTTPStatus.OK,
         tok: str | None = None,
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         """A convenience helper: `change_membership` with `membership` preset to "ban"."""
         return self.change_membership(
             room=room,
@@ -284,7 +284,7 @@ class RestHelper:
         expect_code: int = HTTPStatus.OK,
         expect_errcode: str | None = None,
         expect_additional_fields: dict | None = None,
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         """
         Send a membership state event into a room.
 
@@ -378,7 +378,7 @@ class RestHelper:
         expect_code: int = HTTPStatus.OK,
         custom_headers: Iterable[tuple[AnyStr, AnyStr]] | None = None,
         type: str = "m.room.message",
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         if body is None:
             body = "body_text_here"
 
@@ -429,7 +429,7 @@ class RestHelper:
         tok: str | None = None,
         expect_code: int = HTTPStatus.OK,
         custom_headers: Iterable[tuple[AnyStr, AnyStr]] | None = None,
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         if txn_id is None:
             txn_id = "m%s" % (str(time.time()))
 
@@ -465,7 +465,7 @@ class RestHelper:
         tok: str | None = None,
         expect_code: int = HTTPStatus.OK,
         custom_headers: Iterable[tuple[AnyStr, AnyStr]] | None = None,
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         """
         Send an event that has a sticky duration according to MSC4354.
         """
@@ -498,7 +498,7 @@ class RestHelper:
         event_id: str,
         tok: str | None = None,
         expect_code: int = HTTPStatus.OK,
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         """Request a specific event from the server.
 
         Args:
@@ -538,7 +538,7 @@ class RestHelper:
         expect_code: int = HTTPStatus.OK,
         state_key: str = "",
         method: str = "GET",
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         """Read or write some state from a given room
 
         Args:
@@ -587,7 +587,7 @@ class RestHelper:
         tok: str,
         expect_code: int = HTTPStatus.OK,
         state_key: str = "",
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         """Gets some state from a room
 
         Args:
@@ -615,7 +615,7 @@ class RestHelper:
         tok: str | None = None,
         expect_code: int = HTTPStatus.OK,
         state_key: str = "",
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         """Set some state in a room
 
         Args:
@@ -642,7 +642,7 @@ class RestHelper:
         tok: str,
         filename: str = "test.png",
         expect_code: int = HTTPStatus.OK,
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         """Upload a piece of test media to the media repo
         Args:
             resource: The resource that will handle the upload request
@@ -718,7 +718,7 @@ class RestHelper:
         with_sid: bool = False,
         idp_id: str | None = None,
         expected_status: int = 200,
-    ) -> tuple[JsonDict, FakeAuthorizationGrant]:
+    ) -> tuple[LaxJsonDict, FakeAuthorizationGrant]:
         """Log in (as a new user) via OIDC
 
         Returns the result of the final token login and the fake authorization grant.
@@ -786,7 +786,7 @@ class RestHelper:
     def auth_via_oidc(
         self,
         fake_server: FakeOidcServer,
-        user_info_dict: JsonDict,
+        user_info_dict: LaxJsonDict,
         client_redirect_url: str | None = None,
         ui_auth_session_id: str | None = None,
         with_sid: bool = False,

--- a/tests/rest/key/v2/test_remote_key_resource.py
+++ b/tests/rest/key/v2/test_remote_key_resource.py
@@ -35,7 +35,7 @@ from synapse.http.site import SynapseRequest
 from synapse.rest.key.v2 import KeyResource
 from synapse.server import HomeServer
 from synapse.storage.keys import FetchKeyResult
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 from synapse.util.httpresourcetree import create_resource_tree
 from synapse.util.stringutils import random_string
@@ -67,7 +67,7 @@ class BaseRemoteKeyResourceTestCase(unittest.HomeserverTestCase):
             path: str,
             ignore_backoff: bool = False,
             **kwargs: Any,
-        ) -> JsonDict | list:
+        ) -> LaxJsonDict | list:
             self.assertTrue(ignore_backoff)
             self.assertEqual(destination, server_name)
             key_id = "%s:%s" % (signing_key.alg, signing_key.version)

--- a/tests/rest/media/test_url_preview.py
+++ b/tests/rest/media/test_url_preview.py
@@ -35,7 +35,7 @@ from twisted.web.resource import Resource
 from synapse.config.oembed import OEmbedEndpointConfig
 from synapse.media.url_previewer import IMAGE_CACHE_EXPIRY_MS
 from synapse.server import HomeServer
-from synapse.types import JsonDict
+from synapse.types import LaxJsonDict
 from synapse.util.clock import Clock
 from synapse.util.stringutils import parse_and_validate_mxc_uri
 
@@ -160,7 +160,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         """
         return {"/_matrix/media": self.hs.get_media_repository_resource()}
 
-    def _assert_small_png(self, json_body: JsonDict) -> None:
+    def _assert_small_png(self, json_body: LaxJsonDict) -> None:
         """Assert properties from the SMALL_PNG test image."""
         self.assertTrue(json_body["og:image"].startswith("mxc://"))
         self.assertEqual(json_body["og:image:height"], 1)

--- a/tests/scripts/test_new_matrix_user.py
+++ b/tests/scripts/test_new_matrix_user.py
@@ -21,7 +21,7 @@
 from unittest.mock import Mock, patch
 
 from synapse._scripts.register_new_matrix_user import request_registration
-from synapse.types import JsonDict
+from synapse.types import LaxJsonDict
 
 from tests.unittest import TestCase
 
@@ -40,7 +40,7 @@ class RegisterTestCase(TestCase):
             return r
 
         def post(
-            url: str, json: JsonDict | None = None, verify: bool | None = None
+            url: str, json: LaxJsonDict | None = None, verify: bool | None = None
         ) -> Mock:
             # Make sure we are sent the correct info
             assert json is not None
@@ -129,7 +129,7 @@ class RegisterTestCase(TestCase):
             return r
 
         def post(
-            url: str, json: JsonDict | None = None, verify: bool | None = None
+            url: str, json: LaxJsonDict | None = None, verify: bool | None = None
         ) -> Mock:
             # Make sure we are sent the correct info
             assert json is not None

--- a/tests/server.py
+++ b/tests/server.py
@@ -99,7 +99,7 @@ from synapse.storage import DataStore
 from synapse.storage.database import LoggingDatabaseConnection, make_pool
 from synapse.storage.engines import BaseDatabaseEngine, create_engine
 from synapse.storage.prepare_database import prepare_database
-from synapse.types import ISynapseReactor, JsonDict
+from synapse.types import ISynapseReactor, LaxJsonDict
 from synapse.util.clock import Clock
 from synapse.util.duration import Duration
 from synapse.util.json import json_encoder
@@ -164,13 +164,13 @@ class FakeChannel:
         self._request = request
 
     @property
-    def json_body(self) -> JsonDict:
+    def json_body(self) -> LaxJsonDict:
         body = json.loads(self.text_body)
         assert isinstance(body, dict)
         return body
 
     @property
-    def json_list(self) -> list[JsonDict]:
+    def json_list(self) -> list[LaxJsonDict]:
         body = json.loads(self.text_body)
         assert isinstance(body, list)
         return body
@@ -449,7 +449,7 @@ def make_request(
     site: Site | FakeSite,
     method: bytes | str,
     path: bytes | str,
-    content: bytes | str | JsonDict = b"",
+    content: bytes | str | LaxJsonDict = b"",
     access_token: str | None = None,
     request: type[Request] = SynapseRequest,
     shorthand: bool = True,
@@ -1212,7 +1212,7 @@ def setup_test_homeserver(
     if USE_POSTGRES_FOR_TESTS:
         test_db = "synapse_test_%s" % uuid.uuid4().hex
 
-        database_config: JsonDict = {
+        database_config: LaxJsonDict = {
             "name": "psycopg2",
             "args": {
                 "dbname": test_db,

--- a/tests/server_notices/__init__.py
+++ b/tests/server_notices/__init__.py
@@ -18,7 +18,7 @@ from twisted.test.proto_helpers import MemoryReactor
 import synapse.rest.admin
 from synapse.rest.client import login, room, sync
 from synapse.server import HomeServer
-from synapse.types import JsonDict
+from synapse.types import LaxJsonDict
 from synapse.util.clock import Clock
 from synapse.util.duration import Duration
 
@@ -43,7 +43,7 @@ class ServerNoticesTests(unittest.HomeserverTestCase):
         room.register_servlets,
     ]
 
-    def default_config(self) -> JsonDict:
+    def default_config(self) -> LaxJsonDict:
         config = default_config(server_name="test")
 
         config.update({"server_notices": DEFAULT_SERVER_NOTICES_CONFIG})
@@ -77,7 +77,7 @@ class ServerNoticesTests(unittest.HomeserverTestCase):
         self,
         admin_access_token: str,
         target_user_id: str,
-        notice_content: JsonDict,
+        notice_content: LaxJsonDict,
     ) -> None:
         # Send a server notice.
         channel = self.make_request(
@@ -95,7 +95,7 @@ class ServerNoticesTests(unittest.HomeserverTestCase):
         self,
         target_user_id: str,
         target_access_token: str,
-        expected_content: JsonDict,
+        expected_content: LaxJsonDict,
         user_accepts_invite: bool,
     ) -> None:
         # Have the target user sync.

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -30,7 +30,7 @@ from synapse.server_notices.resource_limits_server_notices import (
     ResourceLimitsServerNotices,
 )
 from synapse.server_notices.server_notices_sender import ServerNoticesSender
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -39,7 +39,7 @@ from tests.utils import default_config
 
 
 class TestResourceLimitsServerNotices(unittest.HomeserverTestCase):
-    def default_config(self) -> JsonDict:
+    def default_config(self) -> LaxJsonDict:
         config = default_config(server_name="test")
 
         config.update(

--- a/tests/storage/test_background_update.py
+++ b/tests/storage/test_background_update.py
@@ -36,7 +36,7 @@ from synapse.storage.background_updates import (
 )
 from synapse.storage.database import LoggingTransaction
 from synapse.storage.engines import PostgresEngine, Sqlite3Engine
-from synapse.types import JsonDict
+from synapse.types import JsonDict, LaxJsonDict
 from synapse.util.clock import Clock
 from synapse.util.duration import Duration
 
@@ -58,7 +58,7 @@ class BackgroundUpdateTestCase(unittest.HomeserverTestCase):
         )
         self.store = self.hs.get_datastores().main
 
-    async def update(self, progress: JsonDict, count: int) -> int:
+    async def update(self, progress: LaxJsonDict, count: int) -> int:
         fake_work_duration = Duration(seconds=1)
         await self.clock.sleep(fake_work_duration)
         progress = {"my_key": progress["my_key"] + 1}
@@ -321,7 +321,7 @@ class BackgroundUpdateTestCase(unittest.HomeserverTestCase):
         )
 
         # Run the update with the long-running update item
-        async def update_long(progress: JsonDict, count: int) -> int:
+        async def update_long(progress: LaxJsonDict, count: int) -> int:
             very_long_fake_work_duration = Duration(seconds=5)
             await self.clock.sleep(very_long_fake_work_duration)
             progress = {"my_key": progress["my_key"] + 1}

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -46,7 +46,7 @@ from synapse.server import HomeServer
 from synapse.storage.database import LoggingTransaction
 from synapse.storage.types import Cursor
 from synapse.synapse_rust.events import EventInternalMetadata
-from synapse.types import JsonDict
+from synapse.types import LaxJsonDict
 from synapse.util.clock import Clock
 from synapse.util.json import json_encoder
 
@@ -1064,7 +1064,7 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
         # The rest are events in the room but not backfilled tet.
         our_server_events = {"5", "4", "B", "3", "A"}
 
-        complete_event_dict_map: dict[str, JsonDict] = {}
+        complete_event_dict_map: dict[str, LaxJsonDict] = {}
         stream_ordering = 0
         for event_id, prev_event_ids in event_graph.items():
             depth = depth_map[event_id]

--- a/tests/storage/test_redaction.py
+++ b/tests/storage/test_redaction.py
@@ -30,7 +30,7 @@ from synapse.events import EventBase, make_event_from_dict
 from synapse.events.builder import EventBuilder
 from synapse.server import HomeServer
 from synapse.synapse_rust.events import EventInternalMetadata
-from synapse.types import JsonDict, RoomID, UserID
+from synapse.types import JsonDict, LaxJsonDict, RoomID, UserID
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -67,7 +67,7 @@ class RedactionTestCase(unittest.HomeserverTestCase):
         room: RoomID,
         user: UserID,
         membership: str,
-        extra_content: JsonDict | None = None,
+        extra_content: LaxJsonDict | None = None,
     ) -> EventBase:
         content = {"membership": membership}
         content.update(extra_content or {})

--- a/tests/storage/test_stream.py
+++ b/tests/storage/test_stream.py
@@ -43,6 +43,7 @@ from synapse.server import HomeServer
 from synapse.storage.databases.main.stream import CurrentStateDeltaMembership
 from synapse.types import (
     JsonDict,
+    LaxJsonDict,
     PersistedEventPosition,
     RoomStreamToken,
     UserID,
@@ -149,7 +150,7 @@ class PaginationTestCase(HomeserverTestCase):
         )
         self.event_id_none = res["event_id"]
 
-    def _filter_messages(self, filter: JsonDict) -> list[str]:
+    def _filter_messages(self, filter: LaxJsonDict) -> list[str]:
         """Make a request to /messages with a filter, returns the chunk of events."""
 
         events, next_key, _ = self.get_success(
@@ -323,7 +324,7 @@ class GetLastEventInRoomBeforeStreamOrderingTestCase(HomeserverTestCase):
 
     def _send_event_on_instance(
         self, instance_name: str, room_id: str, access_token: str
-    ) -> tuple[JsonDict, PersistedEventPosition]:
+    ) -> tuple[LaxJsonDict, PersistedEventPosition]:
         """
         Send an event in a room and mimic that it was persisted by a specific
         instance/worker.

--- a/tests/test_mau.py
+++ b/tests/test_mau.py
@@ -27,7 +27,7 @@ from synapse.api.errors import Codes, HttpResponseException, SynapseError
 from synapse.appservice import ApplicationService
 from synapse.rest.client import register, sync
 from synapse.server import HomeServer
-from synapse.types import JsonDict, UserID
+from synapse.types import LaxJsonDict, UserID
 from synapse.util.clock import Clock
 
 from tests import unittest
@@ -38,7 +38,7 @@ from tests.utils import default_config
 class TestMauLimit(unittest.HomeserverTestCase):
     servlets = [register.register_servlets, sync.register_servlets]
 
-    def default_config(self) -> JsonDict:
+    def default_config(self) -> LaxJsonDict:
         config = default_config(server_name="test")
 
         config.update(

--- a/tests/test_utils/event_builders.py
+++ b/tests/test_utils/event_builders.py
@@ -22,17 +22,17 @@ from synapse.api.room_versions import (
 )
 from synapse.events import EventBase, make_event_from_dict
 from synapse.federation.federation_base import event_from_pdu_json
-from synapse.types import JsonDict
+from synapse.types import LaxJsonDict
 
 
-def default_event_fields(room_version: RoomVersion) -> JsonDict:
+def default_event_fields(room_version: RoomVersion) -> LaxJsonDict:
     """Return default values for every field required by `room_version`."""
 
     # We need to include entries for every required field for the room version.
     # Note that they don't necessarily have to be valid values, just enough to
     # allow us to construct the event class. (Ideally we'd build a fully valid
     # event, but this is fine for now.)
-    defaults: JsonDict = {
+    defaults: LaxJsonDict = {
         "type": "m.test",
         "sender": "@test:test",
         "content": {},
@@ -57,9 +57,9 @@ def default_event_fields(room_version: RoomVersion) -> JsonDict:
 
 
 def make_test_event(
-    event_dict: JsonDict | None = None,
+    event_dict: LaxJsonDict | None = None,
     room_version: RoomVersion = RoomVersions.V1,
-    internal_metadata_dict: JsonDict | None = None,
+    internal_metadata_dict: LaxJsonDict | None = None,
     rejected_reason: str | None = None,
     **fields: Unpack["_EventFields"],
 ) -> EventBase:
@@ -71,7 +71,7 @@ def make_test_event(
     `**fields` wins over `event_dict` so call sites can override a
     shared base dict with one-off tweaks.
     """
-    merged: JsonDict = {
+    merged: LaxJsonDict = {
         **default_event_fields(room_version),
         **(event_dict or {}),
         **fields,
@@ -99,7 +99,7 @@ def make_test_event(
 
 
 def make_test_pdu_event(
-    pdu: JsonDict,
+    pdu: LaxJsonDict,
     room_version: RoomVersion,
     received_time: int | None = None,
 ) -> EventBase:
@@ -121,7 +121,7 @@ class _EventFields(TypedDict):
     event_id: NotRequired[str]
     type: NotRequired[str]
     sender: NotRequired[str]
-    content: NotRequired[JsonDict]
+    content: NotRequired[LaxJsonDict]
     depth: NotRequired[int]
     origin_server_ts: NotRequired[int]
     hashes: NotRequired[dict[str, str]]

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -76,7 +76,14 @@ from synapse.logging.context import (
 from synapse.rest import RegisterServletsFunc
 from synapse.server import HomeServer
 from synapse.storage.keys import FetchKeyResult
-from synapse.types import ISynapseReactor, JsonDict, Requester, UserID, create_requester
+from synapse.types import (
+    ISynapseReactor,
+    JsonDict,
+    LaxJsonDict,
+    Requester,
+    UserID,
+    create_requester,
+)
 from synapse.util.clock import CLOCK_SCHEDULE_EPSILON, Clock
 from synapse.util.httpresourcetree import create_resource_tree
 
@@ -532,7 +539,7 @@ class HomeserverTestCase(TestCase):
             "/_synapse/admin": servlet_resource,
         }
 
-    def default_config(self) -> JsonDict:
+    def default_config(self) -> LaxJsonDict:
         """
         Get a default HomeServer config dict.
         """
@@ -565,7 +572,7 @@ class HomeserverTestCase(TestCase):
         self,
         method: bytes | str,
         path: bytes | str,
-        content: bytes | str | JsonDict = b"",
+        content: bytes | str | LaxJsonDict = b"",
         access_token: str | None = None,
         request: type[Request] = SynapseRequest,
         shorthand: bool = True,
@@ -627,7 +634,7 @@ class HomeserverTestCase(TestCase):
     def setup_test_homeserver(
         self,
         server_name: str | None = None,
-        config: JsonDict | None = None,
+        config: LaxJsonDict | None = None,
         reactor: Optional[ISynapseReactor] = None,
         clock: Clock | None = None,
         **extra_homeserver_attributes: Any,
@@ -1140,7 +1147,7 @@ class FederatingHomeserverTestCase(HomeserverTestCase):
         self,
         method: str,
         path: str,
-        content: JsonDict | None = None,
+        content: LaxJsonDict | None = None,
         await_result: bool = True,
         custom_headers: Iterable[CustomHeaderType] | None = None,
         client_ip: str = "127.0.0.1",
@@ -1184,9 +1191,9 @@ class FederatingHomeserverTestCase(HomeserverTestCase):
 
     def add_hashes_and_signatures_from_other_server(
         self,
-        event_dict: JsonDict,
+        event_dict: LaxJsonDict,
         room_version: RoomVersion = KNOWN_ROOM_VERSIONS[DEFAULT_ROOM_VERSION],
-    ) -> JsonDict:
+    ) -> LaxJsonDict:
         """Adds hashes and signatures to the given event dict
 
         Returns:
@@ -1210,7 +1217,7 @@ def _auth_header_for_request(
     content: JsonDict | None,
 ) -> str:
     """Build a suitable Authorization header for an outgoing federation request"""
-    request_description: JsonDict = {
+    request_description: LaxJsonDict = {
         "method": method,
         "uri": path,
         "destination": destination,
@@ -1230,7 +1237,7 @@ def _auth_header_for_request(
     )
 
 
-def override_config(extra_config: JsonDict) -> Callable[[TV], TV]:
+def override_config(extra_config: LaxJsonDict) -> Callable[[TV], TV]:
     """A decorator which can be applied to test functions to give additional HS config
 
     For use

--- a/tests/util/test_lrucache.py
+++ b/tests/util/test_lrucache.py
@@ -23,7 +23,7 @@
 from unittest.mock import Mock, patch
 
 from synapse.metrics.jemalloc import JemallocStats
-from synapse.types import JsonDict
+from synapse.types import LaxJsonDict
 from synapse.util.caches.lrucache import LruCache, setup_expire_lru_cache_entries
 from synapse.util.caches.treecache import TreeCache
 
@@ -338,7 +338,7 @@ class LruCacheSizedTestCase(unittest.HomeserverTestCase):
 class TimeEvictionTestCase(unittest.HomeserverTestCase):
     """Test that time based eviction works correctly."""
 
-    def default_config(self) -> JsonDict:
+    def default_config(self) -> LaxJsonDict:
         config = super().default_config()
 
         config.setdefault("caches", {})["expiry_time"] = "30m"


### PR DESCRIPTION
Part of: #20103

This pull request is intended for commit-by-commit review.

This PR does not change any semantics, it just makes the reliance of `JsonDict`'s laxity (?) explicit in relevant places of the test suite, in preparation for making `JsonDict` strict in the future.

It's a few-line tiny change in the first commit, plus a lot of repetitively simple boring/easily-verifiable mechanical changes in the second commit.

<ol>
<li>

Introduce LaxJsonDict 

</li>
<li>

Use LaxJsonDict in some tests

NOTE: This is a search and replace of `JsonDict` → `LaxJsonDict` in the `tests` module only, using an LLM-scripted 'trial and error' process to *allegedly* only make the necessary replacements.

I can't guarantee that every replacement is necessary, however via the manual testing steps below, it is easy to verify that this is *sufficient*.
In simpler times, I wouldn't have been against replacing **all** `JsonDict` occurrences in tests with `LaxJsonDict` as we don't frankly need to be strict in tests (and the goal here is _not_ to make writing tests any more painful).

As a result, it's my opinion that even if the LLM-scripted trial and error process did make unnecessary replacements, it's not a big deal here.

</li>
</ol>


---

## Manual Testing

To show that this set of replacements is sufficient to make the tests able to cope with a strict-ification of `JsonDict`,
simulate converting all remaining instances of `JsonDict` to `StrictJsonDict` within the tests module and run `mypy`:

```
rg -l JsonDict tests | xargs sd '\bJsonDict' 'StrictJsonDict' # Find and replace JsonDict -> StrictJsonDict
mypy tests
# Expect no errors
```
