### PR TITLE
Use sharded tokens in MSC4354: Sticky Events sync and sliding sync, preventing events appearing in multiple sync responses.

### DIFF
--- a/changelog.d/20186.bugfix
+++ b/changelog.d/20186.bugfix
@@ -1,0 +1,1 @@
+Use sharded tokens in [MSC4354: Sticky Events] sync and sliding sync, preventing events appearing in multiple sync responses.

--- a/synapse/handlers/sliding_sync/extensions.py
+++ b/synapse/handlers/sliding_sync/extensions.py
@@ -1037,12 +1037,12 @@ class SlidingSyncExtensionHandler:
         # to make sure the client receives all visible (unexpired) sticky events
         since_token = sticky_events_request.since or SlidingSyncStickyEventsToken.START
         (
-            sticky_events_to_id,
+            sticky_events_to_token,
             room_to_event_ids,
         ) = await self.store.get_sticky_events_in_rooms(
             all_interested_room_ids,
-            from_id=since_token.sticky_events_stream_id,
-            to_id=to_token.sticky_events_key,
+            from_token=await since_token.to_stream_token(self.store),
+            to_token=to_token.sticky_events_key,
             now=now,
             limit=min(sticky_events_request.limit, StickyEvent.MAX_EVENTS_IN_SYNC),
         )
