### PR TITLE
Fix deleted profile fields not being communicated to clients in oldschool `/sync`.

### DIFF
--- a/changelog.d/20144.bugfix
+++ b/changelog.d/20144.bugfix
@@ -1,0 +1,1 @@
+Fix deleted profile fields not being communicated to clients in oldschool `/sync`.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -345,6 +345,7 @@ class SyncHandler:
         )
 
         # ExpiringCache((User, Device)) -> LruCache(user_id => event_id)
+        # FIXME: This makes sync non-idempotent. See: https://github.com/element-hq/synapse/issues/19978
         self.lazy_loaded_members_cache: ExpiringCache[
             tuple[str, str | None], LruCache[str, str]
         ] = ExpiringCache(
@@ -359,6 +360,7 @@ class SyncHandler:
         #   -> LruCache(
         #       blake2b(Other User ID + Field Name) -> blake2b(Field value)
         #   )
+        # FIXME: This makes sync non-idempotent. See: https://github.com/element-hq/synapse/issues/19978
         self.lazy_loaded_profile_fields_cache: ExpiringCache[
             tuple[str, str | None], LruCache[bytes, bytes]
         ] = ExpiringCache(
@@ -2368,7 +2370,7 @@ class SyncHandler:
             return
 
         # Serialise the profile updates into the sync response format.
-        # user ID -> {profile field -> value | null if unset }
+        # user ID -> { profile field -> value | null if unset }
         profile_updates: dict[
             str, dict[str, JsonValue | dict[str, JsonValue]] | None
         ] = {}
@@ -2421,8 +2423,17 @@ class SyncHandler:
                     # Include all the fields the client asked for, as this user
                     # has events in a lazy loaded sync response, except for
                     # fields we've recently sent in a previous lazy loaded sync response
-                    fields = set(profile_data.keys()).intersection(profile_fields)
-                    for field_name in fields:
+                    for field_name in profile_fields:
+                        # FIXME: We turn removals into `null` here, but this is currently under consideration on the MSC.
+                        # See: https://github.com/matrix-org/matrix-spec-proposals/pull/4429/files#r3512513534
+                        # FIXME: Arbitrary absent fields are also turned into `null` here, even if the user never had such a field.
+                        # This is necessary because we don't know what we previously sent down to the client.
+                        # It would be better to:
+                        # - For empty cache, signal 'here is a complete profile' instead:
+                        #   See: https://github.com/matrix-org/matrix-spec-proposals/pull/4429/files#r3602866074
+                        # - For non-empty cache, track a profile updates stream position and use it to only emit
+                        #   fields that actually changed since the last notified position.
+                        field_value = profile_data.get(field_name, None)
                         cache_key = (
                             sync_config.user.to_string(),
                             sync_config.device_id,
@@ -2441,7 +2452,7 @@ class SyncHandler:
                         value_hash = hashlib.blake2b(
                             json.dumps(
                                 [
-                                    profile_data.get(field_name),
+                                    field_value,
                                 ],
                                 sort_keys=True,
                                 separators=(",", ":"),
@@ -2451,7 +2462,7 @@ class SyncHandler:
                             digest_size=LAZY_LOADED_PROFILE_FIELDS_CACHE_DIGEST_SIZE,
                         ).digest()
                         if cache.get(cache_value) != value_hash:
-                            per_user_updates[field_name] = profile_data.get(field_name)
+                            per_user_updates[field_name] = field_value
                             # Update our cache to indicate this user/field combo
                             # has been recently sent.
                             cache.set(
@@ -2467,11 +2478,19 @@ class SyncHandler:
                     fields = (
                         profile_fields
                         if other_user_id in joined_room_user_ids
-                        else set(updated_user_fields.get(other_user_id, []))
+                        else updated_user_fields.get(other_user_id, set())
                     )
-                    fields = set(profile_data.keys()).intersection(fields)
                     for field_name in fields:
-                        per_user_updates[field_name] = profile_data[field_name]
+                        # FIXME: We turn removals into `null` here, but this is currently under consideration on the MSC.
+                        # See: https://github.com/matrix-org/matrix-spec-proposals/pull/4429/files#r3512513534
+                        # FIXME: If the user is in `joined_room_user_ids`, this will produce a `null` for every field
+                        # that we are interested in, even if the user never had such a field.
+                        # This is necessary because we don't know what we previously sent down to the client.
+                        # It would be better to signal 'here is a complete profile' instead:
+                        # See: https://github.com/matrix-org/matrix-spec-proposals/pull/4429/files#r3602866074
+                        per_user_updates[field_name] = profile_data.get(
+                            field_name, None
+                        )
 
                 if per_user_updates:
                     profile_updates[other_user_id] = per_user_updates

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -26,7 +26,7 @@ from parameterized import parameterized, parameterized_class
 from twisted.internet import defer
 from twisted.internet.testing import MemoryReactor
 
-from synapse.api.constants import AccountDataTypes, EventTypes, JoinRules
+from synapse.api.constants import AccountDataTypes, EventTypes, JoinRules, ProfileFields
 from synapse.api.errors import Codes, ResourceLimitError
 from synapse.api.filtering import FilterCollection, Filtering
 from synapse.api.room_versions import RoomVersion, RoomVersions
@@ -2106,6 +2106,93 @@ class SyncProfileUpdatesTestCase(tests.unittest.HomeserverTestCase):
         )
         self.assertIsNone(
             incremental_result.profile_updates["@other_user:test"],
+        )
+
+    @override_config({"include_profile_updates_in_sync": True})
+    def test_incremental_sync_sends_down_deleted_fields(self) -> None:
+        """
+        Tests that, with `include_profile_updates_in_sync` enabled,
+        an incremental sync returns deleted fields as a `null` value, both for
+        `displayname` (stored as its own column) and for
+        generic custom fields (stored as JSON).
+        """
+        # Set up a user with `displayname` and `m.status` profile fields
+        requester = create_requester(self.user)
+        other_requester = create_requester(self.other_user)
+        other_user = UserID.from_string(self.other_user)
+        sync_config = generate_sync_config(
+            user_id=self.user,
+            filter_collection=FilterCollection(
+                hs=self.hs,
+                filter_json={
+                    "org.matrix.msc4429.profile_fields": {
+                        "ids": ["displayname", "m.status"]
+                    }
+                },
+            ),
+        )
+        self.get_success(
+            self.profile_handler.set_field(
+                target_user=other_user,
+                requester=other_requester,
+                field_name=ProfileFields.DISPLAYNAME,
+                new_value="Bob",
+            )
+        )
+        self.get_success(
+            self.profile_handler.set_field(
+                target_user=other_user,
+                requester=other_requester,
+                field_name="m.status",
+                new_value={"text": "On holiday"},
+            )
+        )
+
+        # Do an initial sync after the point of those fields being set
+        initial_result = self.get_success(
+            self.sync_handler.wait_for_sync_for_user(
+                requester,
+                sync_config=sync_config,
+                request_key=generate_request_key(),
+            )
+        )
+        self.assertEqual(
+            initial_result.profile_updates["@other_user:test"],
+            {"displayname": "Bob", "m.status": {"text": "On holiday"}},
+        )
+
+        # Delete the displayname and the `m.status` profile fields
+        self.get_success(
+            self.profile_handler.set_field(
+                target_user=other_user,
+                requester=other_requester,
+                field_name=ProfileFields.DISPLAYNAME,
+                new_value="",
+            )
+        )
+        self.get_success(
+            self.profile_handler.delete_profile_field(
+                target_user=other_user,
+                requester=other_requester,
+                field_name="m.status",
+            )
+        )
+
+        # Do an incremental sync.
+        # Expect the deletion of both fields to be communicated in it.
+        incremental_result = self.get_success(
+            self.sync_handler.wait_for_sync_for_user(
+                requester,
+                since_token=initial_result.next_batch,
+                sync_config=sync_config,
+                request_key=generate_request_key(),
+            )
+        )
+        self.assertEqual(
+            incremental_result.profile_updates,
+            # We currently represent deleted fields as `null`, even though
+            # it's ambiguous (TODO MSC change)
+            {"@other_user:test": {"displayname": None, "m.status": None}},
         )
 
     @override_config({"include_profile_updates_in_sync": True})

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -1977,8 +1977,10 @@ class SyncProfileUpdatesTestCase(tests.unittest.HomeserverTestCase):
         )
         assert incremental_result.profile_updates["@other_user:test"] is not None
         self.assertEqual(
-            set(incremental_result.profile_updates["@other_user:test"].keys()),
-            {"avatar_url", "displayname"},
+            incremental_result.profile_updates["@other_user:test"],
+            # FIXME: As we don't track what users already got sent down, absent fields (even ones that were never set
+            # in the first place) are reported as `None`.
+            {"avatar_url": None, "displayname": "other_user", "m.status": None},
         )
 
         # If we have more events from the other_user, and do another lazy sync,
@@ -2009,9 +2011,9 @@ class SyncProfileUpdatesTestCase(tests.unittest.HomeserverTestCase):
                 request_key=generate_request_key(),
             )
         )
-        self.assertCountEqual(
-            incremental_result.profile_updates.keys(),
-            [],
+        self.assertEqual(
+            incremental_result.profile_updates,
+            {},
         )
         # However, if we again add an event, we do expect any fields the client didn't
         # previously ask for to be there.


### PR DESCRIPTION
Introduced in: #19556

Part of: MSC4429

<ol>
<li>

Add failing test for oldschool sync field removals 

</li>
<li>

Signal deleted profile fields down oldschool sync

Unfortunately this also materialises `null` values for fields that never
existed, as we don't actually have the machinery to track deltas across
some conditions in oldschool sync.


</li>
</ol>
