### PR TITLE
Schema diff CI: Fix hanging when Rust module changes

### DIFF
--- a/.ci/scripts/schema_diff.py
+++ b/.ci/scripts/schema_diff.py
@@ -33,6 +33,12 @@ def run_make_full_schema(output_dir: Path) -> None:
         sys.exit(1)
 
     cmd: list[str] = [
+        # Use faketime here for schema deltas that are wall-clock sensitive under SQLite
+        # We must only use faketime at this level because freezing the clock
+        # seems to cause `poetry install` to hang when recompiling our Rust module
+        "faketime",
+        "-f",
+        "2001-05-25 12:42:42",
         "poetry",
         "run",
         str(MAKE_FULL_SCHEMA_SCRIPT),

--- a/.github/workflows/schema_diff.yml
+++ b/.github/workflows/schema_diff.yml
@@ -31,6 +31,7 @@ jobs:
         background: true
         id: postgres
         # Use faketime here for schema deltas that are wall-clock sensitive under Postgres
+        # For SQLite, faketime is used when invoking `make_full_schema.sh` within the script
         run: |
           # Build a docker image with faketime
           mkdir /tmp/postgres-faketime
@@ -78,10 +79,8 @@ jobs:
           PGHOST: localhost
           PGUSER: postgres
           PGPASSWORD: postgres
-        # Use faketime here for schema deltas that are wall-clock sensitive under SQLite
         run: |
-          faketime -f "2001-05-25 12:42:42" \
-            poetry run python .ci/scripts/schema_diff.py \
+          poetry run python .ci/scripts/schema_diff.py \
             --base origin/develop \
             > "${{ runner.temp }}/schema_diff.md"
 

--- a/changelog.d/20129.misc
+++ b/changelog.d/20129.misc
@@ -1,0 +1,1 @@
+Fix the schema diff CI breaking when the Rust module was changed.


### PR DESCRIPTION
Follows: #20117

<ol>
<li>

schema_diff: Move faketime so it doesn't affect `poetry install`

Caused a hang in the CI for
https://github.com/element-hq/synapse/pull/20003
whilst recompiling the Rust module (it seems)

</li>
</ol>
