### PR TITLE
MSC4242: State DAGs (serving)

### DIFF
--- a/changelog.d/20133.misc
+++ b/changelog.d/20133.misc
@@ -1,0 +1,1 @@
+Add HTTP serving functions for future [MSC4242](https://github.com/matrix-org/matrix-spec-proposals/pull/4242) work.

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -500,3 +500,9 @@ class StickyEvent:
 
     This is the default specified in the MSC. Chosen arbitrarily.
     """
+
+
+class StateDag:
+    GET_MISSING_EVENTS_FIELD: Final = "org.matrix.msc4242.state_dag"
+
+    MAX_MISSING_EVENTS: Final = 1000

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -504,5 +504,7 @@ class StickyEvent:
 
 class StateDag:
     GET_MISSING_EVENTS_FIELD: Final = "org.matrix.msc4242.state_dag"
-
+    # Max number of events to return in a single /get_missing_events response.
+    # Arbitrary, servers usually never get this high so it's mostly to bound the max size of
+    # a single /get_missing_events response.
     MAX_MISSING_EVENTS: Final = 1000

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -504,7 +504,9 @@ class StickyEvent:
 
 class StateDag:
     GET_MISSING_EVENTS_FIELD: Final = "org.matrix.msc4242.state_dag"
-    # Max number of events to return in a single /get_missing_events response.
-    # Arbitrary, servers usually never get this high so it's mostly to bound the max size of
-    # a single /get_missing_events response.
     MAX_MISSING_EVENTS: Final = 1000
+    """
+    Max number of events to return in a single /get_missing_events response.
+    Arbitrary, servers usually never get this high so it's mostly to bound the max size of
+    a single /get_missing_events response.
+    """

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -30,6 +30,7 @@ from typing import (
     Callable,
     Collection,
     Mapping,
+    Sequence,
 )
 
 from prometheus_client import Counter, Gauge, Histogram
@@ -56,6 +57,7 @@ from synapse.api.errors import (
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS, RoomVersion
 from synapse.crypto.event_signing import compute_event_signature
 from synapse.events import EventBase
+from synapse.events.py_protocol import supports_msc4242_state_dag
 from synapse.events.snapshot import EventPersistencePair
 from synapse.federation.federation_base import (
     FederationBase,
@@ -864,6 +866,10 @@ class FederationServer(FederationBase):
         event, context = await self._on_send_membership_event(
             origin, content, Membership.JOIN, room_id
         )
+
+        if supports_msc4242_state_dag(event):
+            caller_supports_partial_state = False
+
         # Use the join event's own stream ordering as the upper bound when fetching
         # forward extremities (below), so we only consider extremities that existed at
         # or before the join rather than those introduced by concurrent writes that
@@ -890,28 +896,46 @@ class FederationServer(FederationBase):
             state_event_ids = prev_state_ids.values()
             servers_in_room = None
 
-        auth_chain_event_ids = await self.store.get_auth_chain_ids(
-            room_id, state_event_ids
-        )
+        state_dag: Sequence[EventBase] = ()
+        state_events: Sequence[EventBase] = ()
+        auth_chain_events: Sequence[EventBase] = ()
 
-        # if the caller has opted in, we can omit any auth_chain events which are
-        # already in state_event_ids
-        if caller_supports_partial_state:
-            auth_chain_event_ids.difference_update(state_event_ids)
+        if supports_msc4242_state_dag(event):
+            state_dag_map = await self.store.get_state_dag(
+                room_id, set(event.prev_state_events)
+            )
+            # Sort by depth, though this is just a nicety, MSC4242 does not require it
+            state_dag = sorted(
+                state_dag_map.values(), key=lambda ev: (ev.depth, ev.event_id)
+            )
+        else:
+            auth_chain_event_ids = await self.store.get_auth_chain_ids(
+                room_id, state_event_ids
+            )
 
-        auth_chain_events = await self.store.get_events_as_list(auth_chain_event_ids)
-        state_events = await self.store.get_events_as_list(state_event_ids)
+            # if the caller has opted in, we can omit any auth_chain events which are
+            # already in state_event_ids
+            if caller_supports_partial_state:
+                auth_chain_event_ids.difference_update(state_event_ids)
+
+            auth_chain_events = await self.store.get_events_as_list(
+                auth_chain_event_ids
+            )
+            state_events = await self.store.get_events_as_list(state_event_ids)
 
         # we try to do all the async stuff before this point, so that time_now is as
         # accurate as possible.
         time_now = self._clock.time_msec()
         event_json = event.get_pdu_json(time_now)
-        resp = {
+        resp: JsonDict = {
             "event": event_json,
-            "state": serialize_and_filter_pdus(state_events, time_now),
-            "auth_chain": serialize_and_filter_pdus(auth_chain_events, time_now),
             "members_omitted": caller_supports_partial_state,
         }
+        if supports_msc4242_state_dag(event):
+            resp["state_dag"] = serialize_and_filter_pdus(state_dag, time_now)
+        else:
+            resp["state"] = serialize_and_filter_pdus(state_events, time_now)
+            resp["auth_chain"] = serialize_and_filter_pdus(auth_chain_events, time_now)
 
         # Check the forward extremities for the room here. If there is more than one, it
         # is likely that another event was created in the room during the
@@ -942,7 +966,7 @@ class FederationServer(FederationBase):
 
         await self._federation_callbacks.notify_on_event_delivered_over_federation(
             origin,
-            [event, *state_events, *auth_chain_events],
+            [event, *state_dag, *state_events, *auth_chain_events],
             FederatedEventDeliveryMethod.SEND_JOIN,
         )
 

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -1270,6 +1270,7 @@ class FederationServer(FederationBase):
         earliest_events: list[str],
         latest_events: list[str],
         limit: int,
+        walk_state_dag: bool = False,
     ) -> dict[str, list]:
         async with self._server_linearizer.queue((origin, room_id)):
             origin_host, _ = parse_server_name(origin)
@@ -1284,7 +1285,7 @@ class FederationServer(FederationBase):
             )
 
             missing_events = await self.handler.on_get_missing_events(
-                origin, room_id, earliest_events, latest_events, limit
+                origin, room_id, earliest_events, latest_events, limit, walk_state_dag
             )
 
             if len(missing_events) < 5:

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -868,6 +868,7 @@ class FederationServer(FederationBase):
         )
 
         if supports_msc4242_state_dag(event):
+            # We don't yet support faster room joins in Synapse with MSC4242
             caller_supports_partial_state = False
 
         # Use the join event's own stream ordering as the upper bound when fetching
@@ -904,10 +905,7 @@ class FederationServer(FederationBase):
             state_dag_map = await self.store.get_state_dag(
                 room_id, set(event.prev_state_events)
             )
-            # Sort by depth, though this is just a nicety, MSC4242 does not require it
-            state_dag = sorted(
-                state_dag_map.values(), key=lambda ev: (ev.depth, ev.event_id)
-            )
+            state_dag = list(state_dag_map.values())
         else:
             auth_chain_event_ids = await self.store.get_auth_chain_ids(
                 room_id, state_event_ids
@@ -1284,9 +1282,14 @@ class FederationServer(FederationBase):
                 limit,
             )
 
-            missing_events = await self.handler.on_get_missing_events(
-                origin, room_id, earliest_events, latest_events, limit, walk_state_dag
-            )
+            if walk_state_dag:
+                missing_events = await self.handler.on_get_missing_events_state_dag(
+                    origin, room_id, earliest_events, latest_events, limit
+                )
+            else:
+                missing_events = await self.handler.on_get_missing_events(
+                    origin, room_id, earliest_events, latest_events, limit
+                )
 
             if len(missing_events) < 5:
                 logger.debug(

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -868,7 +868,7 @@ class FederationServer(FederationBase):
         )
 
         if supports_msc4242_state_dag(event):
-            # We don't yet support faster room joins in Synapse with MSC4242
+            # FIXME: We don't yet support faster room joins in Synapse with MSC4242
             caller_supports_partial_state = False
 
         # Use the join event's own stream ordering as the upper bound when fetching

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -149,6 +149,7 @@ import synapse.metrics
 from synapse.api.constants import EventTypes, Membership
 from synapse.api.presence import UserPresenceState
 from synapse.events import EventBase
+from synapse.events.py_protocol import supports_msc4242_state_dag
 from synapse.federation.sender.per_destination_queue import (
     CATCHUP_RETRY_INTERVAL,
     PerDestinationQueue,
@@ -660,7 +661,10 @@ class FederationSender(AbstractFederationSender):
                             # banned then it won't receive the event because it won't
                             # be in the room after the ban.
                             destinations = await self.state.get_hosts_in_room_at_events(
-                                event.room_id, event_ids=event.prev_event_ids()
+                                event.room_id,
+                                event_ids=event.prev_state_events
+                                if supports_msc4242_state_dag(event)
+                                else event.prev_event_ids(),
                             )
                         except Exception:
                             logger.exception(

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -28,7 +28,7 @@ from typing import (
     Sequence,
 )
 
-from synapse.api.constants import Direction, EduTypes
+from synapse.api.constants import Direction, EduTypes, StateDag
 from synapse.api.errors import Codes, SynapseError
 from synapse.api.room_versions import RoomVersions
 from synapse.api.urls import FEDERATION_UNSTABLE_PREFIX, FEDERATION_V2_PREFIX
@@ -639,6 +639,7 @@ class FederationGetMissingEventsServlet(BaseFederationServerServlet):
         limit = int(content.get("limit", 10))
         earliest_events = content.get("earliest_events", [])
         latest_events = content.get("latest_events", [])
+        walk_state_dag = bool(content.get(StateDag.GET_MISSING_EVENTS_FIELD, False))
 
         result = await self.handler.on_get_missing_events(
             origin,
@@ -646,6 +647,7 @@ class FederationGetMissingEventsServlet(BaseFederationServerServlet):
             earliest_events=earliest_events,
             latest_events=latest_events,
             limit=limit,
+            walk_state_dag=walk_state_dag,
         )
 
         return 200, result

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1044,7 +1044,9 @@ class FederationHandler:
         prev_event_ids = None
         prev_state_events = None
         if room_version.msc4242_state_dags:
-            prev_state_events = list(await self.store.get_state_dag_extremities(room_id))
+            prev_state_events = list(
+                await self.store.get_state_dag_extremities(room_id)
+            )
         if room_version.restricted_join_rule:
             # Note that the room's state can change out from under us and render our
             # nice join rules-conformant event non-conformant by the time we build the

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1042,6 +1042,9 @@ class FederationHandler:
         # Note that this requires the /send_join request to come back to the
         # same server.
         prev_event_ids = None
+        prev_state_events = None
+        if room_version.msc4242_state_dags:
+            prev_state_events = list(await self.store.get_state_dag_extremities(room_id))
         if room_version.restricted_join_rule:
             # Note that the room's state can change out from under us and render our
             # nice join rules-conformant event non-conformant by the time we build the
@@ -1098,6 +1101,7 @@ class FederationHandler:
             ) = await self.event_creation_handler.create_new_client_event(
                 builder=builder,
                 prev_event_ids=prev_event_ids,
+                prev_state_events=prev_state_events,
             )
         except SynapseError as e:
             logger.warning("Failed to create join to %s because %s", room_id, e)

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1586,6 +1586,7 @@ class FederationHandler:
             first_hop_events = await self.store.get_events_as_list(
                 sorted(first_hop_event_ids)
             )
+            # the sort exists to make [:limit] truncation deterministic
             first_hop_events.sort(key=lambda ev: ev.event_id)
             first_hop_events = first_hop_events[:limit]
             seed_event_ids.extend(ev.event_id for ev in first_hop_events)

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -40,7 +40,13 @@ from signedjson.sign import verify_signed_json
 from unpaddedbase64 import decode_base64
 
 from synapse import event_auth
-from synapse.api.constants import MAX_DEPTH, EventContentFields, EventTypes, Membership
+from synapse.api.constants import (
+    MAX_DEPTH,
+    EventContentFields,
+    EventTypes,
+    Membership,
+    StateDag,
+)
 from synapse.api.errors import (
     AuthError,
     CodeMessageException,
@@ -58,7 +64,8 @@ from synapse.api.errors import (
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS, RoomVersion
 from synapse.crypto.event_signing import compute_event_signature
 from synapse.event_auth import validate_event_for_room_version
-from synapse.events import EventBase
+from synapse.events import EventBase, event_exists_in_state_dag
+from synapse.events.py_protocol import supports_msc4242_state_dag
 from synapse.events.snapshot import EventContext, UnpersistedEventContextBase
 from synapse.events.validator import EventValidator
 from synapse.federation.federation_client import InvalidResponseError
@@ -1496,10 +1503,16 @@ class FederationHandler:
         earliest_events: list[str],
         latest_events: list[str],
         limit: int,
+        walk_state_dag: bool = False,
     ) -> list[EventBase]:
         # We allow partially joined rooms since in this case we are filtering out
         # non-local events in `filter_events_for_server`.
         await self._event_auth_handler.assert_host_in_room(room_id, origin, True)
+
+        if walk_state_dag:
+            return await self.on_get_missing_events_state_dag(
+                room_id, earliest_events, latest_events, limit
+            )
 
         # Only allow up to 20 events to be retrieved per request.
         limit = min(limit, 20)
@@ -1522,6 +1535,69 @@ class FederationHandler:
         )
 
         return missing_events
+
+    async def on_get_missing_events_state_dag(
+        self,
+        room_id: str,
+        earliest_events: list[str],
+        latest_events: list[str],
+        limit: int,
+    ) -> list[EventBase]:
+        """Processes a /get_missing_events request for the state DAG.
+
+        This is similar to processing the normal DAG with a few notable exceptions:
+          * The max 20 limit does not apply. As the entire state DAG needs to be filled
+            in, we cannot arbitrarily set a low limit. If the state DAG delta is 1000s of
+            events, we rely on the sender to set sensible limits depending on the
+            bandwidth/round trip tradeoff, capped at `StateDag.MAX_MISSING_EVENTS` so a
+            single request cannot ask for an unbounded response.
+          * We do not filter any events in the state DAG. History visibility does not
+            filter out delivery of auth chain events, so neither should this. All of the
+            returned events will be treated as outliers and as such will not be delivered
+            to clients.
+          * `latest_events` may name events which are not themselves in the state DAG,
+            because the caller seeds this request with whatever it received over /send.
+            Only state events have `msc4242_state_dag_edges` rows, so we walk from such an
+            event's `prev_state_events` instead, and return those as the first hop.
+        """
+        limit = min(limit, StateDag.MAX_MISSING_EVENTS)
+        earliest_event_set = set(earliest_events)
+
+        seed_events = await self.store.get_events(latest_events)
+
+        seed_event_ids: list[str] = []
+        first_hop_event_ids: set[str] = set()
+        for event_id, event in seed_events.items():
+            if event_exists_in_state_dag(event):
+                seed_event_ids.append(event_id)
+                continue
+            # event is a message, so its prev_state_events are the first returned hop
+            assert supports_msc4242_state_dag(
+                event
+            )  # type-assert to access .prev_state_events
+            first_hop_event_ids.update(
+                prev_state_event_id
+                for prev_state_event_id in event.prev_state_events
+                if prev_state_event_id not in earliest_event_set
+            )
+
+        first_hop_event_ids.difference_update(seed_event_ids)
+        first_hop_events: list[EventBase] = []
+        if first_hop_event_ids:
+            first_hop_events = await self.store.get_events_as_list(
+                sorted(first_hop_event_ids)
+            )
+            first_hop_events.sort(key=lambda ev: ev.event_id)
+            first_hop_events = first_hop_events[:limit]
+            seed_event_ids.extend(ev.event_id for ev in first_hop_events)
+
+        missing_events = await self.store.get_missing_events_state_dag(
+            room_id=room_id,
+            earliest_event_ids=earliest_events,
+            latest_event_ids=seed_event_ids,
+            limit=limit - len(first_hop_events),
+        )
+        return first_hop_events + missing_events
 
     async def exchange_third_party_invite(
         self, sender_user_id: str, target_user_id: str, room_id: str, signed: JsonDict

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1503,16 +1503,10 @@ class FederationHandler:
         earliest_events: list[str],
         latest_events: list[str],
         limit: int,
-        walk_state_dag: bool = False,
     ) -> list[EventBase]:
         # We allow partially joined rooms since in this case we are filtering out
         # non-local events in `filter_events_for_server`.
         await self._event_auth_handler.assert_host_in_room(room_id, origin, True)
-
-        if walk_state_dag:
-            return await self.on_get_missing_events_state_dag(
-                room_id, earliest_events, latest_events, limit
-            )
 
         # Only allow up to 20 events to be retrieved per request.
         limit = min(limit, 20)
@@ -1538,6 +1532,7 @@ class FederationHandler:
 
     async def on_get_missing_events_state_dag(
         self,
+        origin: str,
         room_id: str,
         earliest_events: list[str],
         latest_events: list[str],
@@ -1560,6 +1555,8 @@ class FederationHandler:
             Only state events have `msc4242_state_dag_edges` rows, so we walk from such an
             event's `prev_state_events` instead, and return those as the first hop.
         """
+
+        await self._event_auth_handler.assert_host_in_room(room_id, origin, True)
         limit = min(limit, StateDag.MAX_MISSING_EVENTS)
         earliest_event_set = set(earliest_events)
 
@@ -1580,7 +1577,9 @@ class FederationHandler:
                 for prev_state_event_id in event.prev_state_events
                 if prev_state_event_id not in earliest_event_set
             )
