### PR TITLE
Ensure that no request have .. or . in the path

### DIFF
--- a/changelog.d/20158.misc
+++ b/changelog.d/20158.misc
@@ -1,0 +1,1 @@
+Fail early upon receipts of a request with a path segment of `.` or `..`.

--- a/changelog.d/20158.misc
+++ b/changelog.d/20158.misc
@@ -1,1 +1,1 @@
-Fail early upon receipts of a request with a path segment of `.` or `..`.
+Fail early upon receipt of a request with a path segment of `.` or `..`.

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -24,6 +24,7 @@ import logging
 import time
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Generator
+from urllib.parse import unquote_to_bytes
 
 import attr
 from zope.interface import implementer
@@ -63,6 +64,10 @@ _next_request_seq = 0
 
 class ContentLengthError(SynapseError):
     """Raised when content-length validation fails."""
+
+
+class DotSegmentError(SynapseError):
+    """Raised when the request path contains "." or ".." segments."""
 
 
 class SynapseRequest(Request):
@@ -196,6 +201,39 @@ class SynapseRequest(Request):
                 Codes.UNKNOWN,
             )
 
+    def _validate_path(self) -> None:
+        """Reject request paths containing "." or ".." segments.
+
+        No Matrix endpoint needs them, and forwarding such a path on to
+        something that resolves it (e.g. an application service we reverse-proxy
+        to) lets a caller escape the path it was supposed to be confined to.
+        Rejecting here means no individual handler has to remember.
+
+        We reject rather than normalise on purpose. Routing matches the raw path
+        and federation signatures cover the raw URI, so rewriting one would
+        break both.
+
+        Raises:
+            DotSegmentError: If the path contains dot segments.
+        """
+
+        # `self.path` is not populated until `Request.process` runs, so split the
+        # query string off ourselves.
+        path = self.uri.split(b"?", 1)[0]
+
+        if has_dot_segments(path):
+            logger.info(
+                "Rejecting request from %s because the path contains dot segments: %s %s",
+                self.client,
+                self.get_method(),
+                self.get_redacted_uri(),
+            )
+            raise DotSegmentError(
+                HTTPStatus.BAD_REQUEST,
+                "Path must not contain '.' or '..' segments",
+                Codes.INVALID_PARAM,
+            )
+
     def _validate_content_length(self) -> None:
         """Validate Content-Length header and actual content size.
 
@@ -261,8 +299,9 @@ class SynapseRequest(Request):
         self.clientproto = version
 
         try:
+            self._validate_path()
             self._validate_content_length()
-        except ContentLengthError as e:
+        except (DotSegmentError, ContentLengthError) as e:
             self._respond_with_error(e)
             return
 
@@ -952,3 +991,21 @@ class SynapseSite(ProxySite):
 class RequestInfo:
     user_agent: str | None
     ip: str
+
+
+def has_dot_segments(path: bytes) -> bool:
+    """Whether the given request path contains any "." or ".." segments.
+
+    The path is percent-decoded before it is split, since `%2e%2e` and `..` are
+    equivalent to anything that resolves the path, and `%2f` hides a separator that
+    would otherwise not be seen. Note that a single decode is deliberate: it matches
+    the single decode that route arguments get in `JsonResource._async_render`, so
+    `%252e%252e` is left alone rather than being treated as a dot segment.
+
+    The caller is expected to reject such a path rather than rewrite it. Synapse
+    routes on the raw path, and federation request signatures cover the raw URI, so
+    normalising a path in place would break both.
+    """
+    return any(
+        segment in (b".", b"..") for segment in unquote_to_bytes(path).split(b"/")
+    )

--- a/tests/http/test_site.py
+++ b/tests/http/test_site.py
@@ -192,6 +192,71 @@ class SynapseRequestTestCase(HomeserverTestCase):
         self.assertRegex(response, r"^HTTP/1\.1 413 ")
         self.assertSubstring("M_TOO_LARGE", response)
 
+    def _send_raw_request(self, target: bytes) -> str:
+        """Send a bare GET with the given request-target and return the raw response."""
+        self.hs.start_listening()
+
+        (port, factory, _backlog, interface) = self.reactor.tcpServers[0]
+        self.assertEqual(interface, "::")
+        self.assertEqual(port, 0)
+
+        client_address = IPv6Address("TCP", "::1", 2345)
+        protocol = factory.buildProtocol(client_address)
+        transport = StringTransport()
+        protocol.makeConnection(transport)
+
+        protocol.dataReceived(
+            b"GET " + target + b" HTTP/1.1\r\nConnection: close\r\n\r\n"
+        )
+
+        while not transport.disconnecting:
+            self.reactor.advance(1)
+
+        return transport.value().decode()
+
+    @parameterized.expand(
+        [
+            (b"/_matrix/client/versions/..",),
+            (b"/_matrix/client/../../etc/passwd",),
+            (b"/_matrix/client/versions/.",),
+            (b"/..",),
+            (b"/_matrix/client/versions/%2e%2e",),
+            (b"/_matrix/client/versions/%2E%2E",),
+            # An encoded separator hides a dot segment from a naive split.
+            (b"/_matrix/client/versions/a%2f..%2fb",),
+            # Dot segments anywhere in the path, not just at the end.
+            (b"/_matrix/../client/versions",),
+            # The query string must not save an otherwise-bad path.
+            (b"/_matrix/client/versions/..?foo=bar",),
+        ]
+    )
+    def test_dot_segments_rejected(self, target: bytes) -> None:
+        """Request paths containing "." or ".." segments should be rejected with 400"""
+        response = self._send_raw_request(target)
+
+        self.assertRegex(response, r"^HTTP/1\.1 400 ")
+        self.assertSubstring("M_INVALID_PARAM", response)
+
+    @parameterized.expand(
+        [
+            # Dots that are not a whole segment are fine.
+            (b"/_matrix/client/versions",),
+            (b"/_matrix/client/v3/rooms/%21a%3Ab/state/m.room.name/..suffix",),
+            (b"/_matrix/client/v3/rooms/%21a%3Ab/state/m.room.name/a..b",),
+            (b"/_matrix/client/v3/rooms/%21a%3Ab/state/m.room.name/...",),
+            # Only one round of decoding, so this is a literal "%2e%2e" segment.
+            (b"/_matrix/client/v3/rooms/%21a%3Ab/state/m.room.name/%252e%252e",),
+            # Dot segments in the query string are none of our business.
+            (b"/_matrix/client/versions?redirectUrl=../../foo",),
+        ]
+    )
+    def test_paths_without_dot_segments_allowed(self, target: bytes) -> None:
+        """Paths that merely contain dots should be routed as normal"""
+        response = self._send_raw_request(target)
+
+        self.assertNotRegex(response, r"^HTTP/1\.1 400 ")
+        self.assertNotIn("M_INVALID_PARAM", response)
+
     def test_too_many_content_length_headers(self) -> None:
         """HTTP requests with multiple Content-Length headers should be rejected with 400"""
         self.hs.start_listening()


### PR DESCRIPTION
This ensures that there are attempts at path traversal, though Synapse already guards against that where necessary (e.g. in media repository).

This is particularly important if we start proxying requests to appservices, like in #19972

No Matrix APIs should have such path segments.

