### PR TITLE
Optimize `mark_as_sent_devices_by_remote` to do less CPU work on the database

### DIFF
--- a/changelog.d/20120.misc
+++ b/changelog.d/20120.misc
@@ -1,0 +1,1 @@
+Reduce database CPU usage when marking device list changes as sent over federation.

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -922,32 +922,54 @@ class DeviceWorkerStore(RoomMemberWorkerStore, EndToEndKeyWorkerStore):
     def _mark_as_sent_devices_by_remote_txn(
         self, txn: LoggingTransaction, destination: str, stream_id: int
     ) -> None:
-        # We update the device_lists_outbound_last_success with the successfully
-        # poked users.
+        # Delete all sent outbound pokes, returning them so that we can update
+        # `device_lists_outbound_last_success` with the successfully poked users.
+        #
+        # This is a high frequency transaction (runs very often when processing a
+        # backlog of device list changes) and can bog down the database CPU with the
+        # sheer number of statements.
+        #
+        # We prefer to trade a little bit of processing time on the Python side
+        # (aggregating `max_stream_id_by_user_id`) as the alternative would be to have
+        # two separate queries; a `SELECT ... GROUP BY user_id` with the aggregation and
+        # then a `DELETE` which means we touch the same rows twice. We get to save the
+        # cost of one of those statements (less CPU on the database) and fewer
+        # statements per transaction (less round-trips) means connections turn over
+        # faster, and can move on to process the next thing.
+        #
+        # By the nature of `MAX_EDUS_PER_TRANSACTION`, we're only dealing with 100 rows
+        # at max which is pretty trivial for us to process on the Python side.
         sql = """
-            SELECT user_id, coalesce(max(o.stream_id), 0)
-            FROM device_lists_outbound_pokes as o
-            WHERE destination = ? AND o.stream_id <= ?
-            GROUP BY user_id
+            DELETE FROM device_lists_outbound_pokes
+            WHERE destination = ? AND stream_id <= ?
+            RETURNING user_id, stream_id
         """
         txn.execute(sql, (destination, stream_id))
-        rows = txn.fetchall()
 
+        # `RETURNING` gives us a row per poke (i.e. per device), so collapse down to the
+        # maximum stream ID we've successfully poked for each user.
+        max_stream_id_by_user_id: dict[str, int] = {}
+        for user_id, poke_stream_id in txn:
+            max_stream_id_by_user_id[user_id] = max(
+                max_stream_id_by_user_id.get(user_id, 0), poke_stream_id
+            )
+
+        # Update `device_lists_outbound_last_success` with the successfully poked
+        # users.
+        #
+        # We could potentially combine this in one big CTE with the query above but it
+        # isn't supported by SQLite (SQLite doesn't support `DELETE` in a CTE).
         self.db_pool.simple_upsert_many_txn(
             txn=txn,
             table="device_lists_outbound_last_success",
             key_names=("destination", "user_id"),
-            key_values=[(destination, user_id) for user_id, _ in rows],
+            key_values=[(destination, user_id) for user_id in max_stream_id_by_user_id],
             value_names=("stream_id",),
-            value_values=[(stream_id,) for _, stream_id in rows],
+            value_values=[
+                (user_stream_id,)
+                for user_stream_id in max_stream_id_by_user_id.values()
+            ],
         )
