### PR TITLE
Enable transaction ID-based request idempotence for the `/_synapse/replication/add_user_account_data` HTTP replication API.

### DIFF
--- a/changelog.d/20125.misc
+++ b/changelog.d/20125.misc
@@ -1,0 +1,1 @@
+Enable transaction ID-based request idempotence for the `/_synapse/replication/add_user_account_data` HTTP replication API.

--- a/synapse/replication/http/account_data.py
+++ b/synapse/replication/http/account_data.py
@@ -49,7 +49,7 @@ class ReplicationAddUserAccountDataRestServlet(ReplicationEndpoint):
 
     NAME = "add_user_account_data"
     PATH_ARGS = ("user_id", "account_data_type")
-    CACHE = False
+    CACHE = True
 
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)


### PR DESCRIPTION
When the `account_data` worker starts to struggle, it seems that the replication requests
from the receipts workers start to time out and so the receipts workers add more and more
to the backlog by retrying the same request multiple times, each one leading to a new
update in the `account_data` stream.

Instead, enable the `CACHE = True` flag which adds a transaction ID to the replication URL
and automagically deduplicates the retries.
This won't solve the load on its own but might help with the death spiral.