-
+        # `latest_events` can mix state and non-state events. If an event's
+        # prev_state_event is also one of the state-event seeds, it will be walked from
+        # below, so returning it as a first hop as well would just duplicate it.
         first_hop_event_ids.difference_update(seed_event_ids)
         first_hop_events: list[EventBase] = []
         if first_hop_event_ids:

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -55,6 +55,7 @@ from synapse.api.errors import (
     FederationError,
     FederationPullAttemptBackoffError,
     HttpResponseException,
+    InvalidAPICallError,
     NotFoundError,
     PartialStateConflictError,
     RequestSendFailed,
@@ -1555,6 +1556,11 @@ class FederationHandler:
             Only state events have `msc4242_state_dag_edges` rows, so we walk from such an
             event's `prev_state_events` instead, and return those as the first hop.
         """
+        # guard against extreme cases
+        if len(earliest_events) > 100 or len(latest_events) > 100:
+            raise InvalidAPICallError(
+                "'earliest_events' and/or 'latest_events' too large, size must be less than 100"
+            )
 
         await self._event_auth_handler.assert_host_in_room(room_id, origin, True)
         limit = min(limit, StateDag.MAX_MISSING_EVENTS)

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1244,10 +1244,6 @@ class RoomCreationHandler:
         creation_content = config.get("creation_content", {})
         # override any attempt to set room versions via the creation_content
         creation_content["room_version"] = room_version.identifier
-        # We do not currently support federating state DAG rooms.
-        # See related restriction in /send_join requests in federation_client.py.
-        if room_version.msc4242_state_dags:
-            creation_content[EventContentFields.FEDERATE] = False
 
         # trusted private chats have the invited users marked as additional creators
         if (

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1195,8 +1195,6 @@ class EventFederationWorkerStore(
         # Return all events where not all sets can reach them.
         return {eid for eid, n in event_to_missing_sets.items() if n}
 
-    # FIXME(2026-04-22): Remove comment when used. Unused currently, but will be used in
-    # future MSC4242 PRs.
     async def get_state_dag(
         self, room_id: str, forward_extrems: set[str]
     ) -> dict[str, MSC4242Event]:
@@ -1260,8 +1258,6 @@ class EventFederationWorkerStore(
 
         return result
 
-    # FIXME(2026-04-22): Remove comment when used. Unused currently, but will be used in
-    # future MSC4242 PRs.
     async def get_missing_events_state_dag(
         self,
         *,

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -20,6 +20,7 @@
 #
 import logging
 from http import HTTPStatus
+from unittest import skip as skip_test
 from unittest.mock import Mock
 
 from parameterized import parameterized
@@ -1002,36 +1003,43 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
         )
         self.assertEqual(channel.code, HTTPStatus.OK, channel.json_body)
 
-        # we should get complete room state back
-        returned_state = [
-            (ev["type"], ev["state_key"]) for ev in channel.json_body["state"]
+        expected_state = [
+            ("m.room.create", ""),
+            ("m.room.power_levels", ""),
+            ("m.room.join_rules", ""),
+            ("m.room.history_visibility", ""),
+            ("m.room.member", f"@kermit_v{room_version}:test"),
+            ("m.room.member", f"@fozzie_v{room_version}:test"),
+            # nb: *not* the joining user
         ]
-        self.assertCountEqual(
-            returned_state,
-            [
-                ("m.room.create", ""),
-                ("m.room.power_levels", ""),
-                ("m.room.join_rules", ""),
-                ("m.room.history_visibility", ""),
-                ("m.room.member", f"@kermit_v{room_version}:test"),
-                ("m.room.member", f"@fozzie_v{room_version}:test"),
-                # nb: *not* the joining user
-            ],
-        )
 
-        # also check the auth chain
-        returned_auth_chain_events = [
-            (ev["type"], ev["state_key"]) for ev in channel.json_body["auth_chain"]
-        ]
-        self.assertCountEqual(
-            returned_auth_chain_events,
-            [
-                ("m.room.create", ""),
-                ("m.room.member", f"@kermit_v{room_version}:test"),
-                ("m.room.power_levels", ""),
-                ("m.room.join_rules", ""),
-            ],
-        )
+        if KNOWN_ROOM_VERSIONS[room_version].msc4242_state_dags:
+            returned_state_dag = [
+                (ev["type"], ev["state_key"]) for ev in channel.json_body["state_dag"]
+            ]
+            self.assertCountEqual(returned_state_dag, expected_state)
+            self.assertNotIn("state", channel.json_body)
+            self.assertNotIn("auth_chain", channel.json_body)
+        else:
+            # we should get complete room state back
+            returned_state = [
+                (ev["type"], ev["state_key"]) for ev in channel.json_body["state"]
+            ]
+            self.assertCountEqual(returned_state, expected_state)
+
+            # also check the auth chain
+            returned_auth_chain_events = [
+                (ev["type"], ev["state_key"]) for ev in channel.json_body["auth_chain"]
+            ]
+            self.assertCountEqual(
+                returned_auth_chain_events,
+                [
+                    ("m.room.create", ""),
+                    ("m.room.member", f"@kermit_v{room_version}:test"),
+                    ("m.room.power_levels", ""),
+                    ("m.room.join_rules", ""),
+                ],
+            )
 
         # the room should show that the new user is a member
         r = self.get_success(self._storage_controllers.state.get_current_state(room_id))
@@ -1041,19 +1049,58 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
     @override_config({"use_frozen_dicts": True})
     def test_send_join_with_frozen_dicts(self, room_version: str) -> None:
         """Test send_join with USE_FROZEN_DICTS=True"""
-        if room_version == RoomVersions.MSC4242v12.identifier:
-            # TODO: This room version doesn't work over federation in this PR.
-            return
         self._test_send_join_common(room_version)
 
     @parameterized.expand([(k,) for k in KNOWN_ROOM_VERSIONS.keys()])
     @override_config({"use_frozen_dicts": False})
     def test_send_join_without_frozen_dicts(self, room_version: str) -> None:
         """Test send_join with USE_FROZEN_DICTS=False"""
-        if room_version == RoomVersions.MSC4242v12.identifier:
-            # TODO: This room version doesn't work over federation in this PR.
-            return
         self._test_send_join_common(room_version)
+
+    @skip_test("requires MSC4242 inbound event auth")
+    @override_config({"experimental_features": {"msc4242_enabled": True}})
+    def test_send_join_state_dag(self) -> None:
+        self._test_send_join_common(RoomVersions.MSC4242v12.identifier)
+
+    @skip_test("requires MSC4242 inbound event auth")
+    @override_config({"experimental_features": {"msc4242_enabled": True}})
+    def test_send_join_state_dag_ignores_partial_state(self) -> None:
+        room_version = RoomVersions.MSC4242v12.identifier
+        creator_user_id = self.register_user("kermit_msc4242", "test")
+        tok = self.login("kermit_msc4242", "test")
+        room_id = self.helper.create_room_as(
+            room_creator=creator_user_id, tok=tok, room_version=room_version
+        )
+
+        joining_user = "@misspiggy:" + self.OTHER_SERVER_NAME
+        channel = self.make_signed_federation_request(
+            "GET",
+            f"/_matrix/federation/v1/make_join/{room_id}/{joining_user}?ver={room_version}",
+        )
+        self.assertEqual(channel.code, HTTPStatus.OK, channel.json_body)
+
+        join_event_dict = channel.json_body["event"]
+        self.add_hashes_and_signatures_from_other_server(
+            join_event_dict,
+            KNOWN_ROOM_VERSIONS[room_version],
+        )
+        channel = self.make_signed_federation_request(
+            "PUT",
+            f"/_matrix/federation/v2/send_join/{room_id}/x?omit_members=true",
+            content=join_event_dict,
+        )
+        self.assertEqual(channel.code, HTTPStatus.OK, channel.json_body)
+        self.assertEqual(channel.json_body["members_omitted"], False)
+        self.assertNotIn("servers_in_room", channel.json_body)
+        self.assertIn("state_dag", channel.json_body)
+
+        state_dag = channel.json_body["state_dag"]
+        create_event_ids = [
+            ev
+            for ev in state_dag
+            if (ev["type"], ev["state_key"]) == ("m.room.create", "")
+        ]
+        self.assertEqual(len(create_event_ids), 1)
 
     @override_config({"experimental_features": {"msc4242_enabled": True}})
     def test_make_join_state_dag(self) -> None:
@@ -1079,7 +1126,9 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
         )
         self.assertGreater(len(extremities), 0)
         self.assertCountEqual(event["prev_state_events"], extremities)
-        self.assertIncludes(set(event["prev_state_events"]), set(extremities), exact=True)
+        self.assertIncludes(
+            set(event["prev_state_events"]), set(extremities), exact=True
+        )
 
     def test_send_join_partial_state(self) -> None:
         """/send_join should return partial state, if requested"""

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -1055,6 +1055,32 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
             return
         self._test_send_join_common(room_version)
 
+    @override_config({"experimental_features": {"msc4242_enabled": True}})
+    def test_make_join_state_dag(self) -> None:
+        room_version = RoomVersions.MSC4242v12.identifier
+        creator_user_id = self.register_user("kermit_msc4242", "test")
+        tok = self.login("kermit_msc4242", "test")
+        room_id = self.helper.create_room_as(
+            room_creator=creator_user_id, tok=tok, room_version=room_version
+        )
+
+        joining_user = "@misspiggy:" + self.OTHER_SERVER_NAME
+        channel = self.make_signed_federation_request(
+            "GET",
+            f"/_matrix/federation/v1/make_join/{room_id}/{joining_user}?ver={room_version}",
+        )
+        self.assertEqual(channel.code, HTTPStatus.OK, channel.json_body)
+
+        event = channel.json_body["event"]
+        self.assertNotIn("auth_events", event)
+
+        extremities = self.get_success(
+            self.hs.get_datastores().main.get_state_dag_extremities(room_id)
+        )
+        self.assertGreater(len(extremities), 0)
+        self.assertCountEqual(event["prev_state_events"], extremities)
+        self.assertIncludes(set(event["prev_state_events"]), set(extremities), exact=True)
+
     def test_send_join_partial_state(self) -> None:
         """/send_join should return partial state, if requested"""
         joining_user = "@misspiggy:" + self.OTHER_SERVER_NAME

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -27,12 +27,13 @@ from parameterized import parameterized
 
 from twisted.internet.testing import MemoryReactor
 
-from synapse.api.constants import EventTypes, Membership
+from synapse.api.constants import EventTypes, Membership, StateDag
 from synapse.api.errors import Codes, FederationError
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS, RoomVersions
 from synapse.config.server import DEFAULT_ROOM_VERSION
 from synapse.crypto.event_signing import add_hashes_and_signatures
 from synapse.events import EventBase
+from synapse.events.py_protocol import supports_msc4242_state_dag
 from synapse.http.types import QueryParams
 from synapse.logging.context import LoggingContext
 from synapse.rest import admin
@@ -392,6 +393,173 @@ def _create_acl_event(content: JsonDict) -> EventBase:
             "content": content,
         }
     )
+
+
+class GetMissingEventsStateDagTests(unittest.FederatingHomeserverTestCase):
+    """
+    Tests for walking the MSC4242 state DAG via /get_missing_events.
+    """
+
+    servlets = [
+        admin.register_servlets,
+        login.register_servlets,
+        room.register_servlets,
+    ]
+
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        config["experimental_features"] = {"msc4242_enabled": True}
+        return config
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        super().prepare(reactor, clock, hs)
+
+        self.local_user_id = self.register_user("alice", "pass")
+        self.local_user_token = self.login("alice", "pass")
+        self.room_id = self.helper.create_room_as(
+            room_creator=self.local_user_id,
+            tok=self.local_user_token,
+            room_version=RoomVersions.MSC4242v12.identifier,
+        )
+        self.inject_room_member(
+            self.room_id, f"@remote:{self.OTHER_SERVER_NAME}", "join"
+        )
+
+        # a message is interleaved between the two topics, so it is an ancestor of
+        # `second_topic_id` in the timeline DAG but absent from the state DAG
+        self.first_topic_id = self.helper.send_state(
+            self.room_id, "m.room.topic", {"topic": "one"}, tok=self.local_user_token
+        )["event_id"]
+        self.message_id = self.helper.send(
+            self.room_id, body="a message", tok=self.local_user_token
+        )["event_id"]
+        self.second_topic_id = self.helper.send_state(
+            self.room_id, "m.room.topic", {"topic": "two"}, tok=self.local_user_token
+        )["event_id"]
+
+    def _get_missing_events(
+        self,
+        earliest_events: list[str],
+        latest_events: list[str],
+        limit: int = 10,
+        walk_state_dag: bool = True,
+    ) -> list[JsonDict]:
+        content: JsonDict = {
+            "earliest_events": earliest_events,
+            "latest_events": latest_events,
+            "limit": limit,
+        }
+        if walk_state_dag:
+            content[StateDag.GET_MISSING_EVENTS_FIELD] = True
+
+        channel = self.make_signed_federation_request(
+            "POST",
+            f"/_matrix/federation/v1/get_missing_events/{self.room_id}",
+            content=content,
+        )
+        self.assertEqual(HTTPStatus.OK, channel.code, channel.json_body)
+        return channel.json_body["events"]
+
+    def test_walks_the_state_dag(self) -> None:
+        events = self._get_missing_events(
+            earliest_events=[],
+            latest_events=[self.second_topic_id],
+            limit=20,
+            walk_state_dag=True,
+        )
+
+        returned = [(ev["type"], ev.get("state_key")) for ev in events]
+        self.assertIn(("m.room.create", ""), returned)
+        self.assertIn(("m.room.topic", ""), returned)
+        self.assertIn(("m.room.member", self.local_user_id), returned)
+        self.assertIn(("m.room.member", f"@remote:{self.OTHER_SERVER_NAME}"), returned)
+
+        # the seed itself is not returned, so only the first topic is
+        self.assertEqual(len([ev for ev in returned if ev[0] == "m.room.topic"]), 1)
+
+        # the state DAG contains no message events
+        self.assertEqual([ev for ev in returned if ev[0] == "m.room.message"], [])
+
+    def test_stops_at_earliest_events(self) -> None:
+        events = self._get_missing_events(
+            earliest_events=[self.first_topic_id],
+            latest_events=[self.second_topic_id],
+            limit=20,
+            walk_state_dag=True,
+        )
+        self.assertEqual(events, [])
+
+    def test_honours_limit(self) -> None:
+        events = self._get_missing_events(
+            earliest_events=[],
+            latest_events=[self.second_topic_id],
+            limit=2,
+            walk_state_dag=True,
+        )
+        self.assertEqual(len(events), 2)
+
+    def test_is_opt_in(self) -> None:
+        state_dag_events = self._get_missing_events(
+            earliest_events=[],
+            latest_events=[self.second_topic_id],
+            limit=20,
+            walk_state_dag=True,
+        )
+        timeline_events = self._get_missing_events(
+            earliest_events=[],
+            latest_events=[self.second_topic_id],
+            limit=20,
+            walk_state_dag=False,
+        )
+
+        self.assertEqual(
+            [ev for ev in state_dag_events if ev["type"] == "m.room.message"], []
+        )
+        self.assertNotEqual(
+            [ev for ev in timeline_events if ev["type"] == "m.room.message"], []
+        )
+
+    def test_walks_from_a_non_state_event(self) -> None:
+        events = self._get_missing_events(
+            earliest_events=[],
+            latest_events=[self.message_id],
+            limit=20,
+            walk_state_dag=True,
+        )
+
+        returned = [(ev["type"], ev.get("state_key")) for ev in events]
+        self.assertIn(("m.room.create", ""), returned)
+        self.assertIn(("m.room.topic", ""), returned)
+        self.assertEqual([ev for ev in returned if ev[0] == "m.room.message"], [])
+
+    def test_first_hop_from_a_non_state_event_is_returned(self) -> None:
+        store = self.hs.get_datastores().main
+        message = self.get_success(store.get_event(self.message_id))
+        assert supports_msc4242_state_dag(message)
+        state_dag = self.get_success(
+            store.get_state_dag(self.room_id, set(message.prev_state_events))
+        )
+
+        events = self._get_missing_events(
+            earliest_events=[], latest_events=[self.message_id], limit=20
+        )
+
+        self.assertCountEqual(
+            [(ev["type"], ev.get("state_key")) for ev in events],
+            [(ev.type, ev.state_key) for ev in state_dag.values()],
+        )
+
+    def test_non_state_seed_stops_at_earliest_events(self) -> None:
+        message = self.get_success(
+            self.hs.get_datastores().main.get_event(self.message_id)
+        )
+        assert supports_msc4242_state_dag(message)
+        events = self._get_missing_events(
+            earliest_events=list(message.prev_state_events),
+            latest_events=[self.message_id],
+            limit=20,
+        )
+        self.assertEqual(events, [])
 
 
 class MessageAcceptTests(unittest.FederatingHomeserverTestCase):

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -441,8 +441,8 @@ class GetMissingEventsStateDagTests(unittest.FederatingHomeserverTestCase):
         self,
         earliest_events: list[str],
         latest_events: list[str],
+        walk_state_dag: bool,
         limit: int = 10,
-        walk_state_dag: bool = True,
     ) -> list[JsonDict]:
         content: JsonDict = {
             "earliest_events": earliest_events,
@@ -541,7 +541,10 @@ class GetMissingEventsStateDagTests(unittest.FederatingHomeserverTestCase):
         )
 
         events = self._get_missing_events(
-            earliest_events=[], latest_events=[self.message_id], limit=20
+            earliest_events=[],
+            latest_events=[self.message_id],
+            walk_state_dag=True,
+            limit=20,
         )
 
         self.assertCountEqual(
@@ -557,6 +560,7 @@ class GetMissingEventsStateDagTests(unittest.FederatingHomeserverTestCase):
         events = self._get_missing_events(
             earliest_events=list(message.prev_state_events),
             latest_events=[self.message_id],
+            walk_state_dag=True,
             limit=20,
         )
         self.assertEqual(events, [])
@@ -1234,8 +1238,8 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
     @override_config({"experimental_features": {"msc4242_enabled": True}})
     def test_send_join_state_dag_ignores_partial_state(self) -> None:
         room_version = RoomVersions.MSC4242v12.identifier
-        creator_user_id = self.register_user("kermit_msc4242", "test")
-        tok = self.login("kermit_msc4242", "test")
+        creator_user_id = self.register_user("user1_msc4242", "test")
+        tok = self.login("user1_msc4242", "test")
         room_id = self.helper.create_room_as(
             room_creator=creator_user_id, tok=tok, room_version=room_version
         )
@@ -1262,19 +1266,26 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
         self.assertNotIn("servers_in_room", channel.json_body)
         self.assertIn("state_dag", channel.json_body)
 
-        state_dag = channel.json_body["state_dag"]
-        create_event_ids = [
-            ev
-            for ev in state_dag
-            if (ev["type"], ev["state_key"]) == ("m.room.create", "")
-        ]
-        self.assertEqual(len(create_event_ids), 1)
+        # the full state DAG is returned, including the member events that a
+        # partial state join would have omitted to prove we are in fact ignoring the
+        # partial state flag.
+        self.assertIncludes(
+            {(ev["type"], ev["state_key"]) for ev in channel.json_body["state_dag"]},
+            {
+                ("m.room.create", ""),
+                ("m.room.power_levels", ""),
+                ("m.room.join_rules", ""),
+                ("m.room.history_visibility", ""),
+                ("m.room.member", creator_user_id),
+            },
+            exact=True,
+        )
 
     @override_config({"experimental_features": {"msc4242_enabled": True}})
     def test_make_join_state_dag(self) -> None:
         room_version = RoomVersions.MSC4242v12.identifier
-        creator_user_id = self.register_user("kermit_msc4242", "test")
-        tok = self.login("kermit_msc4242", "test")
+        creator_user_id = self.register_user("user1_msc4242", "test")
+        tok = self.login("user1_msc4242", "test")
         room_id = self.helper.create_room_as(
             room_creator=creator_user_id, tok=tok, room_version=room_version
         )

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -398,6 +398,9 @@ def _create_acl_event(content: JsonDict) -> EventBase:
 class GetMissingEventsStateDagTests(unittest.FederatingHomeserverTestCase):
     """
     Tests for walking the MSC4242 state DAG via /get_missing_events.
+
+    In future, these can be ported to Complement to benefit other servers,
+    but as of writing MSC4242 is not fully implemented so can't be in Complement yet.
     """
 
     servlets = [
@@ -469,10 +472,15 @@ class GetMissingEventsStateDagTests(unittest.FederatingHomeserverTestCase):
         )
 
         returned = [(ev["type"], ev.get("state_key")) for ev in events]
-        self.assertIn(("m.room.create", ""), returned)
-        self.assertIn(("m.room.topic", ""), returned)
-        self.assertIn(("m.room.member", self.local_user_id), returned)
-        self.assertIn(("m.room.member", f"@remote:{self.OTHER_SERVER_NAME}"), returned)
+        self.assertIncludes(
+            returned,
+            [
+                ("m.room.create", ""),
+                ("m.room.topic", ""),
+                ("m.room.member", self.local_user_id),
+                ("m.room.member", f"@remote:{self.OTHER_SERVER_NAME}"),
+            ], exact=True,
+        )
 
         # the seed itself is not returned, so only the first topic is
         self.assertEqual(len([ev for ev in returned if ev[0] == "m.room.topic"]), 1)
@@ -520,19 +528,6 @@ class GetMissingEventsStateDagTests(unittest.FederatingHomeserverTestCase):
         )
 
     def test_walks_from_a_non_state_event(self) -> None:
-        events = self._get_missing_events(
-            earliest_events=[],
-            latest_events=[self.message_id],
-            limit=20,
-            walk_state_dag=True,
-        )
-
-        returned = [(ev["type"], ev.get("state_key")) for ev in events]
-        self.assertIn(("m.room.create", ""), returned)
-        self.assertIn(("m.room.topic", ""), returned)
-        self.assertEqual([ev for ev in returned if ev[0] == "m.room.message"], [])
-
-    def test_first_hop_from_a_non_state_event_is_returned(self) -> None:
         store = self.hs.get_datastores().main
         message = self.get_success(store.get_event(self.message_id))
         assert supports_msc4242_state_dag(message)
@@ -547,10 +542,14 @@ class GetMissingEventsStateDagTests(unittest.FederatingHomeserverTestCase):
             limit=20,
         )
 
-        self.assertCountEqual(
+        # We get all the same events
+        self.assertIncludes(
             [(ev["type"], ev.get("state_key")) for ev in events],
             [(ev.type, ev.state_key) for ev in state_dag.values()],
+            exact=True,
         )
+        # and no messages (we aren't walking up prev_events)
+        self.assertEqual([ev for ev in events if ev[0] == "m.room.message"], [])
 
     def test_non_state_seed_stops_at_earliest_events(self) -> None:
         message = self.get_success(
@@ -1256,6 +1255,7 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
             join_event_dict,
             KNOWN_ROOM_VERSIONS[room_version],
         )
+        # Ask to join as a partial state (omit_members=true) which should be ignored.
         channel = self.make_signed_federation_request(
             "PUT",
             f"/_matrix/federation/v2/send_join/{room_id}/x?omit_members=true",
@@ -1298,6 +1298,7 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
         self.assertEqual(channel.code, HTTPStatus.OK, channel.json_body)
 
         event = channel.json_body["event"]
+        # MSC4242 events don't have an auth_events field.
         self.assertNotIn("auth_events", event)
 
         extremities = self.get_success(
@@ -1305,6 +1306,7 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
         )
         self.assertGreater(len(extremities), 0)
         self.assertCountEqual(event["prev_state_events"], extremities)
+        # When creating events, prev_state_events should be set to the state DAG fwd extremities
         self.assertIncludes(
             set(event["prev_state_events"]), set(extremities), exact=True
         )

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -473,13 +473,14 @@ class GetMissingEventsStateDagTests(unittest.FederatingHomeserverTestCase):
 
         returned = [(ev["type"], ev.get("state_key")) for ev in events]
         self.assertIncludes(
-            returned,
-            [
+            set(returned),
+            {
                 ("m.room.create", ""),
                 ("m.room.topic", ""),
                 ("m.room.member", self.local_user_id),
                 ("m.room.member", f"@remote:{self.OTHER_SERVER_NAME}"),
-            ], exact=True,
+            },
+            exact=True,
         )
 
         # the seed itself is not returned, so only the first topic is
@@ -544,12 +545,12 @@ class GetMissingEventsStateDagTests(unittest.FederatingHomeserverTestCase):
 
         # We get all the same events
         self.assertIncludes(
-            [(ev["type"], ev.get("state_key")) for ev in events],
-            [(ev.type, ev.state_key) for ev in state_dag.values()],
+            {(ev["type"], ev.get("state_key")) for ev in events},
+            {(ev.type, ev.state_key) for ev in state_dag.values()},
             exact=True,
         )
         # and no messages (we aren't walking up prev_events)
-        self.assertEqual([ev for ev in events if ev[0] == "m.room.message"], [])
+        self.assertEqual([ev for ev in events if ev["type"] == "m.room.message"], [])
 
     def test_non_state_seed_stops_at_earliest_events(self) -> None:
         message = self.get_success(

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -476,6 +476,9 @@ class GetMissingEventsStateDagTests(unittest.FederatingHomeserverTestCase):
             set(returned),
             {
                 ("m.room.create", ""),
+                ("m.room.join_rules", ""),
+                ("m.room.history_visibility", ""),
+                ("m.room.power_levels", ""),
                 ("m.room.topic", ""),
                 ("m.room.member", self.local_user_id),
                 ("m.room.member", f"@remote:{self.OTHER_SERVER_NAME}"),

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -1235,6 +1235,9 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
     @skip_test("requires MSC4242 inbound event auth")
     @override_config({"experimental_features": {"msc4242_enabled": True}})
     def test_send_join_state_dag(self) -> None:
+        # KNOWN_ROOM_VERSIONS lacks MSC4242v12 rooms because it is behind an experimental features flag
+        # so set the flag and do the same test as above. When MSC4242 rooms are not gated behind a
+        # config flag this test can be deleted.
         self._test_send_join_common(RoomVersions.MSC4242v12.identifier)
 
     @skip_test("requires MSC4242 inbound event auth")
@@ -1259,7 +1262,8 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
             join_event_dict,
             KNOWN_ROOM_VERSIONS[room_version],
         )
-        # Ask to join as a partial state (omit_members=true) which should be ignored.
+        # Ask to join as a partial state (omit_members=true) which should be ignored
+        # because we don't support partial joins in state DAG rooms just yet
         channel = self.make_signed_federation_request(
             "PUT",
             f"/_matrix/federation/v2/send_join/{room_id}/x?omit_members=true",

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -1317,7 +1317,6 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
             self.hs.get_datastores().main.get_state_dag_extremities(room_id)
         )
         self.assertGreater(len(extremities), 0)
-        self.assertCountEqual(event["prev_state_events"], extremities)
         # When creating events, prev_state_events should be set to the state DAG fwd extremities
         self.assertIncludes(
             set(event["prev_state_events"]), set(extremities), exact=True

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -1192,7 +1192,7 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
             returned_state_dag = [
                 (ev["type"], ev["state_key"]) for ev in channel.json_body["state_dag"]
             ]
-            self.assertIncludes(returned_state_dag, expected_state, exact=True)
+            self.assertIncludes(set(returned_state_dag), set(expected_state), exact=True)
             self.assertNotIn("state", channel.json_body)
             self.assertNotIn("auth_chain", channel.json_body)
         else:
@@ -1238,7 +1238,7 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
         """
         KNOWN_ROOM_VERSIONS lacks MSC4242v12 rooms because it is behind an experimental features flag
         so set the flag and do the same test as above.
-       
+
         FIXME: When MSC4242 rooms are not gated behind a
         config flag this test can be deleted.
         """

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -1235,9 +1235,13 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
     @skip_test("requires MSC4242 inbound event auth")
     @override_config({"experimental_features": {"msc4242_enabled": True}})
     def test_send_join_state_dag(self) -> None:
-        # KNOWN_ROOM_VERSIONS lacks MSC4242v12 rooms because it is behind an experimental features flag
-        # so set the flag and do the same test as above. When MSC4242 rooms are not gated behind a
-        # config flag this test can be deleted.
+        """
+        KNOWN_ROOM_VERSIONS lacks MSC4242v12 rooms because it is behind an experimental features flag
+        so set the flag and do the same test as above.
+       
+        FIXME: When MSC4242 rooms are not gated behind a
+        config flag this test can be deleted.
+        """
         self._test_send_join_common(RoomVersions.MSC4242v12.identifier)
 
     @skip_test("requires MSC4242 inbound event auth")

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -1192,7 +1192,7 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
             returned_state_dag = [
                 (ev["type"], ev["state_key"]) for ev in channel.json_body["state_dag"]
             ]
-            self.assertCountEqual(returned_state_dag, expected_state)
+            self.assertIncludes(returned_state_dag, expected_state, exact=True)
             self.assertNotIn("state", channel.json_body)
             self.assertNotIn("auth_chain", channel.json_body)
         else:
@@ -1247,6 +1247,7 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
     @skip_test("requires MSC4242 inbound event auth")
     @override_config({"experimental_features": {"msc4242_enabled": True}})
     def test_send_join_state_dag_ignores_partial_state(self) -> None:
+        # FIXME: when we support partial joins this test can be deleted
         room_version = RoomVersions.MSC4242v12.identifier
         creator_user_id = self.register_user("user1_msc4242", "test")
         tok = self.login(creator_user_id, "test")

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -1192,7 +1192,9 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
             returned_state_dag = [
                 (ev["type"], ev["state_key"]) for ev in channel.json_body["state_dag"]
             ]
-            self.assertIncludes(set(returned_state_dag), set(expected_state), exact=True)
+            self.assertIncludes(
+                set(returned_state_dag), set(expected_state), exact=True
+            )
             self.assertNotIn("state", channel.json_body)
             self.assertNotIn("auth_chain", channel.json_body)
         else:

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -1249,7 +1249,7 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
     def test_send_join_state_dag_ignores_partial_state(self) -> None:
         room_version = RoomVersions.MSC4242v12.identifier
         creator_user_id = self.register_user("user1_msc4242", "test")
-        tok = self.login("user1_msc4242", "test")
+        tok = self.login(creator_user_id, "test")
         room_id = self.helper.create_room_as(
             room_creator=creator_user_id, tok=tok, room_version=room_version
         )


### PR DESCRIPTION
Adds the serving functions needed for MSC4242: State DAGs. This PR adds MSC4242 support to /make_join, /send_join and /get_missing_events, as well as calculates the destinations for /send events correctly using `prev_state_events`.

Built on top of https://github.com/element-hq/synapse/pull/19718 for the storage functions it makes.

Split out from https://github.com/element-hq/synapse/pull/19425

Part of a series of 5x PRs to land the federation part of [MSC4242](https://github.com/matrix-org/matrix-spec-proposals/pull/4242) ([storage](https://github.com/element-hq/synapse/pull/19718), [fedclient](https://github.com/element-hq/synapse/pull/20127), serving (this PR), inbound-joins, inbound-pulls).

Whilst this is mostly a port of the code in #19425 there are a few changes:
 - `/get_missing_events` accepts message events when walking the state DAG, in which case it resolves the first hop to be that event's `prev_state_events`. The original PR made the client `/event` the message event and then set `latest=[prev_state_events]` on its own. This is not very efficient (extra round trip to fetch the event) and there's no reason why the server can't do the message->prev_state_events lookup, so we do so. This matches the MSC examples.
 - We cap the amount of events fetched via `/get_missing_events`. The MSC allows it, so it's a good safety check.
 - We sort the returned state DAG in `/send_join` by depth then event ID so it's "mostly" sorted. This is more a formality than anything else, the MSC does not mandate this, but it makes `/send_join` responses deterministic.
 - `notify_on_event_delivered_over_federation` is a new thing since #19425, so we include state DAG events in it like we do with state/auth_chain.

This PR does remove the forced `m.federate: false` setting for MSC4242 rooms, so it makes it possible for federated MSC4242 rooms to be made. This is mostly so we can test via the endpoints. Given you must opt-in to MSC4242 via the experimental features config option, it seems reasonable to loosen this setting. The forced no-federation flag existed prior to review saying that the MSC4242 room version could itself be gated behind an experimental feature. 

Reviewable commit-by-commit.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