@@ -1079,8 +1079,8 @@ class SlidingSyncExtensionHandler:
 
         return SlidingSyncResult.Extensions.StickyEventsExtension(
             room_id_to_sticky_events=room_id_to_sticky_events,
-            next_batch=SlidingSyncStickyEventsToken(
-                sticky_events_stream_id=sticky_events_to_id
+            next_batch=await SlidingSyncStickyEventsToken.from_stream_token(
+                self.store, sticky_events_to_token
             ),
         )
 

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -686,18 +686,24 @@ class SyncHandler:
         with Measure(
             self.clock, name="sticky_events_by_room", server_name=self.server_name
         ):
-            from_id = since_token.sticky_events_key if since_token else 0
+            from_token = (
+                since_token.sticky_events_key
+                if since_token
+                else MultiWriterStreamToken(stream=0)
+            )
 
             room_ids = sync_result_builder.joined_room_ids
 
-            to_id, sticky_by_room = await self.store.get_sticky_events_in_rooms(
+            to_token, sticky_by_room = await self.store.get_sticky_events_in_rooms(
                 room_ids,
-                from_id=from_id,
-                to_id=now_token.sticky_events_key,
+                from_token=from_token,
+                to_token=now_token.sticky_events_key,
                 now=now,
                 limit=StickyEvent.MAX_EVENTS_IN_SYNC,
             )
-            now_token = now_token.copy_and_replace(StreamKeyType.STICKY_EVENTS, to_id)
+            now_token = now_token.copy_and_replace(
+                StreamKeyType.STICKY_EVENTS, to_token
+            )
 
         return now_token, sticky_by_room
 

--- a/synapse/notifier.py
+++ b/synapse/notifier.py
@@ -509,7 +509,7 @@ class Notifier:
     @overload
     def on_new_event(
         self,
-        stream_key: Literal[StreamKeyType.RECEIPT],
+        stream_key: Literal[StreamKeyType.RECEIPT, StreamKeyType.STICKY_EVENTS],
         new_token: MultiWriterStreamToken,
         users: Collection[str | UserID] | None = None,
         rooms: StrCollection | None = None,
@@ -527,7 +527,6 @@ class Notifier:
             StreamKeyType.TYPING,
             StreamKeyType.UN_PARTIAL_STATED_ROOMS,
             StreamKeyType.THREAD_SUBSCRIPTIONS,
-            StreamKeyType.STICKY_EVENTS,
             StreamKeyType.PROFILE_UPDATES,
         ],
         new_token: int,

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -286,7 +286,7 @@ class ReplicationDataHandler:
         elif stream_name == StickyEventsStream.NAME:
             self.notifier.on_new_event(
                 StreamKeyType.STICKY_EVENTS,
-                token,
+                self.store.get_sticky_events_stream_token(),
                 rooms=[row.room_id for row in rows],
             )
 

--- a/synapse/storage/databases/main/sticky_events.py
+++ b/synapse/storage/databases/main/sticky_events.py
@@ -28,7 +28,12 @@ from synapse.storage.database import (
 from synapse.storage.databases.main.cache import CacheInvalidationWorkerStore
 from synapse.storage.databases.main.state import StateGroupWorkerStore
 from synapse.storage.engines import PostgresEngine, Sqlite3Engine
-from synapse.storage.util.id_generators import MultiWriterIdGenerator
+from synapse.storage.util.id_generators import (
+    MultiWriterIdGenerator,
+    advance_multiwriter_sharded_token_after_partial_read,
+    make_multiwriter_sharded_token_bounds_sql,
+)
+from synapse.types import MultiWriterStreamToken
 from synapse.util.duration import Duration
 
 if TYPE_CHECKING:
@@ -126,13 +131,13 @@ class StickyEventsWorkerStore(StateGroupWorkerStore, CacheInvalidationWorkerStor
             self._sticky_events_id_gen.advance(instance_name, token)
         super().process_replication_position(stream_name, instance_name, token)
 
-    def get_max_sticky_events_stream_id(self) -> int:
-        """Get the current maximum stream_id for thread subscriptions.
+    def get_sticky_events_stream_token(self) -> MultiWriterStreamToken:
+        """Get the current position of the sticky events stream.
 
         Returns:
-            The maximum stream_id
+            A (potentially sharded) token for the sticky events stream.
         """
-        return self._sticky_events_id_gen.get_current_token()
+        return MultiWriterStreamToken.from_generator(self._sticky_events_id_gen)
 
     def get_sticky_events_stream_id_generator(self) -> MultiWriterIdGenerator:
         return self._sticky_events_id_gen
@@ -141,41 +146,54 @@ class StickyEventsWorkerStore(StateGroupWorkerStore, CacheInvalidationWorkerStor
         self,
         room_ids: Collection[str],
         *,
-        from_id: int,
-        to_id: int,
+        from_token: MultiWriterStreamToken,
+        to_token: MultiWriterStreamToken,
         now: int,
         limit: int | None,
-    ) -> tuple[int, dict[str, list[str]]]:
+    ) -> tuple[MultiWriterStreamToken, dict[str, list[str]]]:
         """
-        Fetch all the sticky events' IDs in the given rooms, with sticky stream IDs satisfying
-        from_id < sticky stream ID <= to_id.
+        Fetch all the sticky events' IDs in the given rooms, with sticky stream positions
+        after `from_token` and at or before `to_token`.
 
         The events are returned ordered by the sticky events stream.
 
         Args:
             room_ids: The room IDs to return sticky events in.
-            from_id: The sticky stream ID that sticky events should be returned from (exclusive).
-            to_id: The sticky stream ID that sticky events should end at (inclusive).
+            from_token: The sticky stream position to return sticky events from (exclusive).
+            to_token: The sticky stream position to end at (inclusive).
             now: The current time in unix millis, used for skipping expired events.
             limit: Max sticky events to return, or None to apply no limit.
         Returns:
-            to_id, dict[room_id, list[event_ids]]
+            The stream position that has been read up to (which may be behind
+            `to_token` if `limit` was hit), and a dict[room_id, list[event_ids]].
         """
+        if limit == 0:
+            # No rows to return, so don't advance.
+            return from_token, {}
+
         sticky_events_rows = await self.db_pool.runInteraction(
             "get_sticky_events_in_rooms",
             self._get_sticky_events_in_rooms_txn,
             room_ids,
-            from_id=from_id,
-            to_id=to_id,
+            from_token=from_token,
+            to_token=to_token,
             now=now,
             limit=limit,
         )
 
-        if not sticky_events_rows:
-            return to_id, {}
-
-        # Get stream_id of the last row, which is the highest
-        new_to_id, _, _ = sticky_events_rows[-1]
+        if limit is not None and len(sticky_events_rows) == limit:
+            # We hit the limit, so advance the `to_token` partially
+            last_stream_id, _, _ = sticky_events_rows[-1]
+            new_to_token = advance_multiwriter_sharded_token_after_partial_read(
+                from_token_exclusive=from_token,
+                to_token_inclusive=to_token,
+                last_read_stream_id=last_stream_id,
+            )
+        else:
+            # We didn't hit the limit, therefore we have read the whole range.
+            # We can skip ahead to `to_token` (just be careful that we don't
+            # rewind `from_token` in the case this worker is behind.)
+            new_to_token = from_token.copy_and_advance(to_token)
 
         # room ID -> event IDs
         room_id_to_event_ids: dict[str, list[str]] = {}
@@ -183,22 +201,28 @@ class StickyEventsWorkerStore(StateGroupWorkerStore, CacheInvalidationWorkerStor
             events = room_id_to_event_ids.setdefault(room_id, [])
             events.append(event_id)
 
-        return (new_to_id, room_id_to_event_ids)
+        return (new_to_token, room_id_to_event_ids)
 
     def _get_sticky_events_in_rooms_txn(
         self,
         txn: LoggingTransaction,
         room_ids: Collection[str],
         *,
-        from_id: int,
-        to_id: int,
+        from_token: MultiWriterStreamToken,
+        to_token: MultiWriterStreamToken,
         now: int,
         limit: int | None,
     ) -> list[tuple[int, str, str]]:
-        if len(room_ids) == 0:
+        if len(room_ids) == 0 or limit == 0 or to_token.is_before_or_eq(from_token):
             return []
         room_id_in_list_clause, room_id_in_list_values = make_in_list_sql_clause(
             txn.database_engine, "se.room_id", room_ids
+        )
+        stream_clause, stream_values = make_multiwriter_sharded_token_bounds_sql(
+            stream_id_column="se.stream_id",
+            instance_name_column="se.instance_name",
+            from_token_exclusive=from_token,
+            to_token_inclusive=to_token,
         )
         limit_clause = ""
         limit_params: tuple[int, ...] = ()
@@ -219,13 +243,12 @@ class StickyEventsWorkerStore(StateGroupWorkerStore, CacheInvalidationWorkerStor
             WHERE
                 NOT {expr_soft_failed}
                 AND ? < expires_at
-                AND ? < stream_id
-                AND stream_id <= ?
+                AND {stream_clause}
                 AND {room_id_in_list_clause}
-            ORDER BY stream_id ASC
+            ORDER BY se.stream_id ASC
             {limit_clause}
             """,
-            (now, from_id, to_id, *room_id_in_list_values, *limit_params),
+            (now, *stream_values, *room_id_in_list_values, *limit_params),
         )
         return cast(list[tuple[int, str, str]], txn.fetchall())
 

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -36,6 +36,7 @@ from typing import (
 )
 
 import attr
+from immutabledict import immutabledict
 from sortedcontainers import SortedList, SortedSet
 
 from synapse.logging import issue9533_logger
@@ -49,6 +50,7 @@ from synapse.storage.database import (
 from synapse.storage.engines import PostgresEngine
 from synapse.storage.types import Cursor
 from synapse.storage.util.sequence import build_sequence_generator
+from synapse.types import MultiWriterStreamToken
 
 if TYPE_CHECKING:
     from synapse.notifier import ReplicationNotifier
@@ -982,3 +984,180 @@ class _MultiWriterCtxManager:
             )
 
         return False
+
+
+def make_multiwriter_sharded_token_bounds_sql(
+    *,
+    stream_id_column: str,
+    instance_name_column: str,
+    from_token_exclusive: MultiWriterStreamToken,
+    to_token_inclusive: MultiWriterStreamToken,
+) -> tuple[str, Sequence[str | int]]:
+    """
+    Build an SQL clause that, in a multi-writer stream table,
+    matches the rows within the bounds of the `MultiWriterStreamToken` tokens provided.
+
+    Bounds: from_token_exclusive < ... <= to_token_inclusive
+
+    Arguments:
+        stream_id_column: the name of the `stream_id` column
+            Should be prefixed with the table name or alias
+            when used in a multi-table SELECT statement.
+        instance_name_column: the name of the `instance_name` column.
+            Should be prefixed with the table name or alias
+            when used in a multi-table SELECT statement.
+        from_token_exclusive:
+            MultiWriterStreamToken representing the highest position that has 'already been seen'.
+            Exclusive lower bound
+        to_token_inclusive:
+            MultiWriterStreamToken representing the highest position that has visible data.
+            Inclusive upper bound
+
+    Example:
+
+        make_multiwriter_sharded_token_bounds_sql(
+            stream_id_column="se.stream_id",
+            instance_name_column="se.instance_name",
+            # m5~1.8
+            from_token_exclusive=MultiWriterStreamToken(
+                stream=5, instance_map=immutabledict({"worker1": 8})
+            ),
+            # m10~2.14
+            to_token_inclusive=MultiWriterStreamToken(
+                stream=10, instance_map=immutabledict({"worker2": 14})
+            ),
+        )
+
+    gives:
+
+        (
+            5 < se.stream_id AND se.stream_id <= 14
+            AND NOT (se.instance_name = 'worker1' AND se.stream_id <= 8)
+            AND (
+                se.stream_id <= 10
+                OR (se.instance_name = 'worker2' AND se.stream_id <= 14)
+            )
+        )
+
+    which matches, for example:
+        - a `worker1` row at position 9 (past the 8 we had already read from
+            `worker1`, and within the 10 that is visible for every writer);
+        - a `worker2` row at position 12 (past 5, and `worker2` is
+            explicitly visible up to 14);
+    but not:
+        - a `worker1` row at position 7, which the `from` token says we have
+            already read;
+        - a `worker3` row at position 12, which is beyond the position that
+            is visible for writers other than `worker2`.
+
+    See also:
+        - `advance_multiwriter_sharded_token_after_partial_read` to create the next
+          `from_token_exclusive` after the result of reading a limited set of rows.
+    """
+
+    # The SQL we build will fundamentally consist of many clauses ANDed together.
+    #
+    # We start with an envelope delimited by the two outermost, writer-independent, bounds.
+    # We know everything before the lowest position of `from` and everything after the highest
+    # position of `to` must be out-of-bounds.
+    # This pair of bounds is the most likely to be index-friendly.
+    clauses = [f"? < {stream_id_column}", f"{stream_id_column} <= ?"]
+    values: list[int | str] = [
+        from_token_exclusive.stream,
+        to_token_inclusive.get_max_stream_pos(),
+    ]
+
+    # Now for every writer where we had already read further ahead than the baseline (lowest) position of `from`,
+    # we whittle away what we have already seen from the lower end of the envelope.
+    for instance_name, pos in from_token_exclusive.instance_map.items():
+        clauses.append(f"NOT ({instance_name_column} = ? AND {stream_id_column} <= ?)")
+        values.extend((instance_name, pos))
+
+    # Now we need to restrict the upper end of the envelope to only include those rows where either:
+    # - the row is in a region where all writers' rows are visible; or
+    upper_or_clauses = [f"{stream_id_column} <= ?"]
+    upper_or_values: list[int | str] = [to_token_inclusive.stream]
+    # - the row's writer is explicitly visible ahead of the baseline (minimum) position
+    for instance_name, pos in to_token_inclusive.instance_map.items():
+        upper_or_clauses.append(
+            f"({instance_name_column} = ? AND {stream_id_column} <= ?)"
+        )
+        upper_or_values.extend((instance_name, pos))
+
+    clauses.append("(\n\t\t" + "\n\t\tOR ".join(upper_or_clauses) + "\n\t)")
+    values.extend(upper_or_values)
+
+    return "(\n\t" + "\n\tAND ".join(clauses) + "\n)", values
+
+
+def advance_multiwriter_sharded_token_after_partial_read(
+    *,
+    from_token_exclusive: MultiWriterStreamToken,
+    to_token_inclusive: MultiWriterStreamToken,
+    last_read_stream_id: int,
+) -> MultiWriterStreamToken:
+    """
+    Calculates the 'read up to' token after reading a limited number of rows
+    between two `MultiWriterStreamToken` bounds.
+    Pairs with `make_multiwriter_sharded_token_bounds_sql`.
+
+    The read operation MUST have been ordered by the stream ID, e.g.
+    using `ORDER BY stream_id`.
+
+    Arguments:
+        from_token_exclusive: the exclusive lower bound the rows were read with.
+        to_token_inclusive: the inclusive upper bound the rows were read with.
+        last_read_stream_id: the `stream_id` of the last row that was read.
+
+    Returns:
+        A token that could be used as the `from_token_exclusive` for a subsequent
+        read, in order to continue reading rows in range.
+
+        The token represents the maximum 'read up to' position.
+        Rows with positions strictly above the token have not yet been read.
+    """
+    assert from_token_exclusive.stream < last_read_stream_id, "read was out of bounds"
+
+    # Calculate the new baseline position that we have read up to,
+    # which applies across all workers.
+    new_baseline = max(
+        # Must be at least as far as it was before (doesn't go backwards)
+        from_token_exclusive.stream,
+        min(
+            # Simple case: this is just `last_read_stream_id`,
+            # the `stream_id` of the last row we read.
+            last_read_stream_id,
+            # Complicated case: some writers may not have advanced to `last_read_stream_id` yet,
+            # so we have to cap off at the baseline 'to' position (`to_token_inclusive.stream`)
+            to_token_inclusive.stream,
+        ),
+    )
+
+    # Now consider whether any workers are ahead of the baseline.
+    # We do this by calculating the position of each relevant worker.
+    # (Relevant by virtue of being in either the `from` or `to` token.)
+    advanced_instance_map = {}
+    for instance_name in (
+        from_token_exclusive.instance_map.keys()
+        | to_token_inclusive.instance_map.keys()
+    ):
+        # Calculate the worker's position
+        worker_pos = max(
+            # Must be at least as far as it was before (doesn't go backwards)
+            from_token_exclusive.get_stream_pos_for_instance(instance_name),
+            # Then:
+            # - up to `last_read_stream_id`
+            # - unless its rows aren't visible yet, so cap off at the `to` position
+            # Either one of these cases will be at least as high as `new_baseline`.
+            min(
+                last_read_stream_id,
+                to_token_inclusive.get_stream_pos_for_instance(instance_name),
+            ),
+        )
+
+        if worker_pos > new_baseline:
+            advanced_instance_map[instance_name] = worker_pos
+
+    return MultiWriterStreamToken(
+        stream=new_baseline, instance_map=immutabledict(advanced_instance_map)
+    )

--- a/synapse/streams/events.py
+++ b/synapse/streams/events.py
@@ -84,7 +84,7 @@ class EventSources:
             self._instance_name
         )
         thread_subscriptions_key = self.store.get_max_thread_subscriptions_stream_id()
-        sticky_events_key = self.store.get_max_sticky_events_stream_id()
+        sticky_events_key = self.store.get_sticky_events_stream_token()
         quarantined_media_key = self.store.get_quarantined_media_stream_token()
         profile_updates_key = self.store.get_max_profile_updates_stream_id()
 

--- a/synapse/types/__init__.py
+++ b/synapse/types/__init__.py
@@ -1102,7 +1102,10 @@ class MultiWriterStreamToken(AbstractMultiWriterStreamToken):
         instance_name: str | None,
         pos: int,
     ) -> bool:
-        """Checks if a given persisted position is between the two given tokens.
+        """
+        Checks if a given persisted position is between the two given tokens.
+
+        Bounds: low < (instance_name, pos) <= high
 
         If `instance_name` is None then the row was persisted before multi
         writer support.

--- a/synapse/types/__init__.py
+++ b/synapse/types/__init__.py
@@ -1019,7 +1019,23 @@ class RoomStreamToken(AbstractMultiWriterStreamToken):
 
 @attr.s(frozen=True, slots=True, order=False)
 class MultiWriterStreamToken(AbstractMultiWriterStreamToken):
-    """A basic stream token class for streams that supports multiple writers."""
+    """
+    A basic stream token class for streams that supports multiple writers.
+
+    Serialised as either:
+        - the bare `stream` position (e.g. `42`); or
+        - if any writer is ahead of that position,
+          as `m{stream}~{id}.{pos}~{id}.{pos}...`, where:
+          each `id` is the writer's ID from the `instance_map` table
+          (see `DataStore.get_id_for_instance`)
+
+    For the latter (`m{}~{}.{}~...`) form, it is necessary to check the writer of a
+    given row to determine how it compares to the token.
+
+    See:
+        - `is_stream_position_in_range` for a single row
+        - `make_multiwriter_sharded_token_bounds_sql` for SQL
+    """
 
     @classmethod
     async def parse(cls, store: "DataStore", string: str) -> "MultiWriterStreamToken":
@@ -1221,7 +1237,9 @@ class StreamToken:
     groups_key: int
     un_partial_stated_rooms_key: int
     thread_subscriptions_key: int
-    sticky_events_key: int
+    sticky_events_key: MultiWriterStreamToken = attr.ib(
+        validator=attr.validators.instance_of(MultiWriterStreamToken)
+    )
     quarantined_media_key: MultiWriterStreamToken = attr.ib(
         validator=attr.validators.instance_of(MultiWriterStreamToken)
     )
@@ -1273,7 +1291,9 @@ class StreamToken:
                 groups_key=int(groups_key),
                 un_partial_stated_rooms_key=int(un_partial_stated_rooms_key),
                 thread_subscriptions_key=int(thread_subscriptions_key),
-                sticky_events_key=int(sticky_events_key),
+                sticky_events_key=await MultiWriterStreamToken.parse(
+                    store, sticky_events_key
+                ),
                 quarantined_media_key=await MultiWriterStreamToken.parse(
                     store, quarantined_media_key
                 ),
@@ -1301,7 +1321,7 @@ class StreamToken:
                 str(self.groups_key),
                 str(self.un_partial_stated_rooms_key),
                 str(self.thread_subscriptions_key),
-                str(self.sticky_events_key),
+                await self.sticky_events_key.to_string(store),
                 await self.quarantined_media_key.to_string(store),
                 str(self.profile_updates_key),
             ]