-
-        # Delete all sent outbound pokes
-        sql = """
-            DELETE FROM device_lists_outbound_pokes
-            WHERE destination = ? AND stream_id <= ?
-        """
-        txn.execute(sql, (destination, stream_id))
 
     async def add_user_signature_change_to_streams(
         self, from_user_id: str, user_ids: list[str]

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -946,8 +946,7 @@ class DeviceWorkerStore(RoomMemberWorkerStore, EndToEndKeyWorkerStore):
         """
         txn.execute(sql, (destination, stream_id))
 
-        # `RETURNING` gives us a row per poke (i.e. per device), so collapse down to the
-        # maximum stream ID we've successfully poked for each user.
+        # Aggregate `max_stream_id_by_user_id`
         max_stream_id_by_user_id: dict[str, int] = {}
         for user_id, poke_stream_id in txn:
             max_stream_id_by_user_id[user_id] = max(

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -963,7 +963,9 @@ class DeviceWorkerStore(RoomMemberWorkerStore, EndToEndKeyWorkerStore):
             txn=txn,
             table="device_lists_outbound_last_success",
             key_names=("destination", "user_id"),
-            key_values=[(destination, user_id) for user_id in max_stream_id_by_user_id],
+            key_values=[
+                (destination, user_id) for user_id in max_stream_id_by_user_id.keys()
+            ],
             value_names=("stream_id",),
             value_values=[
                 (user_stream_id,)


### PR DESCRIPTION
Optimize `mark_as_sent_devices_by_remote` to do less CPU work on the database


### Background

On `matrix.org`, since 2026-08-15, we are seeing the database CPU being saturated more than usual ([grafana](https://grafana.matrix.org/d/rYdddlPWk/node-exporter?orgId=1&from=2026-08-10T23:23:14.237Z&to=2026-08-17T23:23:14.237Z&timezone=browser&var-DS_PROMETHEUS=default&var-job=machine&var-node=matrix-db-01.matrix.org:9100&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B&refresh=1m&viewPanel=panel-77))

<img width="919" height="265" alt="CPU of database server" src="https://github.com/user-attachments/assets/9a43cf3c-bf9a-4ade-b70e-0bf0fb53f0ef" />


@reivilibre [found](https://matrix.to/#/!yHWhpxlXVaLcsgDUKb:matrix.org/$fUMf60IbFocpEuJNbmbEzFiCyKCFnAl4I4XpB27DUQs?via=banzan.uk&via=element.io&via=matrix.org) `mark_as_sent_devices_by_remote` spiking in the `DB transactions by total txn time` graph ([grafana](https://grafana.matrix.org/d/000000012/synapse?var-bucket_size=$__auto&orgId=1&from=2026-08-10T22:26:07.336Z&to=2026-08-17T22:26:07.336Z&timezone=browser&var-datasource=default&var-instance=matrix.org&var-job=synapse_federation_sender&var-index=$__all&showCategory=Thresholds&viewPanel=panel-11))

<img width="919" height="269" alt="'mark_as_sent_devices_by_remote' spiking in the 'DB transactions by total txn time' graph" src="https://github.com/user-attachments/assets/9336ce29-c045-4940-9c46-9e4906300f2d" />

And we indeed see a bunch of time being spent on `mark_as_sent_devices_by_remote` by looking at `pg_stat_statements`. The top two queries we're spending CPU on are the `SELECT` and `DELETE` statements in [`mark_as_sent_devices_by_remote`](https://github.com/element-hq/synapse/blob/94a5f2afb36a4afdc36813fd1c24b9a1c4aec252/synapse/storage/databases/main/devices.py#L922-L950).

<details>
<summary>Analyzing <code>pg_stat_statements</code></summary>

 1. See for how to access the `matrix.org` database, https://handbook.element.io/books/backend-team/page/matrixorg-ops#bkmrk-access-matrix.org-sy
 1. `ssh matrix-db-01.matrix.org`
 1. `psql matrix`
 1. Start sampling data from `pg_stat_statements` (wait 5 minutes).
    ```sql
    CREATE TEMP TABLE debug_eric_pgss_snap AS SELECT now() AS taken_at, * FROM pg_stat_statements;
    ```
       - To clean-up, just exit the `psql` session. "Temporary tables are automatically dropped at the end of a session" ([Postgres docs](https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-TEMPORARY))
 1. Then run some analysis (complex query from an LLM):
    ```sql
    WITH snap AS (SELECT min(taken_at) AS taken_at FROM debug_eric_pgss_snap)
    SELECT
        (a.total_exec_time - COALESCE(b.total_exec_time, 0))::int           AS ms,
        (a.calls           - COALESCE(b.calls, 0))                          AS calls,
        round(((a.total_exec_time - COALESCE(b.total_exec_time, 0))
               / NULLIF(a.calls - COALESCE(b.calls, 0), 0))::numeric, 3)    AS mean_ms,
        round(((a.total_exec_time - COALESCE(b.total_exec_time, 0))
               / extract(epoch FROM now() - snap.taken_at)
               * 0.001)::numeric, 3)                                        AS cpus_busy,
        round((a.shared_blks_hit - COALESCE(b.shared_blks_hit, 0))::numeric
              / NULLIF(a.calls - COALESCE(b.calls, 0), 0), 1)               AS hits_per_call,
        round((a.shared_blks_read - COALESCE(b.shared_blks_read, 0))::numeric
              / NULLIF(a.calls - COALESCE(b.calls, 0), 0), 1)               AS reads_per_call,
        round((a.shared_blks_dirtied - COALESCE(b.shared_blks_dirtied, 0))::numeric
              / NULLIF(a.calls - COALESCE(b.calls, 0), 0), 1)               AS dirty_per_call,
        round((a.wal_bytes - COALESCE(b.wal_bytes, 0))
              / NULLIF(a.calls - COALESCE(b.calls, 0), 0), 0)               AS wal_per_call,
        (b.calls IS NOT NULL)                                               AS in_snap,
        left(regexp_replace(a.query, '\s+', ' ', 'g'), 120)                 AS query
    FROM pg_stat_statements a
    LEFT JOIN debug_eric_pgss_snap b USING (queryid, userid, dbid)
    CROSS JOIN snap
    WHERE a.calls > COALESCE(b.calls, 0)
    ORDER BY ms DESC
    LIMIT 30;
    ```
 1. See results (I highlighted both relevant queries in green with the `+` diff formatting):
    ```diff
          ms    | calls  | mean_ms  | cpus_busy | hits_per_call | reads_per_call | dirty_per_call | wal_per_call | in_snap |                                                          query
      ----------+--------+----------+-----------+---------------+----------------+----------------+--------------+---------+--------------------------------------------------------------------------------------------------------------------------
    +  19571592 | 135060 |  144.910 |    61.956 |          30.8 |            0.0 |            0.8 |         6753 | t       | SELECT user_id, coalesce(max(o.stream_id), $1) FROM device_lists_outbound_pokes as o WHERE destination = $2 AND o.stream
    +   7244253 | 135080 |   53.629 |    22.932 |          31.0 |            0.0 |            0.0 |         1492 | t       | DELETE FROM device_lists_outbound_pokes WHERE destination = $1 AND stream_id <= $2
        2986823 |   1482 | 2015.400 |     9.455 |       16644.8 |         1191.3 |            0.0 |           99 | t       | WITH RECURSIVE related_events AS ( SELECT event_id, relation_type, relates_to_id, $1 AS depth FROM event_relations WHERE
         632167 |   7249 |   87.207 |     2.001 |       37167.9 |            0.0 |            0.0 |            0 | t       | SELECT s.room_id, e.event_id, s.instance_name, s.stream_id, m.membership, e.sender, s.prev_event_id, e_prev.instance_nam
         494100 |    261 | 1893.102 |     1.564 |      563213.3 |           14.7 |           16.3 |       106873 | t       | WITH pdu_destinations AS ( SELECT DISTINCT destination FROM destination_rooms LEFT JOIN destinations USING (destination)
         442961 |  10725 |   41.302 |     1.402 |          22.0 |            0.8 |            0.2 |         1363 | t       | SELECT event_id, prev_event_id, internal_metadata, rejections.event_id IS NOT NULL FROM event_edges INNER JOIN events US
         387236 |   2759 |  140.354 |     1.226 |       67774.9 |          162.1 |            0.0 |            6 | t       | SELECT room_id, membership_event_id, event_instance_name, event_stream_ordering, membership, sender, prev_membership, ro
         386455 |   4727 |   81.755 |     1.223 |       14861.7 |          206.0 |            0.0 |           38 | t       | WITH RECURSIVE links(chain_id) AS ( SELECT DISTINCT origin_chain_id FROM event_auth_chain_links WHERE origin_chain_id =
         378557 |  56157 |    6.741 |     1.198 |          85.8 |           23.4 |            0.0 |            8 | t       | SELECT e.event_id, e.stream_ordering, e.instance_name, e.room_id, ej.internal_metadata, ej.json, ej.format_version, r.ro
         330211 |  85402 |    3.867 |     1.045 |         320.7 |            1.9 |            0.0 |          182 | t       | SELECT COUNT(*), thread_id FROM event_push_actions LEFT JOIN ( SELECT thread_id, MAX(event_stream_ordering) AS threaded_
         294849 | 102309 |    2.882 |     0.933 |         676.1 |            2.4 |            0.0 |            4 | t       | WITH RECURSIVE sgs(state_group) AS ( VALUES($1::bigint) UNION ALL SELECT prev_state_group FROM state_group_edges e, sgs
         228779 |   9253 |   24.725 |     0.724 |        2348.5 |           85.7 |          101.0 |       789704 | t       | INSERT INTO device_lists_outbound_pokes (destination, instance_name, stream_id, user_id, device_id, sent, ts, opentracin
         218066 |   5042 |   43.250 |     0.690 |        4783.7 |           35.2 |            0.0 |            0 | t       | SELECT state_key, membership, event_id FROM current_state_events WHERE type = $1 AND room_id = $2 AND membership IS NOT
         214494 |   5475 |   39.177 |     0.679 |        5749.7 |          144.4 |            0.0 |           39 | t       | SELECT event_id, chain_id, sequence_number FROM event_auth_chains WHERE event_id = ANY($1)
         210758 |  36054 |    5.846 |     0.667 |         490.0 |           18.5 |            0.4 |         2996 | t       | WITH all_receipts AS ( SELECT room_id, thread_id, MAX(event_stream_ordering) AS max_receipt_stream_ordering FROM receipt
         184184 |   4741 |   38.849 |     0.583 |        7008.1 |            0.0 |            0.0 |           58 | t       | SELECT state_key FROM current_state_events WHERE membership = $1 AND type = $4 AND room_id = $2 AND state_key LIKE $3 LI
         178362 |    414 |  430.825 |     0.565 |       31284.7 |          805.2 |            1.3 |        10413 | t       | WITH matching_users AS ( SELECT user_id, vector FROM user_directory_search WHERE vector @@ to_tsquery('simple', '(''klau
         139619 |   2142 |   65.181 |     0.442 |        3706.2 |          247.5 |            0.0 |          128 | t       | SELECT m.event_id, instance_name, topological_ordering, stream_ordering FROM events AS e, room_memberships AS m WHERE e.
         135184 |   3611 |   37.437 |     0.428 |         407.3 |          192.9 |            0.0 |           85 | t       | SELECT event_id, state_group FROM event_to_state_groups WHERE event_id = ANY(ARRAY[$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$1
         133446 |     57 | 2341.164 |     0.422 |      352586.3 |            0.0 |            8.3 |        57248 | t       | WITH all_receipts AS ( SELECT room_id, thread_id, MAX(event_stream_ordering) AS max_receipt_stream_ordering FROM receipt
         133431 |   1433 |   93.113 |     0.422 |        3575.6 |          628.0 |            0.0 |           28 | t       | SELECT e.event_id, e.stream_ordering, e.instance_name, ej.internal_metadata, ej.json, ej.format_version, r.room_version,
         125461 |    129 |  972.565 |     0.397 |      388594.9 |           30.3 |            0.4 |         3279 | t       | SELECT room_id, e.sender, c.membership, event_id, e.instance_name, e.stream_ordering, r.room_version FROM local_current_
         124664 |  85396 |    1.460 |     0.395 |         211.7 |            1.8 |            0.2 |         1134 | t       | SELECT notif_count, COALESCE(unread_count, $1), thread_id FROM event_push_summary LEFT JOIN ( SELECT thread_id, MAX(even
         111971 |  58611 |    1.910 |     0.354 |         311.4 |            1.6 |            0.0 |          131 | t       | SELECT m.room_id, m.sender, m.membership, m.membership_event_id, r.room_version, m.event_instance_name, m.event_stream_o
         100977 |  12158 |    8.305 |     0.320 |        1122.6 |           13.8 |           23.8 |       157664 | t       | INSERT INTO event_push_actions ( room_id, event_id, user_id, actions, stream_ordering, topological_ordering, notif, high
          94158 |    832 |  113.170 |     0.298 |       36469.5 |            0.1 |            0.2 |         1519 | t       | SELECT state_key, room_id FROM current_state_events WHERE state_key = ANY(ARRAY[$1]) AND type = $2 AND membership = $3
          92692 |   2537 |   36.536 |     0.293 |        5261.8 |          146.9 |            0.1 |          580 | t       | SELECT COUNT(*) FROM e2e_room_keys WHERE user_id = $1 AND version = $2
          91726 |  13029 |    7.040 |     0.290 |        1468.1 |            5.6 |            0.1 |          699 | t       | SELECT user_id, device_id, d.display_name, k.key_json FROM e2e_device_keys_json k INNER JOIN devices d USING (user_id, d
          89883 |  32068 |    2.803 |     0.285 |           8.2 |            0.0 |            0.0 |          147 | t       | INSERT INTO stream_positions (stream_name, instance_name, stream_id) VALUES ($1, $2, $3) ON CONFLICT (stream_name, insta
      (30 rows)
    ```
    - The sampled window is ~5 minutes (`ms * 0.001 / cpus_busy`)
    - `ms`: Total execution time summed across all calls in the window
    - `calls`: Executions during the window
    - `mean_ms`: `ms / calls`, average duration of one execution.
    - `cpus_busy`: `total_exec_time` ("Total time spent executing the statement" [source](https://www.postgresql.org/docs/current/pgstatstatements.html)) accrued per second of wall clock
    - `reads_per_call`: Pages fetched from outside the buffer cache
    - `wal_per_call`;  WAL bytes generated.

</details>



We also did some related work in this area recently with https://github.com/element-hq/synapse/pull/20098 although it was tackling a different bottle-neck.



### This PR

This PRs combines the two separate `SELECT` and `DELETE` queries which touch the same data into one `DELETE ... RETURNING ...` query. This means we get to save the cost of one of those statements (less CPU on the database) and fewer statements per transaction (less round-trips) means connections turn over faster, and can move on to process the next thing.

This is a micro-optimization I spotted while reading [`_mark_as_sent_devices_by_remote_txn`](https://github.com/element-hq/synapse/blob/develop/synapse/storage/databases/main/devices.py#L922-L950) rather than a structural fix. I'm sure there are even better things to do to where we could even avoid this kind of work altogether but this seemed like a quick win especially given how much this particular transaction is saturating the database.

Doing things faster doesn't necessarily mean we solve the saturated/starved CPU problem but it does mean the same task costs less CPU.

From the `pg_stat_statements` samples above, we can expect to be up to ~27% more efficient with database CPU on this code path (derived from the `cpus_busy` numbers above `22.932 / (22.932 + 61.956)`). We're removing the `SELECT` (`61.956` `cpus_busy`) but I still expect the `DELETE` (`22.932` `cpus_busy`) to take on a similar cost as I'm sure it's a warm cache situation between them.


### Dev notes

```
SYNAPSE_TEST_LOG_LEVEL=INFO poetry run trial tests.federation.test_federation_sender.FederationSenderDevicesTestCases
```

---

Our minimum SQLite version is [`3.37.2`](https://github.com/element-hq/synapse/blob/94a5f2afb36a4afdc36813fd1c24b9a1c4aec252/synapse/storage/engines/sqlite.py#L79) and,

> The `RETURNING` syntax has been supported by SQLite since version 3.35.0 (2021-03-12).
>
> *-- https://sqlite.org/lang_returning.html*

---

100% CPU

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
