### PR TITLE
Fix sending duplicate `m.room.encryption` events on room creation

### DIFF
--- a/changelog.d/20106.bugfix
+++ b/changelog.d/20106.bugfix
@@ -1,0 +1,1 @@
+Do not send a duplicate `m.room.encryption` event on room creation when the client already supplies one in the initial state and `encryption_enabled_by_default_for_room_type` is enabled. Contributed by @FrenchGithubUser @Famedly.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -4010,10 +4010,7 @@ Possible options are "all", "invite", and "off". They are defined as:
 
 Note that this option will only affect rooms created after it is set. It will also not affect rooms created by other servers.
 
-If a client supplies its own `m.room.encryption` event in the `initial_state` of its
-`/createRoom` request, that event takes precedence and this option will not overwrite it.
-This means a client may, for example, choose a different encryption algorithm, or disable
-encryption for the room by sending an empty `m.room.encryption` event.
+A client may supply its own `m.room.encryption` event in the `initial_state` of its `/createRoom` request. If that event is valid (it specifies an `algorithm` as a string), it takes precedence and this option will not overwrite it, allowing the client to, for example, choose a different encryption algorithm. An empty or otherwise invalid `m.room.encryption` event does not disable forced encryption: the default will still be applied on top of it.
 
 Defaults to `"off"`.
 

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -4010,6 +4010,11 @@ Possible options are "all", "invite", and "off". They are defined as:
 
 Note that this option will only affect rooms created after it is set. It will also not affect rooms created by other servers.
 
+If a client supplies its own `m.room.encryption` event in the `initial_state` of its
+`/createRoom` request, that event takes precedence and this option will not overwrite it.
+This means a client may, for example, choose a different encryption algorithm, or disable
+encryption for the room by sending an empty `m.room.encryption` event.
+
 Defaults to `"off"`.
 
 Example configuration:

--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -5005,6 +5005,15 @@ properties:
 
       Note that this option will only affect rooms created after it is set. It
       will also not affect rooms created by other servers.
+
+
+      A client may supply its own `m.room.encryption` event in the
+      `initial_state` of its `/createRoom` request. If that event is valid (it
+      specifies an `algorithm` as a string), it takes precedence and this option
+      will not overwrite it, allowing the client to, for example, choose a
+      different encryption algorithm. An empty or otherwise invalid
+      `m.room.encryption` event does not disable forced encryption: the default
+      will still be applied on top of it.
     enum:
       - all
       - invite

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1786,10 +1786,20 @@ class RoomCreationHandler:
             )
             events_to_send.append((event, context))
 
+        # If the client supplied its own `m.room.encryption` event in the
+        # initial state, only let it take precedence over the forced default
+        # if it is valid (i.e. specifies an `algorithm` as a string, as
+        # required by the spec). This prevents a client from bypassing forced
+        # encryption entirely by supplying an empty or malformed event.
+        supplied_encryption = initial_state.get((EventTypes.RoomEncryption, ""))
+        supplied_encryption_is_valid = isinstance(supplied_encryption, dict) and (
+            isinstance(supplied_encryption.get("algorithm"), str)
+        )
+
         if (
             preset_config["encrypted"]
             and not ignore_forced_encryption
-            and (EventTypes.RoomEncryption, "") not in initial_state
+            and not supplied_encryption_is_valid
         ):
             encryption_event, encryption_context = await create_event(
                 EventTypes.RoomEncryption,

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1786,7 +1786,11 @@ class RoomCreationHandler:
             )
             events_to_send.append((event, context))
 