@@ -1339,6 +1359,12 @@ class StreamToken:
                 self.quarantined_media_key.copy_and_advance(new_value),
             )
             return new_token
+        elif key == StreamKeyType.STICKY_EVENTS:
+            new_token = self.copy_and_replace(
+                StreamKeyType.STICKY_EVENTS,
+                self.sticky_events_key.copy_and_advance(new_value),
+            )
+            return new_token
 
         new_token = self.copy_and_replace(key, new_value)
         new_id = new_token.get_field(key)
@@ -1362,6 +1388,7 @@ class StreamToken:
             StreamKeyType.RECEIPT,
             StreamKeyType.DEVICE_LIST,
             StreamKeyType.QUARANTINED_MEDIA,
+            StreamKeyType.STICKY_EVENTS,
         ],
     ) -> MultiWriterStreamToken: ...
 
@@ -1376,7 +1403,6 @@ class StreamToken:
             StreamKeyType.TYPING,
             StreamKeyType.UN_PARTIAL_STATED_ROOMS,
             StreamKeyType.THREAD_SUBSCRIPTIONS,
-            StreamKeyType.STICKY_EVENTS,
             StreamKeyType.PROFILE_UPDATES,
         ],
     ) -> int: ...
@@ -1452,7 +1478,7 @@ StreamToken.START = StreamToken(
     groups_key=0,
     un_partial_stated_rooms_key=0,
     thread_subscriptions_key=0,
-    sticky_events_key=0,
+    sticky_events_key=MultiWriterStreamToken(stream=0),
     quarantined_media_key=MultiWriterStreamToken(stream=0),
     profile_updates_key=0,
 )

