### PR TITLE
Fix the schema diff CI breaking when the Rust module was changed.

### DIFF
--- a/.ci/scripts/schema_diff.py
+++ b/.ci/scripts/schema_diff.py
@@ -193,7 +193,7 @@ def main() -> None:
             # Refresh dependencies
             print("Installing dependencies for base commit...", file=sys.stderr)
             subprocess.run(
-                ["poetry", "install", "--no-root", "--extras", "postgres"],
+                ["poetry", "install", "--extras", "postgres"],
                 cwd=REPO_ROOT,
                 check=True,
                 # Poetry install is noisy, so pipe its stdout to stderr

--- a/changelog.d/20117.misc
+++ b/changelog.d/20117.misc
@@ -1,0 +1,1 @@
+Fix the schema diff CI breaking when the Rust module was changed.


### PR DESCRIPTION
Follows: #20027

Noticed in https://github.com/element-hq/synapse/pull/20003

The problem was that `--no-root` prevents reinstalling the root project (Synapse).
However, since we just did a `git checkout`, we need to reinstall the root project in case the Rust code changed, as the
`poetry install` command is what causes the Rust to be recompiled.

Doing otherwise causes the 'Rust module outdated' error when importing `synapse`.

<ol>
<li>

schema_diff: remove --no-root from poetry install 

</li>
</ol>
