### PR TITLE
MSC3866: Apply missed filter on /users response

### DIFF
--- a/changelog.d/20152.bugfix
+++ b/changelog.d/20152.bugfix
@@ -1,0 +1,1 @@
+When using MSC3866, omit the approval flag from the response of `GET /_synapse/admin/v2/users`.

--- a/changelog.d/20152.bugfix
+++ b/changelog.d/20152.bugfix
@@ -1,1 +1,1 @@
-When using MSC3866, omit the approval flag from the response of `GET /_synapse/admin/v2/users`.
+When not using MSC3866, omit the approval flag from the response of `GET /_synapse/admin/v2/users`.

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -23,7 +23,7 @@ import hmac
 import logging
 import secrets
 from http import HTTPStatus
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import attr
 from pydantic import StrictBool, StrictInt, StrictStr
@@ -181,13 +181,13 @@ class UsersRestServletV2(RestServlet):
         )
 
         # If support for MSC3866 is not enabled, don't show the approval flag.
-        filter = None
+        _filter = None
         if not self._msc3866_enabled:
 
-            def _filter(a: attr.Attribute) -> bool:
+            def _filter(a: attr.Attribute, _v: Any) -> bool:
                 return a.name != "approved"
 
-        ret = {"users": [attr.asdict(u, filter=filter) for u in users], "total": total}
+        ret = {"users": [attr.asdict(u, filter=_filter) for u in users], "total": total}
         if (start + limit) < total:
             ret["next_token"] = str(start + len(users))
 

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -23,7 +23,7 @@ import hmac
 import logging
 import secrets
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import attr
 from pydantic import StrictBool, StrictInt, StrictStr
@@ -185,7 +185,10 @@ class UsersRestServletV2(RestServlet):
         if not self._msc3866_enabled:
             users_filter = attr.filters.exclude("approved")
 
-        ret = {"users": [attr.asdict(u, filter=users_filter) for u in users], "total": total}
+        ret = {
+            "users": [attr.asdict(u, filter=users_filter) for u in users],
+            "total": total,
+        }
         if (start + limit) < total:
             ret["next_token"] = str(start + len(users))
 

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -183,9 +183,7 @@ class UsersRestServletV2(RestServlet):
         # If support for MSC3866 is not enabled, don't show the approval flag.
         users_filter = None
         if not self._msc3866_enabled:
-
-            def users_filter(a: attr.Attribute, _v: Any) -> bool:
-                return a.name != "approved"
+            users_filter = attr.filters.exclude("approved")
 
         ret = {"users": [attr.asdict(u, filter=users_filter) for u in users], "total": total}
         if (start + limit) < total:

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -181,13 +181,13 @@ class UsersRestServletV2(RestServlet):
         )
 
         # If support for MSC3866 is not enabled, don't show the approval flag.
-        _filter = None
+        users_filter = None
         if not self._msc3866_enabled:
 
-            def _filter(a: attr.Attribute, _v: Any) -> bool:
+            def users_filter(a: attr.Attribute, _v: Any) -> bool:
                 return a.name != "approved"
 
-        ret = {"users": [attr.asdict(u, filter=_filter) for u in users], "total": total}
+        ret = {"users": [attr.asdict(u, filter=users_filter) for u in users], "total": total}
         if (start + limit) < total:
             ret["next_token"] = str(start + len(users))
 

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -49,6 +49,7 @@ from synapse.rest.admin._base import (
     assert_user_is_admin,
 )
 from synapse.rest.client._base import client_patterns
+from synapse.storage.databases.main import UserPaginateResponse
 from synapse.storage.databases.main.registration import ExternalIDReuseException
 from synapse.storage.databases.main.stats import UserSortOrder
 from synapse.types import JsonDict, JsonMapping, TaskStatus, UserID
@@ -183,7 +184,9 @@ class UsersRestServletV2(RestServlet):
         # If support for MSC3866 is not enabled, don't show the approval flag.
         users_filter = None
         if not self._msc3866_enabled:
-            users_filter = attr.filters.exclude("approved")
+            users_filter = attr.filters.exclude(
+                attr.fields(UserPaginateResponse).approved
+            )
 
         ret = {
             "users": [attr.asdict(u, filter=users_filter) for u in users],

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -1424,6 +1424,10 @@ class UsersListTestCase(unittest.HomeserverTestCase):
             self.assertIn("avatar_url", u)
             self.assertIn("creation_ts", u)
             self.assertIn("last_seen_ts", u)
+            if self.hs.config.experimental.msc3866.enabled:
+                self.assertIn("approved", u)
+            else:
+                self.assertNotIn("approved", u)
 
     def _create_users(self, number_users: int) -> None:
         """


### PR DESCRIPTION
For the Admin API /users endpoint, the response is meant to exclude the approval flag when MSC3866 is enabled, but the filter that applies the exclusion never actually got used.  Fix things so that it does.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