--- a/synapse/types/rest/client/__init__.py
+++ b/synapse/types/rest/client/__init__.py
@@ -19,7 +19,7 @@
 #
 #
 import re
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import pydantic_core.core_schema
 from pydantic import (
@@ -37,9 +37,17 @@ from pydantic import (
 from pydantic_core import CoreSchema
 from typing_extensions import Annotated, Self
 
-from synapse.types import Absent, AbsentType, NonNegativeStrictInt
+from synapse.types import (
+    Absent,
+    AbsentType,
+    MultiWriterStreamToken,
+    NonNegativeStrictInt,
+)
 from synapse.types.rest import RequestBodyModel
 from synapse.util.threepids import validate_email
+
+if TYPE_CHECKING:
+    from synapse.storage.databases.main import DataStore
 
 
 class AuthenticationData(RequestBodyModel):
@@ -128,20 +136,33 @@ class SlidingSyncStickyEventsToken:
     and then accepted as the `since` parameter in the requests of the same extension.
 
     Current format:
-        SlidingSyncStickyEventsToken ::= 'sticky_' DIGIT+
-        DIGIT ::= '0'-'9'
+        SlidingSyncStickyEventsToken ::= 'sticky_' MultiWriterStreamToken
+
+    where `MultiWriterStreamToken` is the serialised form of a (potentially sharded)
+    `MultiWriterStreamToken` for the sticky events stream, e.g. `42` or `m42~1.45`.
 
     The `sticky_` prefix allows us to make sure it's not swapped for another token
     or to evolve the type of token accepted with backwards compatibility in the future.
+
+    Note that the inner stream token can only be interpreted with access to the
+    database (to resolve instance IDs to instance names), so this class holds the
+    serialised form and converts on demand.
     """
 
-    PATTERN = re.compile(r"^sticky_([0-9]+)$")
+    PATTERN = re.compile(r"^sticky_([0-9]+|m[0-9]+(~[0-9]+\.[0-9]+)*)$")
     START: ClassVar["SlidingSyncStickyEventsToken"]
 
-    def __init__(self, *, sticky_events_stream_id: int) -> None:
-        # FIXME: We should use MultiWriterStreamToken here
-        # Track: https://github.com/element-hq/synapse/issues/19661
-        self.sticky_events_stream_id = sticky_events_stream_id
+    def __init__(self, *, serialised_stream_token: str) -> None:
+        self._serialised_stream_token = serialised_stream_token
+
+    @classmethod
+    async def from_stream_token(
+        cls, store: "DataStore", token: MultiWriterStreamToken
+    ) -> "SlidingSyncStickyEventsToken":
+        return cls(serialised_stream_token=await token.to_string(store))
+
+    async def to_stream_token(self, store: "DataStore") -> MultiWriterStreamToken:
+        return await MultiWriterStreamToken.parse(store, self._serialised_stream_token)
 
     @classmethod
     def __get_pydantic_core_schema__(
@@ -176,7 +197,7 @@ class SlidingSyncStickyEventsToken:
             match = cls.PATTERN.match(v)
             if match is None:
                 raise ValueError(f"Invalid SlidingSyncStickyEventsToken format: {v!r}")
-            return cls(sticky_events_stream_id=int(match.group(1)))
+            return cls(serialised_stream_token=match.group(1))
         raise ValueError(f"Cannot parse SlidingSyncStickyEventsToken from {type(v)}")
 
     def serialise(self) -> str:
@@ -185,7 +206,7 @@ class SlidingSyncStickyEventsToken:
 
         The inverse of `_validate`.
         """
-        return f"sticky_{self.sticky_events_stream_id}"
+        return f"sticky_{self._serialised_stream_token}"
 
     def __repr__(self) -> str:
         # Use the serialised form as debug output.
@@ -194,7 +215,7 @@ class SlidingSyncStickyEventsToken:
 
 # Starting reading a stream at 0 ensures all stream fact rows will be read
 SlidingSyncStickyEventsToken.START = SlidingSyncStickyEventsToken(
-    sticky_events_stream_id=0
+    serialised_stream_token="0"
 )
 
 

--- a/tests/replication/test_sharded_sticky_events.py
+++ b/tests/replication/test_sharded_sticky_events.py
@@ -1,0 +1,290 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 Element Creations Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+import logging
+import sqlite3
+from contextlib import contextmanager
+from typing import Iterator
+from unittest.mock import AsyncMock, patch
+
+from twisted.internet.testing import MemoryReactor
+
+import synapse.rest.admin
+from synapse.api.constants import EventTypes
+from synapse.rest.client import login, room, sync
+from synapse.server import HomeServer
+from synapse.types import JsonDict
+from synapse.util.clock import Clock
+from synapse.util.duration import Duration
+
+from tests.replication._base import BaseMultiWorkerStreamTestCase
+from tests.utils import USE_POSTGRES_FOR_TESTS
+
+logger = logging.getLogger(__name__)
+
+
+class ShardedStickyEventsTestCase(BaseMultiWorkerStreamTestCase):
+    """
+    Tests for sharded Sticky Events.
+    """
+
+    if not USE_POSTGRES_FOR_TESTS and sqlite3.sqlite_version_info < (3, 40, 0):
+        # We need the JSON functionality in SQLite
+        skip = f"SQLite version is too old to support sticky events: {sqlite3.sqlite_version_info} (See https://github.com/element-hq/synapse/issues/19428)"
+
+    servlets = [
+        synapse.rest.admin.register_servlets_for_client_rest_resource,
+        login.register_servlets,
+        room.register_servlets,
+        sync.register_servlets,
+    ]
+
+    def default_config(self) -> JsonDict:
+        conf = super().default_config()
+        conf["experimental_features"] = {
+            # Sliding Sync
+            "msc3575_enabled": True,
+            # Sticky Events
+            "msc4354_enabled": True,
+        }
+        conf["stream_writers"] = {"events": ["worker1", "worker2"]}
+        conf["instance_map"] = {
+            "main": {"host": "testserv", "port": 8765},
+            "worker1": {"host": "testserv", "port": 1001},
+            "worker2": {"host": "testserv", "port": 1002},
+        }
+        return conf
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.store = hs.get_datastores().main
+        # FIXME: This can be removed once we bump `SCHEMA_COMPAT_VERSION`, see
+        # `SlidingSyncBase`.
+        self.store.have_finished_sliding_sync_background_jobs = AsyncMock(  # type: ignore[method-assign]
+            return_value=True
+        )
+
+        self.user_id = self.register_user("user", "pass")
+        self.tok = self.login("user", "pass")
+
+    def _setup_workers_and_rooms(self) -> None:
+        """
+        Start the two event persisters and create a room on each of them.
+        """
+        self.make_worker_hs("synapse.app.generic_worker", {"worker_name": "worker1"})
+        self.worker_hs2 = self.make_worker_hs(
+            "synapse.app.generic_worker", {"worker_name": "worker2"}
+        )
+
+        # Specially selected room IDs that get persisted on different workers.
+        self.room_id1 = "!foo:test"
+        self.room_id2 = "!baz:test"
+        self.assertEqual(
+            self.hs.config.worker.events_shard_config.get_instance(self.room_id1),
+            "worker1",
+        )
+        self.assertEqual(
+            self.hs.config.worker.events_shard_config.get_instance(self.room_id2),
+            "worker2",
+        )
+        self._create_room(self.room_id1)
+        self._create_room(self.room_id2)
+
+    def _create_room(self, room_id: str) -> None:
+        """
+        Create a room with the given room ID, so that we control which event
+        persister ends up owning it.
+        """
+        with patch(
+            "synapse.handlers.room.RoomCreationHandler._generate_room_id"
+        ) as mock:
+            mock.side_effect = lambda: room_id
+            self.helper.create_room_as(self.user_id, tok=self.tok)
+
+    def _send_sticky_event(self, room_id: str, body: str) -> str:
+        return self.helper.send_sticky_event(
+            room_id,
+            EventTypes.Message,
+            duration=Duration(minutes=5),
+            content={"body": body, "msgtype": "m.text"},
+            tok=self.tok,
+        )["event_id"]
+
+    @contextmanager
+    def _stalled_sticky_writer(self) -> Iterator[None]:
+        """
+        Manipulate worker2's sticky events `MultiWriterIdGenerator` to mimic
+        it getting stuck part way through persisting a sticky event.
+
+        Whilst the context manager is entered, worker2's sticky events stream position
+        will not advance.
+        This stops the 'all writers have persisted up to' position from advancing as well.
+        """
+        worker_store2 = self.worker_hs2.get_datastores().main
+        stalled_write = worker_store2._sticky_events_id_gen.get_next()
+
+        self.get_success(stalled_write.__aenter__())
+        try:
+            yield
+        finally:
+            self.get_success(stalled_write.__aexit__(None, None, None))
+
+    def test_torn_oldschool_sync(self) -> None:
+        """
+        Tests that a sticky event must not be presented in two sync responses
+        as a 'torn' sync response. This test is for oldschool sync.
+
+        Specifically, a sticky event must not arrive in the timeline of
+        the first sync response and then in the sticky events section in
+        a subsequent sync response.
+        (This is a specific failure mode that occurred when the reader of the
+        sticky events stream was not shard-aware.)
+        """
+        self._setup_workers_and_rooms()
+
+        # Get our initial sync out of the way
+        channel = self.make_request("GET", "/sync", access_token=self.tok)
+        self.assertEqual(channel.code, 200, channel.result)
+        since = channel.json_body["next_batch"]
+
+        with self._stalled_sticky_writer():
+            sticky_event_id = self._send_sticky_event(self.room_id1, "sticky message")
+
+            # First response of the torn syncs: the event comes down the timeline, because the
+            # events stream token covers worker1's write despite worker2 lagging.
+            channel = self.make_request(
+                "GET", f"/sync?since={since}", access_token=self.tok
+            )
+            self.assertEqual(channel.code, 200, channel.result)
+            room = channel.json_body["rooms"]["join"][self.room_id1]
+            self.assertIn(
+                sticky_event_id,
+                [event["event_id"] for event in room["timeline"]["events"]],
+                room,
+            )
+            # Having been sent it in the timeline, we shouldn't also be sent it in
+            # the sticky section of the same response.
+            self.assertNotIn("msc4354_sticky", room, room)
+            since = channel.json_body["next_batch"]
+
+        # worker2 catches up, so an unsharded sticky events position is now free to
+        # advance past worker1's write.
+        self.replicate()
+
+        # Second response of the torn syncs: the sticky event shouldn't come down
+        # in the sticky event section.
+        channel = self.make_request(
+            "GET", f"/sync?since={since}", access_token=self.tok
+        )
+        self.assertEqual(channel.code, 200, channel.result)
+        room = channel.json_body.get("rooms", {}).get("join", {}).get(self.room_id1, {})
+        self.assertNotIn(
+            "msc4354_sticky",
+            room,
+            f"sticky event {sticky_event_id} was sent down the timeline in the "
+            f"previous sync, so we should not expect to see a sticky section in this sync: "
+            f"{room}",
+        )
+
+    def test_torn_sliding_sync(self) -> None:
+        """
+        Tests that a sticky event must not be presented in two sync responses
+        as a 'torn' sync response. This test is for sliding sync.
+
+        Specifically, a sticky event must not arrive in the timeline of
+        the first sync response and then in the sticky events section in
+        a subsequent sync response.
+        (This is a specific failure mode that occurred when the reader of the
+        sticky events stream was not shard-aware.)
+        """
+        self._setup_workers_and_rooms()
+
+        sync_endpoint = "/_matrix/client/unstable/org.matrix.simplified_msc3575/sync"
+        sync_body: JsonDict = {
+            "lists": {
+                "main": {
+                    "ranges": [[0, 99]],
+                    "required_state": [],
+                    "timeline_limit": 10,
+                }
+            },
+            "extensions": {"org.matrix.msc4354.sticky_events": {"enabled": True}},
+        }
+
+        # Initial sync
+        channel = self.make_request(
+            "POST", sync_endpoint, sync_body, access_token=self.tok
+        )
+        self.assertEqual(channel.code, 200, channel.result)
+        pos = channel.json_body["pos"]
+
+        # There are no sticky events yet
+        self.assertNotIn(
+            "org.matrix.msc4354.sticky_events",
+            channel.json_body["extensions"],
+            channel.json_body["extensions"],
+        )
+
+        with self._stalled_sticky_writer():
+            sticky_event_id = self._send_sticky_event(self.room_id1, "sticky message")
+
+            # First response of the torn syncs: the event comes down the room timeline.
+            channel = self.make_request(
+                "POST", f"{sync_endpoint}?pos={pos}", sync_body, access_token=self.tok
+            )
+            self.assertEqual(channel.code, 200, channel.result)
+            pos = channel.json_body["pos"]
+            room = channel.json_body["rooms"][self.room_id1]
+            self.assertIn(
+                sticky_event_id,
+                [event["event_id"] for event in room["timeline"]],
+                room,
+            )
+
+            # ... and so should have been deduplicated out of the sticky section of
+            # the same response, leaving an empty room entry behind.
+            sticky_extension = channel.json_body["extensions"][
+                "org.matrix.msc4354.sticky_events"
+            ]
+            next_batch = sticky_extension["next_batch"]
+            self.assertEqual(
+                sticky_extension,
+                {
+                    "rooms": {self.room_id1: {"events": []}},
+                    "next_batch": next_batch,
+                },
+                sticky_extension,
+            )
+            # The token should carry the per-writer positions, as worker2 is stalled.
+            self.assertTrue(next_batch.startswith("sticky_m"), next_batch)
+
+            sync_body["extensions"]["org.matrix.msc4354.sticky_events"]["since"] = (
+                next_batch
+            )
+
+        # worker2 catches up, so an unsharded sticky events position is now free to
+        # advance past worker1's write.
+        self.replicate()
+
+        # Second response of the torn syncs: the sticky event shouldn't come down
+        # in the sticky event section.
+        channel = self.make_request(
+            "POST", f"{sync_endpoint}?pos={pos}", sync_body, access_token=self.tok
+        )
+        self.assertEqual(channel.code, 200, channel.result)
+        # There is nothing left to send, so the extension should be omitted entirely.
+        self.assertNotIn(
+            "org.matrix.msc4354.sticky_events",
+            channel.json_body["extensions"],
+            f"sticky event {sticky_event_id} was sent down the timeline in the "
+            f"previous sync, so no sticky events extension should be sent now: "
+            f"{channel.json_body['extensions']}",
+        )

--- a/tests/storage/test_id_generators.py
+++ b/tests/storage/test_id_generators.py
@@ -19,7 +19,10 @@
 #
 #
 
+import sqlite3
 from unittest import mock
+
+from immutabledict import immutabledict
 
 from twisted.internet.defer import CancelledError, Deferred, ensureDeferred
 from twisted.internet.testing import MemoryReactor
@@ -32,15 +35,20 @@ from synapse.storage.database import (
     LoggingTransaction,
 )
 from synapse.storage.types import Cursor
-from synapse.storage.util.id_generators import MultiWriterIdGenerator
+from synapse.storage.util.id_generators import (
+    MultiWriterIdGenerator,
+    advance_multiwriter_sharded_token_after_partial_read,
+    make_multiwriter_sharded_token_bounds_sql,
+)
 from synapse.storage.util.sequence import (
     LocalSequenceGenerator,
     PostgresSequenceGenerator,
     SequenceGenerator,
 )
+from synapse.types import MultiWriterStreamToken
 from synapse.util.clock import Clock
 
-from tests.unittest import HomeserverTestCase
+from tests.unittest import HomeserverTestCase, TestCase
 from tests.utils import USE_POSTGRES_FOR_TESTS
 
 
@@ -886,3 +894,251 @@ class MultiTableMultiWriterIdGeneratorTestCase(MultiWriterIdGeneratorBase):
         self.assertEqual(second_id_gen.get_current_token_for_writer("first"), 7)
         self.assertEqual(second_id_gen.get_current_token_for_writer("second"), 7)
         self.assertEqual(second_id_gen.get_persisted_upto_position(), 7)
+
+
+class MultiWriterShardedTokenBoundsTestCase(TestCase):
+    """Tests for the helpers that read a range of a multi-writer stream.
+
+    These don't need a homeserver: they only exercise the SQL that
+    `make_multiwriter_sharded_token_bounds_sql` builds, against a throwaway
+    SQLite table.
+    """
+
+    ROWS = [
+        # (stream_id, instance_name)
+        (6, "worker1"),
+        (7, "worker1"),
+        (8, "worker2"),
+        (9, "worker1"),
+        (10, "worker3"),
+        (11, "worker1"),
+        (12, "worker2"),
+        (13, "worker3"),
+        (14, "worker2"),
+    ]
+    """
+    (stream_id, instance_name) rows to insert into the example stream table.
+    """
+
+    SHARDED_TOKEN_RANGES = [
+        (
+            MultiWriterStreamToken(stream=5),
+            MultiWriterStreamToken(stream=14),
+        ),
+        (
+            MultiWriterStreamToken(stream=5),
+            MultiWriterStreamToken(
+                stream=10, instance_map=immutabledict({"worker2": 14})
+            ),
+        ),
+        (
+            MultiWriterStreamToken(
+                stream=5, instance_map=immutabledict({"worker1": 9})
+            ),
+            MultiWriterStreamToken(
+                stream=10, instance_map=immutabledict({"worker2": 14})
+            ),
+        ),
+        (
+            MultiWriterStreamToken(
+                stream=5, instance_map=immutabledict({"worker1": 7})
+            ),
+            MultiWriterStreamToken(
+                stream=8, instance_map=immutabledict({"worker1": 11, "worker3": 13})
+            ),
+        ),
+        (
+            MultiWriterStreamToken(
+                stream=5, instance_map=immutabledict({"worker1": 9, "worker2": 8})
+            ),
+            MultiWriterStreamToken(
+                stream=10,
+                instance_map=immutabledict(
+                    {"worker1": 11, "worker2": 14, "worker3": 13}
+                ),
+            ),
+        ),
+    ]
+    """(from, to) token pairs to exercise the bounds against `ROWS`."""
+
+    def setUp(self) -> None:
+        self.conn = sqlite3.connect(":memory:")
+        self.addCleanup(self.conn.close)
+        self.conn.execute(
+            "CREATE TABLE streamtable (stream_id INTEGER PRIMARY KEY, instance_name TEXT)"
+        )
+        self.conn.executemany("INSERT INTO streamtable VALUES (?, ?)", self.ROWS)
+
+    def _select(
+        self,
+        from_token: MultiWriterStreamToken,
+        to_token: MultiWriterStreamToken,
+        limit: int | None = None,
+    ) -> list[tuple[int, str]]:
+        """
+        Helper that selects the rows within the given bounds, in stream order,
+        using `make_multiwriter_sharded_token_bounds_sql`.
+
+        Bounds: from_token < ... <= to_token
+        """
+        clause, values = make_multiwriter_sharded_token_bounds_sql(
+            stream_id_column="streamtable.stream_id",
+            instance_name_column="streamtable.instance_name",
+            from_token_exclusive=from_token,
+            to_token_inclusive=to_token,
+        )
+
+        limit_clause = ""
+        if limit is not None:
+            limit_clause = f"LIMIT {limit}"
+
+        return list(
+            self.conn.execute(
+                f"""
+            SELECT stream_id, instance_name
+            FROM streamtable
+            WHERE {clause}
+            ORDER BY stream_id ASC
+            {limit_clause}
+            """,
+                values,
+            )
+        )
+
+    def _expected(
+        self,
+        from_token: MultiWriterStreamToken,
+        to_token: MultiWriterStreamToken,
+    ) -> list[tuple[int, str]]:
+        """
+        Helper that returns the rows that ought to be within the given bounds.
+        It uses `MultiWriterStreamToken.is_stream_position_in_range` as the 'ground truth'.
+
+        Bounds: from_token < ... <= to_token
+        """
+
+        return [
+            (stream_id, instance_name)
+            for stream_id, instance_name in self.ROWS
+            if MultiWriterStreamToken.is_stream_position_in_range(
+                from_token, to_token, instance_name, stream_id
+            )
+        ]
+
+    def test_bounds_sql_documented_example(self) -> None:
+        """
+        Tests that the example in the docstring is what we actually generate.
+        """
+        clause, values = make_multiwriter_sharded_token_bounds_sql(
+            stream_id_column="se.stream_id",
+            instance_name_column="se.instance_name",
+            from_token_exclusive=MultiWriterStreamToken(
+                stream=5, instance_map=immutabledict({"worker1": 8})
+            ),
+            to_token_inclusive=MultiWriterStreamToken(
+                stream=10, instance_map=immutabledict({"worker2": 14})
+            ),
+        )
+        self.assertEqual(
+            clause,
+            "(\n"
+            "\t? < se.stream_id\n"
+            "\tAND se.stream_id <= ?\n"
+            "\tAND NOT (se.instance_name = ? AND se.stream_id <= ?)\n"
+            "\tAND (\n"
+            "\t\tse.stream_id <= ?\n"
+            "\t\tOR (se.instance_name = ? AND se.stream_id <= ?)\n"
+            "\t)\n"
+            ")",
+        )
+        self.assertEqual(list(values), [5, 14, "worker1", 8, 10, "worker2", 14])
+
+    def test_bounds_sql_selects_expected_rows(self) -> None:
+        """
+        Tests that the `make_multiwriter_sharded_token_bounds_sql` selects the correct rows,
+        using `MultiWriterStreamToken.is_stream_position_in_range` as the 'ground truth'.
+        """
+        for from_token, to_token in self.SHARDED_TOKEN_RANGES:
+            with self.subTest(from_token=str(from_token), to_token=str(to_token)):
+                self.assertEqual(
+                    self._select(from_token, to_token),
+                    self._expected(from_token, to_token),
+                )
+
+    def test_token_after_partial_read_does_not_go_backwards(self) -> None:
+        """
+        Tests that advancing the token after a partial read doesn't let it go
+        backwards.
+
+        This is relevant because Synapse workers don't always advance their current
+        position at the same time.
+        """
+        # As a scenario: the client has already read up to a baseline position of 60,
+        # but this reader worker has only caught up to 10.
+        # It can nonetheless see that worker2 has reached 70.
+        from_token = MultiWriterStreamToken(stream=60)
+        to_token = MultiWriterStreamToken(
+            stream=10, instance_map=immutabledict({"worker2": 70})
+        )
+
+        resume_token = advance_multiwriter_sharded_token_after_partial_read(
+            from_token_exclusive=from_token,
+            to_token_inclusive=to_token,
+            last_read_stream_id=64,
+        )
+
+        # worker2 advances to what we read; everyone else stays where they were.
+        self.assertEqual(
+            resume_token,
+            MultiWriterStreamToken(
+                stream=60, instance_map=immutabledict({"worker2": 64})
+            ),
+        )
+        self.assertTrue(
+            from_token.is_before_or_eq(resume_token),
+            f"Expected {from_token} <= {resume_token}",
+        )
+
+    def test_token_after_partial_read(self) -> None:
+        """
+        Tests that when advancing the token after a partial read, the subsequent read returns all the remaining rows
+        but no more (especially not duplicates).
+        """
+        for from_token, to_token in self.SHARDED_TOKEN_RANGES:
+            all_rows = self._expected(from_token, to_token)
+            for limit in range(1, len(all_rows) + 1):
+                with self.subTest(
+                    from_token=str(from_token), to_token=str(to_token), limit=limit
+                ):
+                    read = self._select(from_token, to_token, limit=limit)
+                    resume_token = advance_multiwriter_sharded_token_after_partial_read(
+                        from_token_exclusive=from_token,
+                        to_token_inclusive=to_token,
+                        last_read_stream_id=read[-1][0],
+                    )
+
+                    # The resumption point must be somewhere within the range we
+                    # were asked to read.
+                    self.assertTrue(
+                        from_token.is_before_or_eq(resume_token),
+                        f"Expected {from_token} <= {resume_token}",
+                    )
+                    self.assertTrue(
+                        resume_token.is_before_or_eq(to_token),
+                        f"Expected {resume_token} <= {to_token}",
+                    )
+
+                    self.assertEqual(
+                        read,
+                        self._expected(from_token, resume_token),
+                        f"The rows we read between {from_token} < ... <= {resume_token} seem wrong.",
+                    )
+
+                    self.assertEqual(
+                        read + self._select(resume_token, to_token),
+                        all_rows,
+                        f"We did a limited read of {limit} rows within {from_token} < ... <= {to_token}, "
+                        f"giving us an advanced token {resume_token}. "
+                        f"We then read {resume_token} < ... <= {to_token} and expected to get "
+                        "all the rows within range (in order, no duplicates), but didn't.",
+                    )

--- a/tests/storage/test_sticky_events.py
+++ b/tests/storage/test_sticky_events.py
@@ -12,6 +12,8 @@
 # <https://www.gnu.org/licenses/agpl-3.0.html>.
 import sqlite3
 
+from immutabledict import immutabledict
+
 from twisted.internet.testing import MemoryReactor
 
 from synapse.api.constants import (
@@ -25,7 +27,7 @@ from synapse.api.room_versions import RoomVersions
 from synapse.rest import admin
 from synapse.rest.client import login, register, room
 from synapse.server import HomeServer
-from synapse.types import JsonDict, create_requester
+from synapse.types import JsonDict, MultiWriterStreamToken, create_requester
 from synapse.util.clock import Clock
 from synapse.util.duration import Duration
 
@@ -176,6 +178,67 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
         )
         self.assertEqual(len(updates), 1)
         self.assertEqual(updates[0].event_id, event_id_1)
+
+    def test_get_sticky_events_in_rooms_token_does_not_go_backwards(self) -> None:
+        """
+        Tests that the token does not get rewound, for instance if a
+        different, lagging, sync worker handles a request.
+        """
+        instance_name = self.hs.get_instance_name()
+
+        self.helper.send_sticky_event(
+            self.room_id,
+            EventTypes.Message,
+            duration=Duration(minutes=1),
+            content={"body": "message 1", "msgtype": "m.text"},
+            tok=self.token,
+        )
+        first_id = self.store.get_sticky_events_stream_token().stream
+
+        event_id_2 = self.helper.send_sticky_event(
+            self.room_id,
+            EventTypes.Message,
+            duration=Duration(minutes=1),
+            content={"body": "message 2", "msgtype": "m.text"},
+            tok=self.token,
+        )["event_id"]
+        second_id = self.store.get_sticky_events_stream_token().stream
+
+        from_token = MultiWriterStreamToken(
+            stream=first_id, instance_map=immutabledict({"someworker": 42})
+        )
+        # `to_token` has 2 components that are behind compared to `from_token`:
+        # the baseline position and the position of the advanced worker 'someworker'
+        to_token = MultiWriterStreamToken(
+            stream=first_id - 1,
+            instance_map=immutabledict({instance_name: second_id, "someworker": 36}),
+        )
+
+        new_token, sticky_by_room = self.get_success(
+            self.store.get_sticky_events_in_rooms(
+                [self.room_id],
+                from_token=from_token,
+                to_token=to_token,
+                now=self.clock.time_msec(),
+                limit=None,
+            )
+        )
+
+        self.assertEqual(sticky_by_room, {self.room_id: [event_id_2]})
+        self.assertEqual(
+            new_token,
+            MultiWriterStreamToken(
+                # The baseline position is not wound back
+                stream=first_id,
+                instance_map=immutabledict(
+                    {
+                        instance_name: second_id,
+                        # The position of this advanced worker is not wound back either
+                        "someworker": 42,
+                    }
+                ),
+            ),
+        )
 
     def test_outlier_events_not_in_table(self) -> None:
         """

--- a/tests/storage/test_sticky_events.py
+++ b/tests/storage/test_sticky_events.py
@@ -66,7 +66,7 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
     def test_get_updated_sticky_events(self) -> None:
         """Test getting updated sticky events between stream IDs."""
         # Get the starting stream_id
-        start_id = self.store.get_max_sticky_events_stream_id()
+        start_id = self.store.get_sticky_events_stream_token().stream
 
         event_id_1 = self.helper.send_sticky_event(
             self.room_id,
@@ -76,7 +76,7 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
             tok=self.token,
         )["event_id"]
 
-        mid_id = self.store.get_max_sticky_events_stream_id()
+        mid_id = self.store.get_sticky_events_stream_token().stream
 
         event_id_2 = self.helper.send_sticky_event(
             self.room_id,
@@ -86,7 +86,7 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
             tok=self.token,
         )["event_id"]
 
-        end_id = self.store.get_max_sticky_events_stream_id()
+        end_id = self.store.get_sticky_events_stream_token().stream
 
         # Get all updates
         updates = self.get_success(
@@ -129,7 +129,7 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
             tok=self.token,
         )["event_id"]
 
-        end_id = self.store.get_max_sticky_events_stream_id()
+        end_id = self.store.get_sticky_events_stream_token().stream
 
         # Delete expired events
         self.get_success(self.store._delete_expired_sticky_events())
@@ -150,7 +150,7 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
     def test_get_updated_sticky_events_with_limit(self) -> None:
         """Test that the limit parameter works correctly."""
         # Get the starting stream_id
-        start_id = self.store.get_max_sticky_events_stream_id()
+        start_id = self.store.get_sticky_events_stream_token().stream
 
         event_id_1 = self.helper.send_sticky_event(
             self.room_id,
@@ -189,7 +189,7 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
         user2_id = self.register_user("user2", "pass")
         user2_tok = self.login(user2_id, "pass")
 
-        start_id = self.store.get_max_sticky_events_stream_id()
+        start_id = self.store.get_sticky_events_stream_token().stream
 
         room_id = self.helper.create_room_as(
             user2_id, tok=user2_tok, room_version=RoomVersions.V10.identifier
@@ -267,7 +267,7 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        end_id = self.store.get_max_sticky_events_stream_id()
+        end_id = self.store.get_sticky_events_stream_token().stream
 
         # Check the event made it into the sticky_events table
         updates = self.get_success(
@@ -288,7 +288,7 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
         token = self.login(user_id, "pass")
         room_id = self.helper.create_room_as(user_id, tok=token)
 
-        start_id = self.store.get_max_sticky_events_stream_id()
+        start_id = self.store.get_sticky_events_stream_token().stream
 
         # Create and persist a sticky event that is soft-failed
         soft_failed_sticky_event = self.get_success(
@@ -306,7 +306,7 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        end_id = self.store.get_max_sticky_events_stream_id()
+        end_id = self.store.get_sticky_events_stream_token().stream
 
         updates = self.get_success(
             self.store.get_updated_sticky_events(
@@ -327,7 +327,7 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
         token = self.login(user_id, "pass")
         room_id = self.helper.create_room_as(user_id, tok=token)
 
-        start_id = self.store.get_max_sticky_events_stream_id()
+        start_id = self.store.get_sticky_events_stream_token().stream
 
         # Create and persist a sticky event that is marked policy_server_spammy
         # N.B. policy_server_spammy events are always soft-failed too
@@ -361,7 +361,7 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        end_id = self.store.get_max_sticky_events_stream_id()
+        end_id = self.store.get_sticky_events_stream_token().stream
 
         # Verify only the regular event was inserted
         updates = self.get_success(
@@ -383,7 +383,7 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
         token = self.login(user_id, "pass")
         room_id = self.helper.create_room_as(user_id, tok=token)
 
-        start_id = self.store.get_max_sticky_events_stream_id()
+        start_id = self.store.get_sticky_events_stream_token().stream
 
         # Create and persist a sticky event that is marked spam_checker_spammy
         # N.B. spam_checker_spammy events are always soft-failed too
@@ -417,7 +417,7 @@ class StickyEventsTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        end_id = self.store.get_max_sticky_events_stream_id()
+        end_id = self.store.get_sticky_events_stream_token().stream
 
         # Verify only the valid sticky event was inserted
         updates = self.get_success(


### PR DESCRIPTION
Fixes: #19661
Part of: MSC4354

This pull request is commit-by-commit review friendly. <!-- -->


---


This PR first introduces some helpers for querying a sharded stream:

- SQL builder for 'give me rows between two sharded tokens'
- a function to return the 'new' from_token after a limited read

It's expected that these helpers will be useful in other places, such as https://github.com/element-hq/synapse/pull/20108#discussion_r3924032994
Some tests are included.


Then, using those helpers, I make the sticky events portions of both
oldschool and sliding sync use sharded tokens.

This prevents a 'torn sync' problem where, because the events and sticky events
streams are both sharded with the same writers:

1. persisting a sticky event leads to an event row and a sticky_events row being created for event `e` (on writer `W`).
2. Suppose another writer is still persisting, so the position of the stream for writer W advances, but the global ['linear'](https://element-hq.github.io/synapse/latest/development/synapse_architecture/streams.html?highlight=%E2%80%9Clinear%E2%80%9D#current-stream-id) (I have been calling this 'baseline') position does not advance yet.
3. sync is sharding-aware for the regular events stream, so `e` appears as a real-time timeline event, thus coming down sync
4. since sticky events were not sharding-aware, `e` is not detected as a sticky event in this sync response. The sticky event position doesn't advance in the sync token, either.
5. (assume the position advances because other writers have finished writing and so the 'linear' position advances for the sticky events stream)
6. the client then syncs again, using the new sync token. This time, `e` appears in the sticky event section.

If we make sticky events sharding-aware in sync, then `e` would appear for consideration in both the timeline section **and** the sticky event section in the first sync.
It then gets deduplicated out of the sticky section since it is appearing in the timeline section in the same sync.



Original commit schedule, with full messages:

<ol>
<li>

Add utilities for sharded stream tokens 

</li>
<li>

Support sharded tokens for sticky events in sync 

</li>
<li>

Update storage test to follow rename 

</li>
<li>

Add sharding tests for sticky events \
Conceptual cousin of `test_sharded_receipts` etc

Main interesting case we want to prevent is the 'torn sync' problem, so
that's what I've focussed on for the test.
It is sufficient to demonstrate that the stream is sharded.


</li>
<li>

Comment on MultiWriterStreamToken.is_stream_position_in_range 

</li>
<li>

Add storage test against sticky event token rewind 

</li>
</ol>
