### PR TITLE
Allocate device list stream IDs per batch

### DIFF
--- a/changelog.d/20151.bugfix
+++ b/changelog.d/20151.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where a device list change for a user with a large number of devices would consume far more `device_lists` stream IDs than necessary, causing replication to fall behind.

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -2085,7 +2085,7 @@ class DeviceWorkerStore(RoomMemberWorkerStore, EndToEndKeyWorkerStore):
             batch_device_ids: StrCollection,
         ) -> int:
             stream_ids = self._device_list_id_gen.get_next_mult_txn(
-                txn, len(device_ids)
+                txn, len(batch_device_ids)
             )
 
             self._add_device_change_to_stream_txn(

--- a/tests/storage/test_devices.py
+++ b/tests/storage/test_devices.py
@@ -358,6 +358,38 @@ class DeviceStoreTestCase(HomeserverTestCase):
         )
         self.assertEqual(404, exc.value.code)
 
+    def test_add_device_change_to_streams_allocates_one_id_per_device(self) -> None:
+        """Adding more devices than fit in a single batch should still only consume
+        one stream ID per device.
+        """
+        user_id = "@user_id:test"
+        # Enough devices to span more than one `batch_iter` batch.
+        device_ids = [f"device_id{i}" for i in range(1500)]
+
+        self.get_success(
+            self.store.add_device_change_to_streams(
+                user_id=user_id,
+                device_ids=device_ids,
+                room_ids=["!some:room"],
+            )
+        )
+
+        stream_ids = self.get_success(
+            self.store.db_pool.simple_select_onecol(
+                table="device_lists_stream",
+                keyvalues={"user_id": user_id},
+                retcol="stream_id",
+            )
+        )
+
+        self.assertEqual(len(stream_ids), len(device_ids))
+        # The allocated IDs should be contiguous: a gap means IDs were allocated
+        # and then thrown away.
+        self.assertEqual(
+            max(stream_ids) - min(stream_ids) + 1,
+            len(device_ids),
+        )
+
     @patch("synapse.storage.databases.main.devices.PRUNE_DEVICE_LISTS_BATCH_SIZE", 5)
     def test_prune_old_device_lists_changes_in_room(self) -> None:
         """Test that old entries in the `device_lists_changes_in_room` table are pruned properly."""


### PR DESCRIPTION
`add_device_change_to_streams` chunks `device_ids` into batches of 1000, but allocated `len(device_ids)` stream IDs for every batch instead of `len(batch_device_ids)`. Both `_add_device_change_to_stream_txn` and `_add_device_outbound_room_poke_txn` zip the IDs against the batch they were handed, so the surplus was silently discarded.

This was particularly a problem when deleting devices on m.org on accounts with >1M devices, as every batch would allocate millions of stream IDs, making it impossible for consumers to ever catch up. This fix is currently deployed on m.org
