### PR TITLE
Allow a pre-existing row when persisting state groups

### DIFF
--- a/changelog.d/20150.bugfix
+++ b/changelog.d/20150.bugfix
@@ -1,0 +1,1 @@
+Prevent 500's on event sending when the connection to the database has previously been lost since startup.

--- a/synapse/storage/databases/state/deletion.py
+++ b/synapse/storage/databases/state/deletion.py
@@ -277,11 +277,22 @@ class StateDeletionDataStore:
                 f"state groups have been deleted: {shortstr(missing_state_groups)}"
             )
 
-        self.db_pool.simple_insert_many_txn(
+        # We upsert here, as it may be possible for a row for this state group to
+        # already exist. This can happen in an edge case, where the connection to the DB
+        # is lost between inserting the row and finally deleting it. This has been
+        # observed in the wild on EMS with a flaky RDS.
+        #
+        # State groups persistence rows are fine to re-use, so it's OK for this to be
+        # idempotent.
+        self.db_pool.simple_upsert_many_txn(
             txn,
             table="state_groups_persisting",
-            keys=("state_group", "instance_name"),
-            values=[(state_group, self._instance_name) for state_group in state_groups],
+            key_names=("state_group", "instance_name"),
+            key_values=[
+                (state_group, self._instance_name) for state_group in state_groups
+            ],
+            value_names=(),
+            value_values=(),
         )
 
     def _finish_persisting_txn(

--- a/tests/storage/test_state_deletion.py
+++ b/tests/storage/test_state_deletion.py
@@ -87,6 +87,89 @@ class StateDeletionStoreTestCase(HomeserverTestCase):
         self.get_success(ctx_mgr.__aenter__())
         self.get_success(ctx_mgr.__aexit__(None, None, None))
 
+    def test_existing_persisting_marker(self) -> None:
+        """
+        When persisting an event, Synapse will:
+
+            * Confirm the reference state group exists.
+            * Insert (state_group, instance_name) into the state_groups_persisting table.
+            * Persist the event.
+            * Delete the temp. row in a `finally` block.
+
+        Previously, a well-timed DB connection loss could cause the row in
+        state_groups_persisting to stick around. The next time an event was to be
+        persisted, failing to re-insert the same row would fail with a 500. This
+        was fixed by switching the insert to an upsert.
+
+        Regression test for https://github.com/element-hq/synapse/pull/20150.
+        """
+        # Establish the current state group of the room.
+        event, context = self.get_success(
+            create_event(
+                self.hs,
+                room_id=self.room_id,
+                type="m.test",
+                sender=self.user_id,
+            )
+        )
+        assert context.state_group is not None
+
+        # Simulate a transaction which committed the marker before the database
+        # connection was lost, causing Synapse to retry the transaction.
+        self.get_success(
+            self.state_deletion_store.db_pool.simple_insert(
+                table="state_groups_persisting",
+                values={
+                    "state_group": context.state_group,
+                    "instance_name": self.hs.get_instance_name(),
+                },
+                desc="test_existing_persisting_marker",
+            )
+        )
+
+        # Try to mark the state group as persisting.
+        #
+        # Previously this would fail with a 500 due to the pre-existing row.
+        ctx_mgr = self.state_deletion_store.persisting_state_group_references(
+            [(event, context)]
+        )
+
+        # Start persisting the event.
+        self.get_success(ctx_mgr.__aenter__())
+
+        # Double check that a marker is in fact in there.
+        marker = self.get_success(
+            self.state_deletion_store.db_pool.simple_select_one_onecol(
+                table="state_groups_persisting",
+                keyvalues={
+                    "state_group": context.state_group,
+                    "instance_name": self.hs.get_instance_name(),
+                },
+                retcol="1",
+                allow_none=True,
+                desc="test_existing_persisting_marker",
+            )
+        )
+        self.assertEqual(marker, 1)
+
+        # Finish persisting the event.
+        self.get_success(ctx_mgr.__aexit__(None, None, None))
+
+        # Check that the marker was deleted successfully.
+        marker = self.get_success(
+            self.state_deletion_store.db_pool.simple_select_one_onecol(
+                table="state_groups_persisting",
+                keyvalues={
+                    "state_group": context.state_group,
+                    "instance_name": self.hs.get_instance_name(),
+                },
+                retcol="1",
+                allow_none=True,
+                desc="test_existing_persisting_marker",
+            )
+        )
+        self.assertIsNone(marker)
+
     def test_no_deletion_error(self) -> None:
         """Test that calling persisting_state_group_references is fine if
         nothing is pending deletion, but an error occurs."""


### PR DESCRIPTION
Allows events to still be sent in rooms even if a state group persisting row has stuck around from a previous DB connection loss. This saves the sysadmin from needing to restart the worker.

Observed in EMS when our RDS instances began to become unstable, leading to frequent DB connection losses:

```
psycopg2.OperationalError: SSL SYSCALL error: EOF detected
```

<img width="1102" height="629" alt="image" src="https://github.com/user-attachments/assets/5e8c38c0-0504-4312-a4c5-8f8001bfacc4" />

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
