### PR TITLE
Add `trusted_proxies` listener option to resolve client IPs safely

### DIFF
--- a/changelog.d/20183.bugfix
+++ b/changelog.d/20183.bugfix
@@ -1,0 +1,1 @@
+Fix client IP spoofing when `x_forwarded` is enabled by adding a `trusted_proxies` listener option which safely resolves the client address from the X-Forwarded-For chain. Configuring it is strongly recommended; without it the previous behaviour is kept.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -534,6 +534,21 @@ Options for each entry include:
 
 * `x_forwarded` (boolean): Only valid for an `http` listener. Set to true to use the X-Forwarded-For header as the client IP. Useful when Synapse is behind a [reverse-proxy](../../reverse_proxy.md).
 
+* `trusted_proxies` (array): Only valid for an `http` listener with `x_forwarded` enabled. A list of IP addresses or CIDR ranges of reverse proxies that Synapse should trust when resolving the client IP from the X-Forwarded-For header. The chain is walked from right to left, starting at the address the connection was received from, and each hop is only followed while the address to its right is a trusted proxy. Clients can spoof their IP address if this is not configured (or if the reverse proxy does not itself sanitise the header). Defaults to no trusted proxies, in which case the first address in the X-Forwarded-For header is used, as before.
+
+  Example:
+  ```yaml
+  listeners:
+    - port: 8008
+      x_forwarded: true
+      trusted_proxies:
+        - 127.0.0.1
+        - ::1
+        - 10.0.0.0/8
+      resources:
+        - names: [client, federation]
+  ```
+
 * `request_id_header` (string|null): The header extracted from each incoming request that is used as the basis for the request ID. The request ID is used in [logs](../administration/request_log.md#request-log-format) and tracing to correlate and match up requests. When unset, Synapse will automatically generate sequential request IDs. This option is useful when Synapse is behind a [reverse-proxy](../../reverse_proxy.md).
 
   _Added in Synapse 1.68.0._

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -242,6 +242,7 @@ class HttpListenerConfig:
     """Object describing the http-specific parts of the config of a listener"""
 
     x_forwarded: bool = False
+    trusted_proxies: list[str] | None = None
     resources: list[HttpResourceConfig] = attr.Factory(list)
     additional_resources: dict[str, dict] = attr.Factory(dict)
     tag: str | None = None
@@ -1174,8 +1175,27 @@ def parse_listener_def(num: int, listener: Any) -> ListenerConfig:
         # getting a client IP.
         # Note: a reverse proxy is required anyway, as there is no way of exposing a
         # unix socket to the internet.
+        trusted_proxies = listener.get("trusted_proxies")
+        if trusted_proxies is not None:
+            if not isinstance(trusted_proxies, list) or not all(
+                isinstance(proxy, str) for proxy in trusted_proxies
+            ):
+                raise ConfigError(
+                    "listener option 'trusted_proxies' must be a list of IP addresses"
+                    " or CIDR ranges"
+                )
+            try:
+                for proxy in trusted_proxies:
+                    IPNetwork(proxy)
+            except (AddrFormatError, ValueError) as e:
+                raise ConfigError(
+                    f"Invalid IP address or CIDR range in listener option"
+                    f" 'trusted_proxies': {e}"
+                ) from e
+
         http_config = HttpListenerConfig(
             x_forwarded=listener.get("x_forwarded", (True if socket_path else False)),
+            trusted_proxies=trusted_proxies,
             resources=resources,
             additional_resources=listener.get("additional_resources", {}),
             tag=listener.get("tag"),

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -23,9 +23,10 @@ import json
 import logging
 import time
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Generator
+from typing import TYPE_CHECKING, Any, Collection, Generator
 
 import attr
+from netaddr import AddrFormatError, IPAddress, IPNetwork
 from zope.interface import implementer
 
 from twisted.internet.address import UNIXAddress
@@ -733,13 +734,24 @@ class XForwardedForRequest(SynapseRequest):
         if not headers:
             return
 
-        # for now, we just use the first x-forwarded-for header. Really, we ought
-        # to start from the client IP address, and check whether it is trusted; if it
-        # is, work backwards through the headers until we find an untrusted address.
-        # see https://github.com/matrix-org/synapse/issues/9471
-        self._forwarded_for = _XForwardedForAddress(
-            headers[0].split(b",")[0].strip().decode("ascii")
-        )
+        # Multiple X-Forwarded-For headers are equivalent to one comma-separated
+        # list, in the order the headers appear.
+        entries = [entry.strip() for header in headers for entry in header.split(b",")]
+
+        trusted_proxies = self.synapse_site.trusted_proxies
+        if not trusted_proxies:
+            # No trusted proxies are configured, so the chain cannot be verified.
+            # Keep the historical behaviour of taking the first address in the
+            # list; configuring `trusted_proxies` is required to safely resolve
+            # the client IP from the chain.
+            # See https://github.com/matrix-org/synapse/issues/9471
+            self._forwarded_for = _XForwardedForAddress(
+                headers[0].split(b",")[0].strip().decode("ascii")
+            )
+        else:
+            self._forwarded_for = _XForwardedForAddress(
+                self._get_forwarded_client_ip(entries, trusted_proxies)
+            )
 
         # if we got an x-forwarded-for header, also look for an x-forwarded-proto header
         header = self.getHeader(b"x-forwarded-proto")
@@ -757,6 +769,50 @@ class XForwardedForRequest(SynapseRequest):
         if self._forwarded_https:
             return True
         return super().isSecure()
+
+    def _get_forwarded_client_ip(
+        self,
+        entries: list[bytes],
+        trusted_proxies: Collection[IPNetwork],
+    ) -> str:
+        """Resolve the client IP from an X-Forwarded-For chain.
+
+        The chain is walked from right to left, starting at the peer address of
+        the connection: each hop is only followed (moving left) while the
+        address on its right is a trusted proxy. The first untrusted address —
+        or the leftmost entry if the whole chain is trusted — is returned.
+
+        An attacker can only influence the result by injecting entries which
+        are then mistaken for trusted proxies, which requires control of a
+        trusted proxy itself.
+        """
+        peer = super().getClientAddress()
+        if isinstance(peer, UNIXAddress):
+            # A connection over a unix socket necessarily comes from a local
+            # (and therefore trusted) process.
+            current: str | None = None
+            current_is_trusted = True
+        else:
+            current = peer.host
+            current_is_trusted = _is_trusted_proxy(current, trusted_proxies)
+
+        for raw_entry in reversed(entries):
+            if not current_is_trusted:
+                break
+            try:
+                candidate = IPAddress(raw_entry.decode("ascii"))
+            except (AddrFormatError, ValueError):
+                # Not a valid IP address, so we cannot tell whether it is a
+                # trusted proxy: stop trusting the rest of the chain.
+                break
+            current = str(candidate)
+            current_is_trusted = _is_trusted_proxy(current, trusted_proxies)
+
+        if current is None:
+            # Degenerate case (eg. an empty chain on a unix socket listener):
+            # fall back to the first entry, as without trusted proxies.
+            return entries[0].decode("ascii", errors="replace")
+        return current
 
     def getClientIP(self) -> str:
         """
@@ -781,6 +837,15 @@ class XForwardedForRequest(SynapseRequest):
 @attr.s(frozen=True, slots=True, auto_attribs=True)
 class _XForwardedForAddress:
     host: str
+
+
+def _is_trusted_proxy(host: str, trusted_proxies: Collection[IPNetwork]) -> bool:
+    """Whether the given IP address (as a string) is one of the trusted proxies."""
+    try:
+        ip = IPAddress(host)
+    except (AddrFormatError, ValueError):
+        return False
+    return any(ip in network for network in trusted_proxies)
 
 
 class SynapseProtocol(HTTPChannel):
@@ -899,6 +964,14 @@ class SynapseSite(ProxySite):
         assert config.http_options is not None
         proxied = config.http_options.x_forwarded
         self.request_class = XForwardedForRequest if proxied else SynapseRequest
+
+        # Networks whose proxies we trust to provide an accurate
+        # X-Forwarded-For chain. Empty if `trusted_proxies` was not configured,
+        # in which case the whole chain is treated as untrusted.
+        self.trusted_proxies: tuple[IPNetwork, ...] = tuple(
+            IPNetwork(trusted_proxy)
+            for trusted_proxy in (config.http_options.trusted_proxies or ())
+        )
 
         self.request_id_header = config.http_options.request_id_header
         self.max_request_body_size = max_request_body_size

--- a/tests/config/test_server.py
+++ b/tests/config/test_server.py
@@ -322,3 +322,70 @@ class GenerateIpSetTestCase(unittest.TestCase):
         # The following get treated as empty data.
         self.assertFalse(generate_ip_set(None))
         self.assertFalse(generate_ip_set({}))
+
+
+class TrustedProxiesConfigTestCase(unittest.TestCase):
+    def _read_listeners(self, listeners: list[JsonDict]) -> ServerConfig:
+        config = ServerConfig(RootConfig())
+        config.read_config(
+            {"server_name": "test.example.com", "listeners": listeners},
+        )
+        return config
+
+    def test_trusted_proxies_passed_through(self) -> None:
+        config = self._read_listeners(
+            [
+                {
+                    "port": 8008,
+                    "type": "http",
+                    "x_forwarded": True,
+                    "trusted_proxies": ["127.0.0.1", "::1", "10.0.0.0/8"],
+                    "resources": [{"names": ["client"]}],
+                }
+            ]
+        )
+        self.assertEqual(
+            config.listeners[0].http_options.trusted_proxies,
+            ["127.0.0.1", "::1", "10.0.0.0/8"],
+        )
+
+    def test_trusted_proxies_default_to_none(self) -> None:
+        config = self._read_listeners(
+            [
+                {
+                    "port": 8008,
+                    "type": "http",
+                    "x_forwarded": True,
+                    "resources": [{"names": ["client"]}],
+                }
+            ]
+        )
+        self.assertIsNone(config.listeners[0].http_options.trusted_proxies)
+
+    def test_trusted_proxies_must_be_a_list(self) -> None:
+        with self.assertRaises(ConfigError):
+            self._read_listeners(
+                [
+                    {
+                        "port": 8008,
+                        "type": "http",
+                        "x_forwarded": True,
+                        "trusted_proxies": "127.0.0.1",
+                        "resources": [{"names": ["client"]}],
+                    }
+                ]
+            )
+
+    def test_trusted_proxies_must_be_valid_addresses(self) -> None:
+        with self.assertRaises(ConfigError):
+            self._read_listeners(
+                [
+                    {
+                        "port": 8008,
+                        "type": "http",
+                        "x_forwarded": True,
+                        "trusted_proxies": ["not-an-ip"],
+                        "resources": [{"names": ["client"]}],
+                    }
+                ]
+            )

--- a/tests/http/test_site.py
+++ b/tests/http/test_site.py
@@ -19,17 +19,22 @@
 #
 #
 
+from unittest.mock import Mock
+
+from netaddr import IPNetwork
 from parameterized import parameterized
 
-from twisted.internet.address import IPv6Address
+from twisted.internet.address import IPv4Address, IPv6Address, UNIXAddress
 from twisted.internet.testing import MemoryReactor, StringTransport
+from twisted.web.http_headers import Headers
 
 from synapse.app._base import max_request_body_size
 from synapse.app.homeserver import SynapseHomeServer
+from synapse.http.site import XForwardedForRequest
 from synapse.server import HomeServer
 from synapse.util.clock import Clock
 
-from tests.unittest import HomeserverTestCase
+from tests.unittest import HomeserverTestCase, TestCase
 
 
 class SynapseRequestTestCase(HomeserverTestCase):
@@ -256,3 +261,113 @@ class SynapseRequestTestCase(HomeserverTestCase):
         # We should get a 400
         response = transport.value().decode()
         self.assertRegex(response, r"^HTTP/1\.1 400 ")
+
+
+class XForwardedForRequestTestCase(TestCase):
+    """Tests for resolving the client IP from the X-Forwarded-For header."""
+
+    def _make_request(
+        self,
+        peer: object,
+        forwarded_for: list[bytes],
+        trusted_proxies: tuple[IPNetwork, ...] = (),
+    ) -> XForwardedForRequest:
+        site = Mock()
+        site.reactor = Mock()
+        site.trusted_proxies = trusted_proxies
+
+        channel = Mock()
+        channel.getPeer.return_value = peer
+
+        request = XForwardedForRequest(channel, site, our_server_name="test.server")
+        request.requestHeaders = Headers({b"X-Forwarded-For": forwarded_for})
+        request._process_forwarded_headers()
+        return request
+
+    def test_no_trusted_proxies_keeps_first_entry(self) -> None:
+        """Without trusted_proxies, the first entry is used as before."""
+        request = self._make_request(
+            peer=IPv4Address("TCP", "192.168.0.1", 45000),
+            forwarded_for=[b"9.9.9.9, 1.2.3.4"],
+        )
+        self.assertEqual(request.getClientIP(), "9.9.9.9")
+
+    def test_trusted_proxy_single_hop(self) -> None:
+        """The address reported by a trusted proxy is used."""
+        request = self._make_request(
+            peer=IPv4Address("TCP", "10.0.0.9", 45000),
+            forwarded_for=[b"1.2.3.4"],
+            trusted_proxies=(IPNetwork("10.0.0.0/8"),),
+        )
+        self.assertEqual(request.getClientIP(), "1.2.3.4")
+
+    def test_spoofed_entries_are_ignored(self) -> None:
+        """Entries injected by the client cannot override the proxy's report.
+
+        The reverse proxy appends the real client IP to the (spoofed) chain it
+        received, giving `9.9.9.9, 1.2.3.4`. Only `1.2.3.4` is one hop away
+        from the trusted proxy, so `9.9.9.9` must be ignored.
+        """
+        request = self._make_request(
+            peer=IPv4Address("TCP", "10.0.0.9", 45000),
+            forwarded_for=[b"9.9.9.9, 1.2.3.4"],
+            trusted_proxies=(IPNetwork("10.0.0.0/8"),),
+        )
+        self.assertEqual(request.getClientIP(), "1.2.3.4")
+
+    def test_untrusted_peer_is_not_spoofable(self) -> None:
+        """The header is ignored entirely if the peer is not a trusted proxy."""
+        request = self._make_request(
+            peer=IPv4Address("TCP", "192.168.0.1", 45000),
+            forwarded_for=[b"1.2.3.4"],
+            trusted_proxies=(IPNetwork("10.0.0.0/8"),),
+        )
+        self.assertEqual(request.getClientIP(), "192.168.0.1")
+
+    def test_multiple_trusted_proxies(self) -> None:
+        """The chain is followed through multiple trusted proxies."""
+        request = self._make_request(
+            peer=IPv4Address("TCP", "10.0.0.9", 45000),
+            forwarded_for=[b"10.1.0.9, 10.0.0.5, 1.2.3.4"],
+            trusted_proxies=(
+                IPNetwork("10.0.0.0/8"),
+                IPNetwork("10.1.0.0/16"),
+            ),
+        )
+        self.assertEqual(request.getClientIP(), "1.2.3.4")
+
+    def test_all_trusted_chain_uses_leftmost_entry(self) -> None:
+        """If the whole chain is trusted, the leftmost entry is the client."""
+        request = self._make_request(
+            peer=IPv4Address("TCP", "10.0.0.9", 45000),
+            forwarded_for=[b"10.1.0.9, 10.0.0.5"],
+            trusted_proxies=(IPNetwork("10.0.0.0/8"),),
+        )
+        self.assertEqual(request.getClientIP(), "10.1.0.9")
+
+    def test_unix_socket_peer_is_trusted(self) -> None:
+        """A unix socket peer is local, so the chain is honoured."""
+        request = self._make_request(
+            peer=UNIXAddress(b"/run/synapse.sock"),
+            forwarded_for=[b"10.0.0.5, 1.2.3.4"],
+            trusted_proxies=(IPNetwork("10.0.0.0/8"),),
+        )
+        self.assertEqual(request.getClientIP(), "1.2.3.4")
+
+    def test_invalid_entry_stops_the_chain(self) -> None:
+        """The chain is not followed past an entry which is not an IP address."""
+        request = self._make_request(
+            peer=IPv4Address("TCP", "10.0.0.9", 45000),
+            forwarded_for=[b"1.2.3.4, not-an-ip, 10.0.0.5"],
+            trusted_proxies=(IPNetwork("10.0.0.0/8"),),
+        )
+        self.assertEqual(request.getClientIP(), "10.0.0.5")
+
+    def test_multiple_headers_are_concatenated(self) -> None:
+        """Multiple X-Forwarded-For headers behave as one comma-separated list."""
+        request = self._make_request(
+            peer=IPv4Address("TCP", "10.0.0.9", 45000),
+            forwarded_for=[b"9.9.9.9", b"1.2.3.4"],
+            trusted_proxies=(IPNetwork("10.0.0.0/8"),),
+        )
+        self.assertEqual(request.getClientIP(), "1.2.3.4")


### PR DESCRIPTION
Fixes #9471

### Problem

When `x_forwarded: true` is set on a listener, Synapse takes the **first** entry of the `X-Forwarded-For` header as the client IP (there is even a code comment in `synapse/http/site.py` pointing this out and linking the issue). Standard reverse proxies *append* to the chain, so a client that sends `X-Forwarded-For: 1.2.3.4` ends up with the header `1.2.3.4, <real client ip>` — and Synapse reports the spoofed `1.2.3.4`.

This lets clients forge their IP for:

- rate limiting (registration, etc.)
- application service IP allowlists
- device "last seen" IPs
- request logs / `user_ips`

unless the outermost proxy is explicitly configured to sanitise the header.

### Fix

Implements what the issue proposes (and the code comment describes): a per-listener `trusted_proxies` option, a list of IP addresses / CIDR ranges. When set, the chain is resolved by walking **from right to left, starting at the connection's peer address**, following one hop left only while the address on the right is a trusted proxy — the standard `X-Real-IP`-style algorithm:

- peer not trusted → the peer address itself is reported, header ignored
- peer trusted, rightmost entry untrusted → that entry is reported (this kills the spoof above: `9.9.9.9, 1.2.3.4` now resolves to `1.2.3.4`)
- whole chain trusted → the leftmost entry is reported

Additional behaviour:

- **When `trusted_proxies` is not configured, the previous behaviour is kept** (first header entry), so no existing deployment silently changes; the docs recommend configuring it.
- Multiple `X-Forwarded-For` headers are concatenated, as they are equivalent to one comma-separated list.
- Entries which are not valid IP addresses stop the walk (the chain past them cannot be verified).
- Unix-socket peers are treated as trusted (local process), matching the fact that `x_forwarded` defaults to true for unix socket listeners.
- Invalid `trusted_proxies` config is rejected at startup with a `ConfigError`.

### Docs

- `trusted_proxies` documented in the listeners section of the config manual, with an example.

### Changelog

Added in a follow-up commit with the PR number.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html#pull-request-weights-and-sizes before submitting your PR. -->

* [x] Pull request which is not marked as **constraining**.
* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog)
* [x] Pull request includes a [sign off](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] Code style is correct (ran the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#code-style))