### PR TITLE
Remove the unstable `org.matrix.msc3202.device_id` masquerading alias

### DIFF
--- a/changelog.d/20191.removal
+++ b/changelog.d/20191.removal
@@ -1,0 +1,1 @@
+Remove support for the unstable `org.matrix.msc3202.device_id` query parameter for application service device masquerading.

--- a/synapse/api/auth/base.py
+++ b/synapse/api/auth/base.py
@@ -317,9 +317,6 @@ class BaseAuth:
         - The returned device ID, if present, has been checked to be a valid device ID
           for the returned user ID.
         """
-        # TODO: We can drop unstable support after 2026-01-01 (couple months after stable support)
-        UNSTABLE_DEVICE_ID_ARG_NAME = b"org.matrix.msc3202.device_id"
-
         app_service = self.store.get_app_service_by_token(access_token)
         if app_service is None:
             return None
@@ -340,9 +337,7 @@ class BaseAuth:
         else:
             effective_user_id = app_service.sender
 
-        effective_device_id_args = request.args.get(
-            b"device_id", request.args.get(UNSTABLE_DEVICE_ID_ARG_NAME)
-        )
+        effective_device_id_args = request.args.get(b"device_id")
         if effective_device_id_args:
             effective_device_id = effective_device_id_args[0].decode("utf8")
             # We only just set this so it can't be None!


### PR DESCRIPTION
Follow-up to #19033.

TLDR: appservice device masquerading now only accepts the stable `device_id` query parameter; the unstable `org.matrix.msc3202.device_id` alias is dropped.

> **[Added in `v1.17`]** Application services MAY similarly masquerade as a specific device ID belonging the user ID through use of the `device_id` query string parameter on the request. If the given device ID is not known to belong to the user, the server will return a 400 `M_UNKNOWN_DEVICE` error.
>
> — [Matrix v1.19, Application Service API — Identity assertion](https://spec.matrix.org/v1.19/application-service-api/#identity-assertion)

Synapse has accepted the stable `device_id` parameter since v1.141.0 (#19033), keeping the unstable name as a fallback with a note that it could be dropped after 2026-01-01. That date has passed and the behaviour has been part of the spec since Matrix 1.17, so this removes the fallback. Requests that still send only the unstable parameter are now treated as having no device ID.

Before:

```
GET /_matrix/client/v3/account/whoami?user_id=@alice:test&org.matrix.msc3202.device_id=DEVICEID  # appservice token
  200 {"user_id": "@alice:test", "is_guest": false, "device_id": "DEVICEID"}
```

After:

```
GET /_matrix/client/v3/account/whoami?user_id=@alice:test&org.matrix.msc3202.device_id=DEVICEID  # appservice token
  200 {"user_id": "@alice:test", "is_guest": false}
```

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
