### PR TITLE
Make `federation_domain_whitelist` nullable in config schema

### DIFF
--- a/changelog.d/20140.doc
+++ b/changelog.d/20140.doc
@@ -1,0 +1,1 @@
+Make `federation_domain_whitelist` nullable in config schema.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1287,10 +1287,15 @@ Options related to federation.
 ---
 ### `federation_domain_whitelist`
 
-*(array)* Restrict federation to the given whitelist of domains. N.B. we recommend also firewalling your federation listener to limit inbound federation traffic as early as possible, rather than relying purely on this application-layer restriction.
+*(null|array)* Restrict federation to the given whitelist of domains. N.B. we recommend also firewalling your federation listener to limit inbound federation traffic as early as possible, rather than relying purely on this application-layer restriction.
+
 If specified as an empty list (`[]`), federation will be denied with all servers. Specifying an empty list (`[]`) here is the recommended way of disabling federation.
-If not specified, the default is to allow federation with all servers.
-Note: this does not stop a server from joining rooms that servers not on the whitelist are in. As such, this option is really only useful to establish a "private federation", where a group of servers all whitelist each other and have the same whitelist. There is no default for this option.
+
+If unset or null, allows federation with all servers.
+
+Note: this does not stop a server from joining rooms that servers not on the whitelist are in. As such, this option is really only useful to establish a "private federation", where a group of servers all whitelist each other and have the same whitelist.
+
+Defaults to `null`.
 
 Example configuration:
 ```yaml

--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -1573,17 +1573,20 @@ properties:
         - myCA2.pem
         - myCA3.pem
   federation_domain_whitelist:
-    type: array
+    type: ["null", "array"]
     description: >-
       Restrict federation to the given whitelist of domains. N.B. we recommend
       also firewalling your federation listener to limit inbound federation
       traffic as early as possible, rather than relying purely on this
       application-layer restriction.
 
+
       If specified as an empty list (`[]`), federation will be denied with all servers.
       Specifying an empty list (`[]`) here is the recommended way of disabling federation.
 
-      If not specified, the default is to allow federation with all servers.
+
+      If unset or null, allows federation with all servers.
+
 
       Note: this does not stop a server from joining rooms that servers not on
       the whitelist are in. As such, this option is really only useful to
@@ -1591,6 +1594,7 @@ properties:
       each other and have the same whitelist.
     items:
       type: string
+    default: null
     examples:
       - - lon.example.com
         - nyc.example.com


### PR DESCRIPTION
Aligns the config schema of `federation_domain_whitelist` more closely with its semantics and its actual implementation in Synapse. This is done by making it nullable.

- all behavior of the option is now achievable by setting the config option to an actual value
- aligned behavior of the property between unset and null
- provide a definitive default value

This also fixes the formatting problem with separating the paragraphs in the documentation.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
