### PR TITLE
Add unit tests for is_compliant_user_id_localpart

### DIFF
--- a/changelog.d/20164.misc
+++ b/changelog.d/20164.misc
@@ -1,0 +1,1 @@
+Add unit tests for `is_compliant_user_id_localpart`. Contributed by @guillemo12.

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -37,6 +37,7 @@ from synapse.types import (
     UserID,
     get_domain_from_id,
     get_localpart_from_id,
+    is_compliant_user_id_localpart,
     map_username_to_mxid_localpart,
 )
 
@@ -350,3 +351,27 @@ class NonNegativeStrictIntTestCase(unittest.TestCase):
 
         self.assertEqual(MyModel.model_validate_json('{"limit": 0}'), MyModel(limit=0))
         self.assertEqual(MyModel.model_validate({"limit": 42}), MyModel(limit=42))
+
+
+class IsCompliantUserIdLocalpartTestCase(unittest.TestCase):
+    def test_empty_string(self) -> None:
+        self.assertFalse(is_compliant_user_id_localpart(""))
+
+    def test_valid_characters(self) -> None:
+        # alphanumeric
+        self.assertTrue(is_compliant_user_id_localpart("alice"))
+        self.assertTrue(is_compliant_user_id_localpart("Alice123"))
+
+        # symbols between 0x21 and 0x7E
+        self.assertTrue(is_compliant_user_id_localpart("!@#$"))
+        self.assertTrue(is_compliant_user_id_localpart("bob.jones"))
+        self.assertTrue(is_compliant_user_id_localpart("=+-[]{}"))
+
+    def test_invalid_characters(self) -> None:
+        # non-ascii / outside range
+        self.assertFalse(is_compliant_user_id_localpart("álice"))
+        self.assertFalse(is_compliant_user_id_localpart("alice 123"))  # space is 0x20
+        self.assertFalse(is_compliant_user_id_localpart("alice\t"))
+        self.assertFalse(is_compliant_user_id_localpart("alice\n"))
+        self.assertFalse(is_compliant_user_id_localpart("alice\x1f"))  # control char
+        self.assertFalse(is_compliant_user_id_localpart("alice\x7f"))  # DEL is 0x7F


### PR DESCRIPTION
### What I hope to achieve

Add missing unit test coverage for `is_compliant_user_id_localpart` in `synapse/types/__init__.py`.

### How it addresses those goals

Added `IsCompliantUserIdLocalpartTestCase` in `tests/test_types.py` covering:

 - Empty strings
 - Compliant ASCII characters within the range U+0021 to U+007E (alphanumeric and valid symbols)
 - Non-compliant characters (spaces, non-ASCII characters, control characters, tabs, newlines, and DEL `\x7f`).

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