-        if preset_config["encrypted"] and not ignore_forced_encryption:
+        if (
+            preset_config["encrypted"]
+            and not ignore_forced_encryption
+            and (EventTypes.RoomEncryption, "") not in initial_state
+        ):
             encryption_event, encryption_context = await create_event(
                 EventTypes.RoomEncryption,
                 {"algorithm": RoomEncryptionAlgorithms.DEFAULT},

--- a/tests/handlers/test_room.py
+++ b/tests/handlers/test_room.py
@@ -149,10 +149,11 @@ class EncryptedByDefaultTestCase(unittest.HomeserverTestCase):
         self.assertEqual(event_content, custom_content)
 
     @override_config({"encryption_enabled_by_default_for_room_type": "all"})
-    def test_user_can_disable_encryption_via_initial_state(self) -> None:
-        """Tests that a user can disable encryption for a room by supplying an
-        empty m.room.encryption event in the initial state, even when
-        encryption_enabled_by_default_for_room_type would otherwise force it on.
+    def test_empty_encryption_event_does_not_bypass_forced_encryption(self) -> None:
+        """Tests that a user cannot bypass encryption_enabled_by_default_for_room_type
+        by supplying an empty m.room.encryption event in the initial state. Since
+        such an event is not valid (it lacks the required `algorithm` key), the
+        forced default must still be applied.
         """
         # Create a user
         user = self.register_user("user", "pass")
@@ -174,14 +175,53 @@ class EncryptedByDefaultTestCase(unittest.HomeserverTestCase):
             },
         )
 
-        # Check that the room's encryption event is empty, i.e. the default was
-        # not forced on top of it.
+        # Check that the forced default encryption was still applied on top of the
+        # empty event, rather than the bypass succeeding.
         event_content = self.helper.get_state(
             room_id=room_id,
             event_type=EventTypes.RoomEncryption,
             tok=user_token,
         )
-        self.assertEqual(event_content, {})
+        self.assertEqual(
+            event_content, {"algorithm": RoomEncryptionAlgorithms.DEFAULT}
+        )
+
+    @override_config({"encryption_enabled_by_default_for_room_type": "all"})
+    def test_non_string_algorithm_does_not_bypass_forced_encryption(self) -> None:
+        """Tests that a user cannot bypass encryption_enabled_by_default_for_room_type
+        by supplying an m.room.encryption event whose `algorithm` is not a string.
+        The forced default must still be applied.
+        """
+        # Create a user
+        user = self.register_user("user", "pass")
+        user_token = self.login(user, "pass")
+
+        # Create a room, supplying an encryption event with a malformed
+        # (non-string) algorithm in the initial state.
+        room_id = self.helper.create_room_as(
+            user,
+            is_public=False,
+            tok=user_token,
+            extra_content={
+                "initial_state": [
+                    {
+                        "type": EventTypes.RoomEncryption,
+                        "state_key": "",
+                        "content": {"algorithm": 42},
+                    }
+                ]
+            },
+        )
+
+        # Check that the forced default encryption was still applied.
+        event_content = self.helper.get_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomEncryption,
+            tok=user_token,
+        )
+        self.assertEqual(
+            event_content, {"algorithm": RoomEncryptionAlgorithms.DEFAULT}
+        )
 
 
 class RoomIDCollisionTestCase(unittest.HomeserverTestCase):

--- a/tests/handlers/test_room.py
+++ b/tests/handlers/test_room.py
@@ -110,6 +110,79 @@ class EncryptedByDefaultTestCase(unittest.HomeserverTestCase):
             expect_code=404,
         )
 
+    @override_config({"encryption_enabled_by_default_for_room_type": "all"})
+    def test_user_supplied_encryption_event_is_not_overwritten(self) -> None:
+        """Tests that an m.room.encryption event supplied by the user in the
+        initial state takes precedence over the one that would otherwise be forced
+        by encryption_enabled_by_default_for_room_type, rather than a duplicate
+        default event being sent.
+        """
+        # Create a user
+        user = self.register_user("user", "pass")
+        user_token = self.login(user, "pass")
+
+        # Create a room, supplying our own encryption event with a non-default
+        # algorithm in the initial state.
+        custom_content = {"algorithm": "some.custom.invalid.algorithm"}
+        room_id = self.helper.create_room_as(
+            user,
+            is_public=False,
+            tok=user_token,
+            extra_content={
+                "initial_state": [
+                    {
+                        "type": EventTypes.RoomEncryption,
+                        "state_key": "",
+                        "content": custom_content,
+                    }
+                ]
+            },
+        )
+
+        # Check that the room's encryption event is the one we supplied, not the
+        # default that the config option would otherwise force.
+        event_content = self.helper.get_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomEncryption,
+            tok=user_token,
+        )
+        self.assertEqual(event_content, custom_content)
+
+    @override_config({"encryption_enabled_by_default_for_room_type": "all"})
+    def test_user_can_disable_encryption_via_initial_state(self) -> None:
+        """Tests that a user can disable encryption for a room by supplying an
+        empty m.room.encryption event in the initial state, even when
+        encryption_enabled_by_default_for_room_type would otherwise force it on.
+        """
+        # Create a user
+        user = self.register_user("user", "pass")
+        user_token = self.login(user, "pass")
+
+        # Create a room, supplying an empty encryption event in the initial state.
+        room_id = self.helper.create_room_as(
+            user,
+            is_public=False,
+            tok=user_token,
+            extra_content={
+                "initial_state": [
+                    {
+                        "type": EventTypes.RoomEncryption,
+                        "state_key": "",
+                        "content": {},
+                    }
+                ]
+            },
+        )
+
+        # Check that the room's encryption event is empty, i.e. the default was
+        # not forced on top of it.
+        event_content = self.helper.get_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomEncryption,
+            tok=user_token,
+        )
+        self.assertEqual(event_content, {})
+
 
 class RoomIDCollisionTestCase(unittest.HomeserverTestCase):
     servlets = [

--- a/tests/handlers/test_room.py
+++ b/tests/handlers/test_room.py
@@ -182,9 +182,7 @@ class EncryptedByDefaultTestCase(unittest.HomeserverTestCase):
             event_type=EventTypes.RoomEncryption,
             tok=user_token,
         )
-        self.assertEqual(
-            event_content, {"algorithm": RoomEncryptionAlgorithms.DEFAULT}
-        )
+        self.assertEqual(event_content, {"algorithm": RoomEncryptionAlgorithms.DEFAULT})
 
     @override_config({"encryption_enabled_by_default_for_room_type": "all"})
     def test_non_string_algorithm_does_not_bypass_forced_encryption(self) -> None:
@@ -219,9 +217,7 @@ class EncryptedByDefaultTestCase(unittest.HomeserverTestCase):
             event_type=EventTypes.RoomEncryption,
             tok=user_token,
         )
-        self.assertEqual(
-            event_content, {"algorithm": RoomEncryptionAlgorithms.DEFAULT}
-        )
+        self.assertEqual(event_content, {"algorithm": RoomEncryptionAlgorithms.DEFAULT})
 
 
 class RoomIDCollisionTestCase(unittest.HomeserverTestCase):


### PR DESCRIPTION
 on room creation when the client already supplies one in the initial state and `encryption_enabled_by_default_for_room_type` is enabled.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
