### PR TITLE
Fix history in depth bombed rooms

### DIFF
--- a/changelog.d/20157.bugfix
+++ b/changelog.d/20157.bugfix
@@ -1,0 +1,1 @@
+Fix the ordering of history in rooms affected by [GHSA-v56r-hwv5-mxg6](https://github.com/advisories/GHSA-v56r-hwv5-mxg6). Messages now come back in the order they were sent, and stay that way. Contributed by @catfromplan9.

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -39,6 +39,7 @@ from prometheus_client import Counter
 
 import synapse.metrics
 from synapse.api.constants import (
+    MAX_DEPTH,
     EventContentFields,
     EventTypes,
     Membership,
@@ -2827,6 +2828,57 @@ class PersistEventsStore:
 
         return [ec for ec in events_and_contexts if ec[0] not in to_remove]
 
+    def _compute_topological_orderings_txn(
+        self,
+        txn: LoggingTransaction,
+        events_and_contexts: Collection[EventPersistencePair],
+    ) -> dict[str, int]:
+        """Compute the topological_ordering to store for each event.
+
+        Normally this is just the event's depth. But in rooms whose depth
+        reached MAX_DEPTH (see GHSA-v56r-hwv5-mxg6), every new event arrives
+        with depth == MAX_DEPTH, which would pile them all onto one ordering
+        and reduce /messages to arrival order. We store such events just above
+        the room's current maximum ordering instead, so a room repaired by the
+        fixup_max_depth_tie_ordering background update stays in chronological
+        order. Until that update runs, the room's maximum is itself MAX_DEPTH
+        and this reduces to the old behaviour.
+
+        Only events appended to the live timeline (positive stream ordering)
+        get this treatment. A backfilled at-cap event is older than the room's
+        maximum, and storing it above the maximum would strand it at the live
+        edge with an ordering the background update can no longer recognise as
+        wrong. Backfilled events keep the cap.
+        """
+        orderings = {event.event_id: event.depth for event, _ in events_and_contexts}
+
+        def place_past_cap(event: EventBase) -> bool:
+            return (
+                event.depth >= MAX_DEPTH
+                and (event.internal_metadata.stream_ordering or 0) > 0
+            )
+
+        capped_rooms = {
+            event.room_id for event, _ in events_and_contexts if place_past_cap(event)
+        }
+        next_ordering: dict[str, int] = {}
+        for room_id in capped_rooms:
+            txn.execute(
+                "SELECT COALESCE(max(topological_ordering), 0) FROM events WHERE room_id = ?",
+                (room_id,),
+            )
+            row = txn.fetchone()
+            assert row is not None
+            next_ordering[room_id] = min(row[0] + 1, MAX_DEPTH)
+
+        for event, _ in events_and_contexts:
+            if place_past_cap(event):
+                ordering = next_ordering[event.room_id]
+                orderings[event.event_id] = ordering
+                next_ordering[event.room_id] = min(ordering + 1, MAX_DEPTH)
+
+        return orderings
+
     def _store_event_txn(
         self,
         txn: LoggingTransaction,
@@ -2862,6 +2914,10 @@ class PersistEventsStore:
             ],
         )
 
+        topological_orderings = self._compute_topological_orderings_txn(
+            txn, events_and_contexts
+        )
+
         self.db_pool.simple_insert_many_txn(
             txn,
             table="events",
@@ -2886,7 +2942,7 @@ class PersistEventsStore:
                 (
                     self._instance_name,
                     event.internal_metadata.stream_ordering,
-                    event.depth,  # topological_ordering
+                    topological_orderings[event.event_id],
                     event.depth,  # depth
                     event.event_id,
                     event.room_id,

--- a/synapse/storage/databases/main/events_bg_updates.py
+++ b/synapse/storage/databases/main/events_bg_updates.py
@@ -358,6 +358,11 @@ class EventsBackgroundUpdatesStore(
         )
 
         self.db_pool.updates.register_background_update_handler(
+            _BackgroundUpdates.FIXUP_MAX_DEPTH_TIE_ORDERING,
+            self.fixup_max_depth_tie_ordering_bg_update,
+        )
+
+        self.db_pool.updates.register_background_update_handler(
             _BackgroundUpdates.EVENT_RESIGN,
             self._resign_events,
         )
@@ -2728,6 +2733,117 @@ class EventsBackgroundUpdatesStore(
             )
 
         return num_rooms
+
+    async def fixup_max_depth_tie_ordering_bg_update(
+        self, progress: JsonDict, batch_size: int
+    ) -> int:
+        """Restore chronological ordering for events whose topological
+        ordering collapsed onto (or above) MAX_DEPTH.
+
+        In a room that was sent events with a huge depth (see
+        GHSA-v56r-hwv5-mxg6), every later event is created with its depth
+        capped at MAX_DEPTH. They all share one topological ordering, so
+        /messages falls back to arrival order. In room versions without strict
+        canonical JSON validation, the original over-large orderings also sort
+        above the capped ones, inverting the timeline.
+
+        This update re-spreads all events at or above MAX_DEPTH across the
+        unused ordering range above the room's highest real depth, ranked by
+        origin_server_ts. topological_ordering is local to this server, so
+        nothing changes over federation.
+        """
+
+        room_id_bound = progress.get("room_id", "")
+
+        def fixup_tie_ordering_txn(txn: LoggingTransaction) -> tuple[bool, int]:
+            txn.execute(
+                """
+                SELECT room_id FROM rooms
+                WHERE room_id > ?
+                ORDER BY room_id
+                LIMIT ?
+                """,
+                (room_id_bound, batch_size),
+            )
+            room_ids = [room_id for (room_id,) in txn]
+
+            if not room_ids:
+                return True, 0
+
+            self.db_pool.updates._background_update_progress_txn(
+                txn,
+                _BackgroundUpdates.FIXUP_MAX_DEPTH_TIE_ORDERING,
+                progress={"room_id": room_ids[-1]},
+            )
+
+            num_fixed = 0
+            for room_id in room_ids:
+                if self._fixup_depth_ties_in_room_txn(txn, room_id):
+                    num_fixed += 1
+
+            return False, num_fixed
+
+        done, num_fixed = await self.db_pool.runInteraction(
+            "fixup_max_depth_tie_ordering", fixup_tie_ordering_txn
+        )
+
+        if done:
+            await self.db_pool.updates._end_background_update(
+                _BackgroundUpdates.FIXUP_MAX_DEPTH_TIE_ORDERING
+            )
+
+        return num_fixed
+
+    def _fixup_depth_ties_in_room_txn(
+        self, txn: LoggingTransaction, room_id: str
+    ) -> bool:
+        """Re-spread this room's events at or above MAX_DEPTH by
+        origin_server_ts. Returns True if anything changed."""
+
+        txn.execute(
+            "SELECT count(*) FROM events WHERE room_id = ? AND topological_ordering >= ?",
+            (room_id, MAX_DEPTH),
+        )
+        row = txn.fetchone()
+        assert row is not None
+        count = row[0]
+        # A single event at the cap cannot be mis-ordered relative to the tie.
+        if count <= 1:
+            return False
+
+        txn.execute(
+            """
+            SELECT COALESCE(max(topological_ordering), 0) FROM events
+            WHERE room_id = ? AND topological_ordering < ?
+            """,
+            (room_id, MAX_DEPTH),
+        )
+        row = txn.fetchone()
+        assert row is not None
+        base = row[0]
+
+        # Spread over at most half the free range, leaving headroom above the
+        # block so newly persisted at-cap events can continue past it.
+        stride = max(1, (MAX_DEPTH - base) // (2 * (count + 1)))
+
+        txn.execute(
+            """
+            SELECT event_id FROM events
+            WHERE room_id = ? AND topological_ordering >= ?
+            ORDER BY COALESCE(origin_server_ts, 0) ASC, stream_ordering ASC
+            """,
+            (room_id, MAX_DEPTH),
+        )
+        event_ids = [event_id for (event_id,) in txn]
+
+        txn.execute_batch(
+            "UPDATE events SET topological_ordering = ? WHERE event_id = ?",
+            [
+                (min(base + stride * (i + 1), MAX_DEPTH), event_id)
+                for i, event_id in enumerate(event_ids)
+            ],
+        )
+        return True
 
     async def _resign_events(self, progress: dict, batch_size: int) -> int:
         """Retroactively re-sign events signed with a different key than the

--- a/synapse/storage/schema/main/delta/94/09_fixup_max_depth_tie_ordering.sql
+++ b/synapse/storage/schema/main/delta/94/09_fixup_max_depth_tie_ordering.sql
@@ -1,0 +1,18 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2026 New Vector, Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+-- Background update that restores chronological ordering for events whose
+-- topological_ordering collapsed onto MAX_DEPTH (or above it, in room versions
+-- without strict canonical JSON).
+INSERT INTO background_updates (ordering, update_name, progress_json, depends_on) VALUES
+  (9409, 'fixup_max_depth_tie_ordering', '{}', 'fixup_max_depth_cap');

--- a/synapse/types/storage/__init__.py
+++ b/synapse/types/storage/__init__.py
@@ -65,6 +65,8 @@ class _BackgroundUpdates:
 
     FIXUP_MAX_DEPTH_CAP = "fixup_max_depth_cap"
 
+    FIXUP_MAX_DEPTH_TIE_ORDERING = "fixup_max_depth_tie_ordering"
+
     REDACTIONS_RECHECK_BG_UPDATE = "redactions_recheck"
 
     EVENT_RESIGN = "event_resign"

--- a/tests/storage/test_events_bg_updates.py
+++ b/tests/storage/test_events_bg_updates.py
@@ -165,6 +165,274 @@ class TestFixupMaxDepthCapBgUpdate(HomeserverTestCase):
         self.assertDictEqual(event_id_to_depth, dict(rows))
 
 
+class TestFixupMaxDepthTieOrderingBgUpdate(HomeserverTestCase):
+    """Test the background update that re-spreads events tied at (or above)
+    MAX_DEPTH by origin_server_ts."""
+
+    def prepare(
+        self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
+    ) -> None:
+        self.store = self.hs.get_datastores().main
+        self.db_pool = self.store.db_pool
+        self._next_stream_ordering = 1
+
+        # Reinsert the background update as it was already run at the start of
+        # the test.
+        self.get_success(
+            self.db_pool.simple_insert(
+                table="background_updates",
+                values={
+                    "update_name": "fixup_max_depth_tie_ordering",
+                    "progress_json": "{}",
+                },
+            )
+        )
+
+    def create_room(
+        self,
+        room_id: str,
+        room_version: RoomVersion,
+        events: list[tuple[str, int, int]],
+    ) -> None:
+        """Create a room and insert events given as
+        (event_id, topological_ordering, origin_server_ts)."""
+
+        self.get_success(
+            self.db_pool.simple_insert(
+                table="rooms",
+                values={
+                    "room_id": room_id,
+                    "room_version": room_version.identifier,
+                },
+            )
+        )
+
+        for event_id, topological_ordering, origin_server_ts in events:
+            self.get_success(
+                self.db_pool.simple_insert(
+                    table="events",
+                    values={
+                        "event_id": event_id,
+                        "room_id": room_id,
+                        "stream_ordering": self._next_stream_ordering,
+                        "topological_ordering": topological_ordering,
+                        "depth": topological_ordering,
+                        "origin_server_ts": origin_server_ts,
+                        "type": "m.test",
+                        "sender": "@user:test",
+                        "processed": True,
+                        "outlier": False,
+                    },
+                )
+            )
+            self._next_stream_ordering += 1
+
+    def run_update(self) -> int:
+        return self.get_success(
+            self.store.fixup_max_depth_tie_ordering_bg_update({"room_id": ""}, 10)
+        )
+
+    def get_orderings(self, room_id: str) -> dict[str, int]:
+        rows = self.get_success(
+            self.db_pool.simple_select_list(
+                table="events",
+                keyvalues={"room_id": room_id},
+                retcols=["event_id", "topological_ordering"],
+            )
+        )
+        return dict(rows)
+
+    def test_tie_block_respread_by_ts(self) -> None:
+        """Events tied at MAX_DEPTH end up ordered by origin_server_ts, above
+        the room's last real depth."""
+
+        room_id = "!tied:example.com"
+        self.create_room(
+            room_id,
+            RoomVersions.V6,
+            [
+                ("$normal1:e", 1, 1000),
+                ("$normal2:e", 2, 2000),
+                ("$normal3:e", 3, 3000),
+                # Tie block, deliberately out of chronological order relative
+                # to insertion (= stream) order.
+                ("$tie_c:e", MAX_DEPTH, 6000),
+                ("$tie_a:e", MAX_DEPTH, 4000),
+                ("$tie_b:e", MAX_DEPTH, 5000),
+            ],
+        )
+
+        self.assertEqual(self.run_update(), 1)
+
+        orderings = self.get_orderings(room_id)
+
+        # Normal events untouched.
+        self.assertEqual(orderings["$normal1:e"], 1)
+        self.assertEqual(orderings["$normal2:e"], 2)
+        self.assertEqual(orderings["$normal3:e"], 3)
+
+        # Tied events now sit strictly between the last real depth and
+        # MAX_DEPTH, in chronological order, with distinct orderings.
+        tied = [orderings["$tie_a:e"], orderings["$tie_b:e"], orderings["$tie_c:e"]]
+        self.assertEqual(tied, sorted(tied))
+        self.assertEqual(len(set(tied)), 3)
+        self.assertGreater(tied[0], 3)
+        self.assertLess(tied[-1], MAX_DEPTH)
+
+    def test_overflow_rows_in_old_room_version(self) -> None:
+        """In room versions without strict canonical JSON, events above
+        MAX_DEPTH (which the fixup_max_depth_cap update skipped) are also
+        re-spread, fixing the inverted ordering."""
+
+        room_id = "!old:example.com"
+        self.create_room(
+            room_id,
+            RoomVersions.V5,
+            [
+                ("$normal:e", 1, 1000),
+                # The original bomb-era events, above MAX_DEPTH.
+                ("$bomb1:e", 2**63 - 1, 2000),
+                ("$bomb2:e", 2**63 - 1, 3000),
+                # Post-1.127.1 events, capped at MAX_DEPTH, which sorted below
+                # the bomb-era events despite being newer.
+                ("$capped1:e", MAX_DEPTH, 4000),
+                ("$capped2:e", MAX_DEPTH, 5000),
+            ],
+        )
+
+        self.assertEqual(self.run_update(), 1)
+
+        orderings = self.get_orderings(room_id)
+        self.assertEqual(orderings["$normal:e"], 1)
+
+        by_ordering = sorted((o, e) for e, o in orderings.items() if e != "$normal:e")
+        self.assertEqual(
+            [e for _, e in by_ordering],
+            ["$bomb1:e", "$bomb2:e", "$capped1:e", "$capped2:e"],
+        )
+        self.assertLess(by_ordering[-1][0], MAX_DEPTH)
+
+    def test_rooms_without_ties_untouched(self) -> None:
+        """A room with at most one event at MAX_DEPTH is left alone."""
+
+        room_id = "!healthy:example.com"
+        self.create_room(
+            room_id,
+            RoomVersions.V6,
+            [
+                ("$normal1:e", 1, 1000),
+                ("$normal2:e", 2, 2000),
+                ("$single:e", MAX_DEPTH, 3000),
+            ],
+        )
+
+        self.assertEqual(self.run_update(), 0)
+
+        orderings = self.get_orderings(room_id)
+        self.assertEqual(orderings["$normal1:e"], 1)
+        self.assertEqual(orderings["$normal2:e"], 2)
+        self.assertEqual(orderings["$single:e"], MAX_DEPTH)
+
+
+class TestCappedDepthTopologicalPlacement(HomeserverTestCase):
+    """Test that newly persisted events with depth >= MAX_DEPTH are placed
+    just above the room's current maximum topological ordering."""
+
+    class _StubInternalMetadata:
+        def __init__(self, stream_ordering: int) -> None:
+            self.stream_ordering = stream_ordering
+
+    class _StubEvent:
+        def __init__(
+            self, event_id: str, room_id: str, depth: int, stream_ordering: int = 1
+        ) -> None:
+            self.event_id = event_id
+            self.room_id = room_id
+            self.depth = depth
+            self.internal_metadata = (
+                TestCappedDepthTopologicalPlacement._StubInternalMetadata(
+                    stream_ordering
+                )
+            )
+
+    def prepare(
+        self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
+    ) -> None:
+        self.store = self.hs.get_datastores().main
+        self.persist_store = self.hs.get_datastores().persist_events
+        assert self.persist_store is not None
+        self.db_pool = self.store.db_pool
+
+    def seed_room(self, room_id: str, max_ordering: int) -> None:
+        self.get_success(
+            self.db_pool.simple_insert(
+                table="events",
+                values={
+                    "event_id": f"$seed{max_ordering}:{room_id}",
+                    "room_id": room_id,
+                    "topological_ordering": max_ordering,
+                    "depth": max_ordering,
+                    "origin_server_ts": 1000,
+                    "type": "m.test",
+                    "sender": "@user:test",
+                    "processed": True,
+                    "outlier": False,
+                },
+            )
+        )
+
+    def compute(self, events: list["_StubEvent"]) -> dict[str, int]:
+        assert self.persist_store is not None
+        return self.get_success(
+            self.db_pool.runInteraction(
+                "test_compute_topological_orderings",
+                self.persist_store._compute_topological_orderings_txn,
+                [(event, None) for event in events],
+            )
+        )
+
+    def test_normal_events_keep_their_depth(self) -> None:
+        room_id = "!normal:example.com"
+        self.seed_room(room_id, 500)
+        orderings = self.compute([self._StubEvent("$new:e", room_id, 501)])
+        self.assertEqual(orderings["$new:e"], 501)
+
+    def test_capped_events_continue_past_block_top(self) -> None:
+        """In a room whose tie block has been re-spread, at-cap events chain
+        chronologically from the current maximum."""
+
+        room_id = "!spliced:example.com"
+        self.seed_room(room_id, 500)
+        orderings = self.compute(
+            [
+                self._StubEvent("$cap1:e", room_id, MAX_DEPTH),
+                self._StubEvent("$cap2:e", room_id, MAX_DEPTH),
+            ]
+        )
+        self.assertEqual(orderings["$cap1:e"], 501)
+        self.assertEqual(orderings["$cap2:e"], 502)
+
+    def test_backfilled_capped_events_keep_the_cap(self) -> None:
+        """A backfilled at-cap event (negative stream ordering) is older than
+        the room's maximum, so it must not be placed at the live edge."""
+
+        room_id = "!backfill:example.com"
+        self.seed_room(room_id, 500)
+        orderings = self.compute(
+            [self._StubEvent("$old:e", room_id, MAX_DEPTH, stream_ordering=-5)]
+        )
+        self.assertEqual(orderings["$old:e"], MAX_DEPTH)
+
+    def test_unspliced_room_falls_back_to_cap(self) -> None:
+        """While the room still has events at MAX_DEPTH as its maximum, the
+        old capping behaviour is preserved."""
+
+        room_id = "!unspliced:example.com"
+        self.seed_room(room_id, MAX_DEPTH)
+        orderings = self.compute([self._StubEvent("$cap:e", room_id, MAX_DEPTH)])
+        self.assertEqual(orderings["$cap:e"], MAX_DEPTH)
+
+
 class TestRedactionsRecheckBgUpdate(HomeserverTestCase):
     """Test the background update that backfills the `recheck` column in redactions."""
 


### PR DESCRIPTION
In depth bombed rooms ([GHSA-v56r-hwv5-mxg6](https://github.com/advisories/GHSA-v56r-hwv5-mxg6)) on room version 6 and above, the server returned everything sent since the attack in the order it received it, not the order it was sent. Federation lag and backfill made those two orders differ, so pagination could jump back months mid-scroll. Rooms on versions 1 to 5, which #18447 skipped, were worse off. There the attack-era events permanently sorted as the newest in the room, and everything sent since sorted as older than them.

The cause in both cases was `topological_ordering`. Every event created since the attack carried a depth capped at `MAX_DEPTH`, so the affected stretch of the room collapsed onto one ordering value, and on old room versions it also sat below the uncapped attack events. This PR adds a background update that re-spreads all events at or above `MAX_DEPTH` across the unused ordering range above the room's highest real depth, ranked by `origin_server_ts`. Event persistence now stores a new at-cap event just above the room's current maximum, which keeps a repaired room repaired. `topological_ordering` is local to each server, so nothing changes over federation.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
