### PR TITLE
Fix missing validation for `membership` field after `make_*` requests

### DIFF
--- a/changelog.d/20189.bugfix
+++ b/changelog.d/20189.bugfix
@@ -1,0 +1,1 @@
+Fix missing validation of `membership` when making `make_*` requests over federation. Contributed by @tulir @ Beeper.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1268,6 +1268,7 @@ class FederationHandler:
         assert event.sender == user_id
         assert event.state_key == user_id
         assert event.room_id == room_id
+        assert event.content.get("membership") == membership
         return origin, event, room_version
 
     async def on_make_leave_request(


### PR DESCRIPTION
It was specced as a part of https://github.com/matrix-org/matrix-spec/pull/2284

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
