### PR TITLE
Evict oldest OTKs if clients upload more than 500 keys

### DIFF
--- a/changelog.d/20159.feature
+++ b/changelog.d/20159.feature
@@ -1,0 +1,1 @@
+Limit the number of end-to-end encryption one-time keys stored per device, per algorithm, discarding the oldest keys above the new `max_one_time_keys_per_device` limit.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -729,6 +729,21 @@ Example configuration:
 delete_stale_devices_after: 1y
 ```
 ---
+### `max_one_time_keys_per_device`
+
+*(integer)* The maximum number of end-to-end encryption one-time keys, per key algorithm, to keep for each device. When a device uploads more than this, the oldest keys are discarded.
+
+Clients only retain a bounded number of their private one-time keys (discarding the oldest first), so keys beyond that bound could never be used anyway. This limit protects against clients that keep uploading keys regardless of how many the server already holds, which would otherwise leave the server handing out keys the device has forgotten.
+
+Take care not to set this below the number of keys clients upload at a time — 50, for clients built on the matrix-rust-sdk — as they would then re-upload keys on every sync, which is the very behaviour this limit exists to contain.
+
+Defaults to `500`.
+
+Example configuration:
+```yaml
+max_one_time_keys_per_device: 1000
+```
+---
 ### `email`
 
 *(object)* Configuration for sending emails from Synapse.

--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -800,6 +800,29 @@ properties:
     default: null
     examples:
       - 1y
+  max_one_time_keys_per_device:
+    type: integer
+    minimum: 1
+    description: >-
+      The maximum number of end-to-end encryption one-time keys, per key
+      algorithm, to keep for each device. When a device uploads more than this,
+      the oldest keys are discarded.
+
+
+      Clients only retain a bounded number of their private one-time keys
+      (discarding the oldest first), so keys beyond that bound could never be
+      used anyway. This limit protects against clients that keep uploading keys
+      regardless of how many the server already holds, which would otherwise
+      leave the server handing out keys the device has forgotten.
+
+
+      Take care not to set this below the number of keys clients upload at a
+      time — 50, for clients built on the matrix-rust-sdk — as they would then
+      re-upload keys on every sync, which is the very behaviour this limit
+      exists to contain.
+    default: 500
+    examples:
+      - 1000
   email:
     type: object
     description: >-

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -67,6 +67,19 @@ Using direct TCP replication for workers is no longer supported.
 Please see https://element-hq.github.io/synapse/latest/upgrade.html#direct-tcp-replication-is-no-longer-supported-migrate-to-redis
 """
 
+# The number of one-time keys that clients built on the matrix-rust-sdk upload at a
+# time. Keeping fewer than this per device means such clients top their keys back up
+# on every sync, which is the churn the limit exists to prevent.
+SENSIBLE_MIN_ONE_TIME_KEYS_PER_DEVICE = 50
+
+LOW_ONE_TIME_KEYS_PER_DEVICE_WARNING = """\
+WARNING: The 'max_one_time_keys_per_device' configuration setting is lower than the
+%i one-time keys that clients built on the matrix-rust-sdk upload at a time. Those
+clients will re-upload keys on every sync. See the config documentation at
+    https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#max_one_time_keys_per_device
+--------------------------------------------------------------------------------
+"""
+
 # by default, we attempt to listen on both '::' *and* '0.0.0.0' because some OSes
 # (Windows, macOS, other BSD/Linux where net.ipv6.bindv6only is set) will only listen
 # on IPv6 when '::' is set.
@@ -684,6 +697,26 @@ class ServerConfig(Config):
         # Admin uri to direct users at should their instance become blocked
         # due to resource constraints
         self.admin_contact = config.get("admin_contact", None)
+
+        # The maximum number of one-time keys of each algorithm to keep for a device.
+        # Uploading more causes the oldest keys to be discarded, which protects
+        # against clients that keep uploading keys they will never be able to use.
+        self.max_one_time_keys_per_device: int = config.get(
+            "max_one_time_keys_per_device", 500
+        )
+        if (
+            not isinstance(self.max_one_time_keys_per_device, int)
+            or self.max_one_time_keys_per_device < 1
+        ):
+            raise ConfigError(
+                "'max_one_time_keys_per_device' must be a positive integer",
+                ("max_one_time_keys_per_device",),
+            )
+        if self.max_one_time_keys_per_device < SENSIBLE_MIN_ONE_TIME_KEYS_PER_DEVICE:
+            logger.warning(
+                LOW_ONE_TIME_KEYS_PER_DEVICE_WARNING,
+                SENSIBLE_MIN_ONE_TIME_KEYS_PER_DEVICE,
+            )
 
         ip_range_blocklist = config.get(
             "ip_range_blacklist", DEFAULT_IP_RANGE_BLOCKLIST

--- a/synapse/handlers/e2e_keys.py
+++ b/synapse/handlers/e2e_keys.py
@@ -20,7 +20,7 @@
 #
 #
 import logging
-from typing import TYPE_CHECKING, Iterable, Mapping
+from typing import TYPE_CHECKING, Awaitable, Callable, Iterable, Mapping
 
 import attr
 from canonicaljson import encode_canonical_json
@@ -124,6 +124,9 @@ class E2eKeysHandler:
 
         self._task_scheduler.register_action(
             self._delete_old_one_time_keys_task, "delete_old_otks"
+        )
+        self._task_scheduler.register_action(
+            self._trim_one_time_keys_task, "trim_one_time_keys"
         )
 
     @trace
@@ -1607,19 +1610,50 @@ class E2eKeysHandler:
         that it could still have old OTKs that the client has dropped. This task is scheduled exactly once
         by a database schema delta file, and it clears out old one-time-keys that look like they came from libolm.
         """
+        return await self._process_one_time_keys_in_user_batches(
+            task, self.store.delete_old_otks_for_next_user_batch, "old"
+        )
+
+    async def _trim_one_time_keys_task(
+        self, task: ScheduledTask
+    ) -> tuple[TaskStatus, JsonMapping | None, str | None]:
+        """Scheduler task to trim the one-time keys of devices holding more than the configured maximum.
+
+        Before the maximum was introduced, a client bug could cause a device to upload a fresh batch of one-time
+        keys on every sync, leaving tens of thousands of keys on the server, most of which the client had already
+        forgotten. This task is scheduled exactly once by a database schema delta file, and trims such devices
+        down to the maximum; uploads are trimmed as they arrive from then on.
+        """
+        return await self._process_one_time_keys_in_user_batches(
+            task, self.store.trim_otks_for_next_user_batch, "surplus"
+        )
+
+    async def _process_one_time_keys_in_user_batches(
+        self,
+        task: ScheduledTask,
+        process_batch: Callable[[str, int], Awaitable[tuple[list[str], int]]],
+        description: str,
+    ) -> tuple[TaskStatus, JsonMapping | None, str | None]:
+        """Run a one-time key clean-up over all users, a batch at a time, recording progress on the task.
+
+        Args:
+            task: the scheduled task, whose result records the last user processed
+            process_batch: called with `(last_user_id, batch_size)`; returns `(users, deleted_rows)`, with
+                `users` empty once there is nothing left to process
+            description: the kind of keys being deleted, for logging
+        """
         last_user = task.result.get("from_user", "") if task.result else ""
         while True:
             # We process users in batches of 100
-            users, rowcount = await self.store.delete_old_otks_for_next_user_batch(
-                last_user, 100
-            )
+            users, rowcount = await process_batch(last_user, 100)
             if len(users) == 0:
                 # We're done!
                 return TaskStatus.COMPLETE, None, None
 
             logger.debug(
-                "Deleted %i old one-time-keys for users '%s'..'%s'",
+                "Deleted %i %s one-time-keys for users '%s'..'%s'",
                 rowcount,
+                description,
                 users[0],
                 users[-1],
             )

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -114,6 +114,9 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
         self._allow_device_name_lookup_over_federation = (
             self.hs.config.federation.allow_device_name_lookup_over_federation
         )
+        self._max_one_time_keys_per_device = (
+            self.hs.config.server.max_one_time_keys_per_device
+        )
 
         self._cross_signing_id_gen = MultiWriterIdGenerator(
             db_conn=db_conn,
@@ -655,9 +658,54 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
                 for algorithm, key_id, json_bytes in new_keys
             ],
         )
+        for algorithm in {algorithm for algorithm, _, _ in new_keys}:
+            self._trim_e2e_one_time_keys_txn(txn, user_id, device_id, algorithm)
         self._invalidate_cache_and_stream(
             txn, self.count_e2e_one_time_keys, (user_id, device_id)
         )
+
+    def _trim_e2e_one_time_keys_txn(
+        self, txn: LoggingTransaction, user_id: str, device_id: str, algorithm: str
+    ) -> int:
+        """Delete all but the newest `max_one_time_keys_per_device` one-time keys of
+        the given algorithm for a device.
+
+        Clients only retain a bounded number of private one-time keys, discarding the
+        oldest first, so keys beyond that bound can never be used. Keeping only the
+        newest keys mirrors that, and protects against clients that keep uploading
+        keys regardless of how many the server already holds.
+
+        For reference, vodozemac (and so the matrix-rust-sdk) publishes 50 keys at a
+        time (`PUBLIC_MAX_ONE_TIME_KEYS`) and retains 5000 private keys before
+        evicting the oldest (`OneTimeKeys::MAX_ONE_TIME_KEYS`). The default limit sits
+        between the two: comfortably above what a client publishes, so we never trim
+        keys a well-behaved client is still waiting to have claimed, and well below
+        what it retains, so we never hold a key the client has already discarded.
+
+        Returns:
+            The number of deleted keys.
+        """
+        txn.execute(
+            """
+            DELETE FROM e2e_one_time_keys_json
+            WHERE user_id = ? AND device_id = ? AND algorithm = ? AND key_id NOT IN (
+                SELECT key_id FROM e2e_one_time_keys_json
+                WHERE user_id = ? AND device_id = ? AND algorithm = ?
+                ORDER BY ts_added_ms DESC
+                LIMIT ?
+            )
+            """,
+            (
+                user_id,
+                device_id,
+                algorithm,
+                user_id,
+                device_id,
+                algorithm,
+                self._max_one_time_keys_per_device,
+            ),
+        )
+        return txn.rowcount
 
     @cached(max_entries=10000, tree=True)
     async def count_e2e_one_time_keys(
@@ -1566,6 +1614,61 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
         return await self.db_pool.runInteraction(
             "delete_old_otks_for_next_user_batch", impl
         )
+
+    async def trim_otks_for_next_user_batch(
+        self, after_user_id: str, number_of_users: int
+    ) -> tuple[list[str], int]:
+        """Trims the one-time keys of any devices which hold more than
+        `max_one_time_keys_per_device`, for the next batch of users.
+
+        Returns:
+            `(users, rows)`, where:
+             * `users` is the user IDs of the processed users. An empty list if we are done.
+             * `rows` is the number of deleted rows
+        """
+
+        def impl(txn: LoggingTransaction) -> tuple[list[str], int]:
+            # Find a batch of users
+            txn.execute(
+                """
+                SELECT DISTINCT(user_id) FROM e2e_one_time_keys_json
+                    WHERE user_id > ?
+                    ORDER BY user_id
+                    LIMIT ?
+                """,
+                (after_user_id, number_of_users),
+            )
+            users = [row[0] for row in txn.fetchall()]
+            if len(users) == 0:
+                return users, 0
+
+            # Find the devices (and algorithms) of those users which are over the limit.
+            clause, args = make_in_list_sql_clause(
+                txn.database_engine, "user_id", users
+            )
+            txn.execute(
+                f"""
+                SELECT user_id, device_id, algorithm FROM e2e_one_time_keys_json
+                    WHERE {clause}
+                    GROUP BY user_id, device_id, algorithm
+                    HAVING COUNT(*) > ?
+                """,
+                args + [self._max_one_time_keys_per_device],
+            )
+            over_limit = txn.fetchall()
+
+            deleted = 0
+            for user_id, device_id, algorithm in over_limit:
+                deleted += self._trim_e2e_one_time_keys_txn(
+                    txn, user_id, device_id, algorithm
+                )
+                self._invalidate_cache_and_stream(
+                    txn, self.count_e2e_one_time_keys, (user_id, device_id)
+                )
+
+            return users, deleted
+
+        return await self.db_pool.runInteraction("trim_otks_for_next_user_batch", impl)
 
     async def allow_master_cross_signing_key_replacement_without_uia(
         self, user_id: str, duration_ms: int

--- a/synapse/storage/schema/main/delta/94/09_trim_one_time_keys.sql.postgres
+++ b/synapse/storage/schema/main/delta/94/09_trim_one_time_keys.sql.postgres
@@ -1,0 +1,19 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2026 Element Creations Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+-- Before Synapse limited the number of one-time keys held per device, a client bug could
+-- leave tens of thousands of keys on the server, most of which the client had already forgotten.
+--
+-- We create a scheduled task which trims any such devices down to the configured maximum.
+INSERT INTO scheduled_tasks(id, action, status, timestamp)
+    VALUES ('trim_one_time_keys_task', 'trim_one_time_keys', 'scheduled', extract(epoch from current_timestamp) * 1000);

--- a/synapse/storage/schema/main/delta/94/09_trim_one_time_keys.sql.sqlite
+++ b/synapse/storage/schema/main/delta/94/09_trim_one_time_keys.sql.sqlite
@@ -1,0 +1,19 @@
+--
+-- This file is licensed under the Affero General Public License (AGPL) version 3.
+--
+-- Copyright (C) 2026 Element Creations Ltd
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- See the GNU Affero General Public License for more details:
+-- <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+-- Before Synapse limited the number of one-time keys held per device, a client bug could
+-- leave tens of thousands of keys on the server, most of which the client had already forgotten.
+--
+-- We create a scheduled task which trims any such devices down to the configured maximum.
+INSERT INTO scheduled_tasks(id, action, status, timestamp)
+    VALUES ('trim_one_time_keys_task', 'trim_one_time_keys', 'scheduled', strftime('%s', 'now') * 1000);

--- a/tests/config/test_server.py
+++ b/tests/config/test_server.py
@@ -229,6 +229,21 @@ class ServerConfigTestCase(unittest.TestCase):
             with self.assertRaises(ConfigError):
                 _read_config(generate_config(disallowed_value))
 
+    def test_max_one_time_keys_per_device_enforces_positive_int(self) -> None:
+        """
+        Test that the configured maximum number of one-time keys must be a positive
+        value, as a device can never hold fewer than one key
+        """
+
+        def generate_config(value: Any) -> JsonDict:
+            return {"max_one_time_keys_per_device": value}
+
+        _read_config(generate_config(1))
+
+        for disallowed_value in (-1, 0, 0.5):
+            with self.assertRaises(ConfigError):
+                _read_config(generate_config(disallowed_value))
+
     @parameterized.expand(
         [
             [

--- a/tests/handlers/test_e2e_keys.py
+++ b/tests/handlers/test_e2e_keys.py
@@ -36,6 +36,7 @@ from synapse.server import HomeServer
 from synapse.storage.databases.main.appservice import _make_exclusive_regex
 from synapse.types import JsonDict, UserID
 from synapse.util.clock import Clock
+from synapse.util.task_scheduler import TaskScheduler, TaskStatus
 
 from tests import unittest
 from tests.unittest import override_config
@@ -404,6 +405,74 @@ class E2eKeysHandlerTestCase(unittest.HomeserverTestCase):
         self.assertEqual(len(claimed_keys), 2)
         for key_id in claimed_keys.keys():
             self.assertIn(key_id, ["alg1:k20", "alg1:k21", "alg1:k22"])
+
+    @override_config({"max_one_time_keys_per_device": 5})
+    def test_upload_one_time_keys_over_limit_discards_oldest(self) -> None:
+        """Uploading more one-time keys than the limit discards the oldest ones"""
+        local_user = "@boris:" + self.hs.hostname
+        device_id = "xyz"
+
+        res = self.get_success(
+            self.handler.upload_keys_for_user(
+                local_user,
+                device_id,
+                {"one_time_keys": {f"alg1:k{i}": f"key{i}" for i in range(1, 6)}},
+            )
+        )
+        self.assertEqual(res["one_time_key_counts"]["alg1"], 5)
+
+        # Advance time by 1s, to ensure that there is a difference in upload time.
+        self.reactor.advance(1)
+        res = self.get_success(
+            self.handler.upload_keys_for_user(
+                local_user,
+                device_id,
+                {"one_time_keys": {f"alg1:k{i}": f"key{i}" for i in range(6, 9)}},
+            )
+        )
+        # The count reported back to the client reflects the trimmed set.
+        self.assertEqual(res["one_time_key_counts"]["alg1"], 5)
+
+        # The newest keys are all kept; the surplus came out of the older batch.
+        keys = self.get_success(
+            self.store.get_e2e_one_time_keys(
+                local_user, device_id, [f"k{i}" for i in range(1, 9)]
+            )
+        )
+        self.assertEqual(len(keys), 5)
+        for i in range(6, 9):
+            self.assertIn(("alg1", f"k{i}"), keys)
+
+    @override_config({"max_one_time_keys_per_device": 5})
+    def test_trim_one_time_keys_task(self) -> None:
+        """The one-off trim task brings devices which are over the limit back down to it"""
+        local_user = "@boris:" + self.hs.hostname
+        device_id = "xyz"
+
+        # Get a device over the limit, as a buggy client could have before the
+        # limit existed, by lifting the limit for the upload.
+        self.store._max_one_time_keys_per_device = 1000
+        self.get_success(
+            self.handler.upload_keys_for_user(
+                local_user,
+                device_id,
+                {"one_time_keys": {f"alg1:k{i}": f"key{i}" for i in range(1, 9)}},
+            )
+        )
+        self.store._max_one_time_keys_per_device = 5
+
+        task_scheduler = self.hs.get_task_scheduler()
+        task_id = self.get_success(task_scheduler.schedule_task("trim_one_time_keys"))
+        # Let the scheduler pick the task up, and the task sleep between batches.
+        self.reactor.advance(TaskScheduler.SCHEDULE_INTERVAL.as_secs() + 60)
+
+        task = self.get_success(task_scheduler.get_task(task_id))
+        assert task is not None
+        self.assertEqual(task.status, TaskStatus.COMPLETE)
+        counts = self.get_success(
+            self.store.count_e2e_one_time_keys(local_user, device_id)
+        )
+        self.assertEqual(counts["alg1"], 5)
 
     def test_fallback_key(self) -> None:
         local_user = "@boris:" + self.hs.hostname


### PR DESCRIPTION
### Motivation

In https://github.com/matrix-org/matrix-js-sdk/issues/5501, clients can upload arbitrary numbers of one-time keys (up to several thousand) while forgetting about their private halves (Vodozemac keeps 100 locally), leading peers to claim OTKs and use them to send pre-key sessions the client cannot decrypt, preventing new Olm sessions from being established.

No server-side limit exists in Synapse, and the specification does not prevent us from forgetting about older keys as long as we guarantee only one peer can ever claim a particular key. This limit would mitigate some of the effects of OTK starvation, although it is best paired with the relevant JS SDK fix, https://github.com/matrix-org/matrix-js-sdk/pull/5503.

### Notes

Two important things worth considering before merging:

- This PR makes changes to the database schema;
- The OTK eviction task **could start performing a lot of work when deployed to old/large homeservers**, e.g. matrix.org - worth checking how many devices already exceed the 500 limit.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
