### PR TITLE
Support fd-passed sockets from systemd

### DIFF
--- a/changelog.d/20201.feature
+++ b/changelog.d/20201.feature
@@ -1,0 +1,1 @@
+Add support for [systemd socket activation](https://www.freedesktop.org/software/systemd/man/latest/systemd.socket.html), for both TCP and Unix socket listeners.

--- a/contrib/systemd/README.md
+++ b/contrib/systemd/README.md
@@ -17,6 +17,16 @@ appropriate locations of your installation.
 6. Verify Synapse is running: `sudo systemctl status matrix-synapse`
 7. *optional* Enable Synapse to start at system boot: `sudo systemctl enable matrix-synapse`
 
+## Systemd socket (optional)
+
+To let systemd own the listening socket instead of Synapse binding it
+directly, use `matrix-synapse.socket` alongside a `listeners` entry in
+`homeserver.yaml` with `path: "systemd:matrix-synapse"` (the name must match
+the socket unit's `FileDescriptorName=`, or its filename if unset). See the
+[listener configuration
+docs](https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#listeners)
+for details.
+
 ## Logging
 
 If you use `contrib/systemd/log_config.yaml`, install `systemd-python` in the

--- a/contrib/systemd/matrix-synapse.socket
+++ b/contrib/systemd/matrix-synapse.socket
@@ -1,0 +1,25 @@
+# Example systemd socket unit for Synapse.
+#
+# This is optional: Synapse binds its own sockets by default. Pairing this
+# with a `listeners` entry using `path: "systemd:matrix-synapse"` in
+# homeserver.yaml lets systemd own the listening socket instead.
+#
+# Copy alongside matrix-synapse.service into /etc/systemd/system/, then:
+#
+#    systemctl enable --now matrix-synapse.socket
+#
+# **NOTE:** This is an example unit that may change in the future. If you
+# wish to use this please copy rather than symlink it.
+
+[Unit]
+Description=Synapse Matrix homeserver socket
+
+[Socket]
+FileDescriptorName=matrix-synapse
+
+ListenStream=8008
+# Or alternatively a unix socket:
+# ListenStream=/run/matrix-synapse/matrix-synapse.socket
+
+[Install]
+WantedBy=sockets.target

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -555,6 +555,12 @@ Options for each entry include:
 
   _Added in Synapse 1.89.0_: Unix socket support
 
+  Instead of a filesystem path, `path` may also be set to `systemd:<name>` to have Synapse adopt a socket that was passed to it by systemd via [socket activation](https://www.freedesktop.org/software/systemd/man/latest/systemd.socket.html), rather than binding its own. `<name>` must match the corresponding `FileDescriptorName=` setting in the relevant `.socket` unit, or the unit's own name if `FileDescriptorName=` isn't set.
+
+  `bind_addresses` and `mode` don't apply for systemd sockets. `tls` *is* supported, but only if the inherited socket turns out to be TCP-backed. Synapse doesn't know which kind of socket it was handed until startup, so requesting `tls: true` on a Unix-socket-backed systemd socket is an error raised at runtime. As with plain Unix sockets, this is currently only supported for `type: http` (not `metrics` or `manhole`). See [`contrib/systemd/`](https://github.com/element-hq/synapse/tree/develop/contrib/systemd) for an example `.socket` unit.
+
+  _Added in Synapse 1.162.0_: systemd socket activation support
+
 * `mode` (integer|null): The file permissions to set on the UNIX socket. Defaults to `666` if unset or null.
 
   **Note:** Must be set as `type: http` (does not support `metrics` and `manhole`). Also make sure that `metrics` is not included in `resources` -> `names`
@@ -606,6 +612,26 @@ listeners:
   - names:
     - client
     - federation
+```
+
+```yaml
+listeners:
+- path: "systemd:matrix-federation"
+  type: http
+  resources:
+  - names:
+    - federation
+```
+
+with a matching `.socket` unit:
+
+```ini
+[Socket]
+ListenStream=8448
+FileDescriptorName=matrix-federation
+
+[Install]
+WantedBy=sockets.target
 ```
 ---
 ### `manhole`

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -24,6 +24,7 @@ import logging
 import os
 import signal
 import socket
+import stat
 import sys
 import traceback
 import warnings
@@ -45,7 +46,8 @@ from cryptography.utils import CryptographyDeprecationWarning
 from typing_extensions import ParamSpec, assert_never
 
 import twisted
-from twisted.internet import defer, error, reactor as _reactor
+from twisted.internet import defer, error, reactor as _reactor, unix
+from twisted.internet.endpoints import _SystemdParser
 from twisted.internet.interfaces import (
     IOpenSSLContextFactory,
     IReactorSSL,
@@ -56,6 +58,7 @@ from twisted.internet.protocol import ServerFactory
 from twisted.internet.tcp import Port
 from twisted.logger import LoggingFile, LogLevel
 from twisted.protocols.tls import TLSMemoryBIOFactory
+from twisted.python.failure import Failure
 from twisted.python.threadpool import ThreadPool
 from twisted.web.resource import Resource
 
@@ -68,6 +71,7 @@ from synapse.config.homeserver import HomeServerConfig
 from synapse.config.server import (
     ListenerConfig,
     ManholeConfig,
+    SystemdListenerConfig,
     TCPListenerConfig,
     UnixListenerConfig,
 )
@@ -419,6 +423,94 @@ def listen_unix(
     ]
 
 
+class _AdoptedUnixPort(unix.Port):
+    """A `unix.Port` for a socket file owned by systemd.
+
+    Twisted currently hardcodes a few behaviours that break systemd socket support:
+
+    - `startListening()` chmods the path to `unix.Port`'s own default mode.
+    - `connectionLost()` unlinks the path on shutdown, which leaves systemd's
+      socket unit listening on an unlinked inode.
+    - `_SocketCloser._closeSocket()` (mixed in via `tcp.Port`) calls
+      `socket.shutdown(SHUT_RDWR)` before `close()` on an "orderly" teardown.
+
+    This overridden class makes sure that we avoid all of these problems.
+
+    It may be possible to drop this once this upstream issue is fixed:
+    sockets: https://github.com/twisted/twisted/issues/10261
+    """
+
+    _shouldShutdown = False
+
+    def startListening(self) -> None:
+        if unix._inFilesystemNamespace(self.port):
+            self.mode = stat.S_IMODE(os.stat(self.port).st_mode)
+        super().startListening()
+
+    def connectionLost(self, reason: Failure) -> None:
+        Port.connectionLost(self, reason)
+
+
+def listen_systemd(
+    fd_name: str,
+    factory: ServerFactory,
+    reactor: ISynapseReactor = reactor,
+    context_factory: Optional[IOpenSSLContextFactory] = None,
+) -> list[Port]:
+    """
+    Adopt a file descriptor inherited from systemd via socket activation.
+
+    Returns:
+        list of twisted.internet.tcp.Port (or unix.Port) listening on the
+        inherited descriptor.
+    """
+    # `twisted.internet.endpoints` parses the systemd environment at import time,
+    # deleting LISTEN_PID/LISTEN_FDS in the process, so calling `ListenFDs.fromEnvironment()`
+    # ourselves here would find nothing. This private singleton is unfortunately the only
+    # place the inherited descriptors survive. We *could* in theory extract it directly
+    # from /proc/self/environ instead, but woul just be a different hack around the problem.
+    named_descriptors = _SystemdParser._sddaemon.inheritedNamedDescriptors()
+
+    if fd_name not in named_descriptors:
+        raise ConfigError(
+            f"No socket named {fd_name} was passed to Synapse by systemd."
+            f"Sockets available: {sorted(named_descriptors) or '(none)'}"
+            "Check the 'FileDescriptorName=' setting (or the unit name)"
+            "in the relevant .socket unit, and that Synapse was "
+            "started via socket activation."
+        )
+
+    fd = named_descriptors[fd_name]
+
+    # socket.socket(fileno=) doesn't dup the fd, and detach() hands it back
+    # without closing it, so this doesn't disturb the inherited descriptor.
+    sock = socket.socket(fileno=fd)
+    family = sock.family
+    sock.setblocking(False)
+    sock.detach()
+
+    listen_factory: ServerFactory = factory
+    if context_factory is not None:
+        if family == socket.AF_UNIX:
+            raise ConfigError(
+                "Can not use TLS with the systemd socket named %r: it is a "
+                "Unix domain socket, not a TCP socket." % (fd_name,)
+            )
+        # This is what `reactor.listenSSL` does internally too.
+        listen_factory = TLSMemoryBIOFactory(context_factory, False, factory)
+
+    # This piece of code was taken from `PosixReactorBase.adoptStreamPort`,
+    # so that we can compensate for the chmod/unlink problems upstream.
+    # See the docstring of `_AdoptedUnixPort` for more details.
+    if family == socket.AF_UNIX:
+        port = _AdoptedUnixPort._fromListeningDescriptor(reactor, fd, listen_factory)
+    else:
+        port = Port._fromListeningDescriptor(reactor, fd, family, listen_factory)
+    port.startListening()
+
+    return [port]
+
+
 class ListenerException(RuntimeError):
     """
     An exception raised when we fail to listen with the given `ListenerConfig`.
@@ -439,6 +531,9 @@ class ListenerException(RuntimeError):
         elif isinstance(listener_config, UnixListenerConfig):
             listener_human_name = "unix socket"
             port = listener_config.path
+        elif isinstance(listener_config, SystemdListenerConfig):
+            listener_human_name = "systemd socket"
+            port = listener_config.fd_name
         else:
             assert_never(listener_config)
 
@@ -520,6 +615,23 @@ def listen_http(
             logger.info(
                 "Synapse now listening on Unix Socket at: %s",
                 ports[0].getHost().name.decode("utf-8"),
+            )
+        elif isinstance(listener_config, SystemdListenerConfig):
+            is_tls = listener_config.is_tls()
+            if is_tls:
+                # refresh_certificate should have been called before this.
+                assert context_factory is not None
+            ports = listen_systemd(
+                listener_config.fd_name,
+                site,
+                reactor=reactor,
+                context_factory=context_factory if is_tls else None,
+            )
+            logger.info(
+                "Synapse now listening on systemd socket %r (%s)%s",
+                listener_config.fd_name,
+                ports[0].getHost(),
+                " (TLS)" if is_tls else "",
             )
         else:
             assert_never(listener_config)

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -290,7 +290,8 @@ class GenericWorkerServer(HomeServer):
                     )
                 else:
                     raise ConfigError(
-                        "Can not using a unix socket for manhole at this time."
+                        "Can not use a unix socket or systemd socket activation "
+                        "for manhole at this time."
                     )
 
             elif listener.type == "metrics":
@@ -308,7 +309,8 @@ class GenericWorkerServer(HomeServer):
                         )
                     else:
                         raise ConfigError(
-                            "Can not use a unix socket for metrics at this time."
+                            "Can not use a unix socket or systemd socket activation "
+                            "for metrics at this time."
                         )
 
             else:

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -291,7 +291,8 @@ class SynapseHomeServer(HomeServer):
                     )
                 else:
                     raise ConfigError(
-                        "Can not use a unix socket for manhole at this time."
+                        "Can not use a unix socket or systemd socket activation "
+                        "for manhole at this time."
                     )
             elif listener.type == "metrics":
                 if not self.config.metrics.enable_metrics:
@@ -308,7 +309,8 @@ class SynapseHomeServer(HomeServer):
                         )
                     else:
                         raise ConfigError(
-                            "Can not use a unix socket for metrics at this time."
+                            "Can not use a unix socket or systemd socket activation "
+                            "for metrics at this time."
                         )
 
             else:

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -293,7 +293,26 @@ class UnixListenerConfig:
         return False
 
 
-ListenerConfig = TCPListenerConfig | UnixListenerConfig
+@attr.s(slots=True, frozen=True, auto_attribs=True)
+class SystemdListenerConfig:
+    """Object describing the configuration of a single systemd socket-activated listener."""
+
+    # Matched against $LISTEN_FDNAMES, i.e. `FileDescriptorName=` in the .socket unit.
+    fd_name: str = attr.ib(validator=attr.validators.instance_of(str))
+    type: str = attr.ib(validator=attr.validators.in_(KNOWN_LISTENER_TYPES))
+    tls: bool = False
+
+    # only populated if type=http
+    http_options: HttpListenerConfig | None = None
+
+    def get_site_tag(self) -> str:
+        return self.fd_name
+
+    def is_tls(self) -> bool:
+        return self.tls
+
+
+ListenerConfig = TCPListenerConfig | UnixListenerConfig | SystemdListenerConfig
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
@@ -758,6 +777,7 @@ class ServerConfig(Config):
             raise ConfigError("Expected a list", ("listeners",))
 
         self.listeners = [parse_listener_def(i, x) for i, x in enumerate(listeners)]
+        check_for_duplicate_systemd_sockets(self.listeners)
 
         # no_tls is not really supported anymore, but let's grandfather it in here.
         if config.get("no_tls", False):
@@ -1183,6 +1203,16 @@ def parse_listener_def(num: int, listener: Any) -> ListenerConfig:
         )
 
     if socket_path:
+        if socket_path.startswith("systemd:"):
+            fd_name = socket_path[len("systemd:") :]
+            if not fd_name:
+                raise ConfigError(
+                    "A name must be given after 'systemd:' in the 'path' option, "
+                    "matching the name of a socket inherited from systemd "
+                    "(LISTEN_FDNAMES)."
+                )
+            return SystemdListenerConfig(fd_name, listener_type, tls, http_config)
+
         # TODO: Add in path validation, like if the directory exists and is writable?
         # Set a default for the permission, in case it's left out
         socket_mode = listener.get("mode", 0o666)
@@ -1206,6 +1236,21 @@ def parse_listener_def(num: int, listener: Any) -> ListenerConfig:
                 bind_addresses.extend(DEFAULT_BIND_ADDRESSES)
 
         return TCPListenerConfig(port, bind_addresses, listener_type, tls, http_config)
+
+
+def check_for_duplicate_systemd_sockets(listeners: Iterable[ListenerConfig]) -> None:
+    """Check that no two listeners in the given list adopt the same systemd socket"""
+    seen: set[str] = set()
+    for listener in listeners:
+        if not isinstance(listener, SystemdListenerConfig):
+            continue
+
+        if listener.fd_name in seen:
+            raise ConfigError(
+                f"The systemd socket named {listener.fd_name} is used by more "
+                "than one listener."
+            )
+        seen.add(listener.fd_name)
 
 
 _MANHOLE_SETTINGS_SCHEMA = {

--- a/synapse/config/workers.py
+++ b/synapse/config/workers.py
@@ -42,6 +42,7 @@ from synapse.config._util import parse_and_validate_mapping
 from synapse.config.server import (
     DIRECT_TCP_ERROR,
     TCPListenerConfig,
+    check_for_duplicate_systemd_sockets,
     parse_listener_def,
 )
 from synapse.types import JsonDict
@@ -232,6 +233,7 @@ class WorkerConfig(Config):
             parse_listener_def(i, x)
             for i, x in enumerate(config.get("worker_listeners", []))
         ]
+        check_for_duplicate_systemd_sockets(self.worker_listeners)
         self.worker_daemonize = bool(config.get("worker_daemonize"))
         self.worker_pid_file = config.get("worker_pid_file")
 

--- a/synapse/types/__init__.py
+++ b/synapse/types/__init__.py
@@ -60,6 +60,7 @@ from twisted.internet.defer import CancelledError
 from twisted.internet.interfaces import (
     IReactorCore,
     IReactorPluggableNameResolver,
+    IReactorSocket,
     IReactorSSL,
     IReactorTCP,
     IReactorThreads,
@@ -267,6 +268,7 @@ class ISynapseThreadlessReactor(
     IReactorTCP,
     IReactorSSL,
     IReactorUNIX,
+    IReactorSocket,
     IReactorPluggableNameResolver,
     IReactorTime,
     IReactorCore,

--- a/tests/config/test_server.py
+++ b/tests/config/test_server.py
@@ -26,7 +26,15 @@ from parameterized import parameterized
 
 from synapse.config._base import ConfigError, RootConfig
 from synapse.config.homeserver import HomeServerConfig
-from synapse.config.server import ServerConfig, generate_ip_set, is_threepid_reserved
+from synapse.config.server import (
+    ServerConfig,
+    SystemdListenerConfig,
+    TCPListenerConfig,
+    UnixListenerConfig,
+    generate_ip_set,
+    is_threepid_reserved,
+    parse_listener_def,
+)
 from synapse.types import JsonDict
 
 from tests import unittest
@@ -264,6 +272,57 @@ def _read_config(config_values: JsonDict) -> None:
         )
         | config_values
     )
+
+
+class ParseListenerDefTestCase(unittest.TestCase):
+    def test_tcp_listener(self) -> None:
+        config = parse_listener_def(0, {"type": "http", "port": 8008})
+        self.assertIsInstance(config, TCPListenerConfig)
+        assert isinstance(config, TCPListenerConfig)
+        self.assertEqual(config.port, 8008)
+
+    def test_unix_socket_listener(self) -> None:
+        config = parse_listener_def(
+            0, {"type": "http", "path": "/var/run/synapse.sock"}
+        )
+        self.assertIsInstance(config, UnixListenerConfig)
+        assert isinstance(config, UnixListenerConfig)
+        self.assertEqual(config.path, "/var/run/synapse.sock")
+
+    def test_systemd_listener(self) -> None:
+        config = parse_listener_def(
+            0, {"type": "http", "path": "systemd:matrix-federation"}
+        )
+        self.assertIsInstance(config, SystemdListenerConfig)
+        assert isinstance(config, SystemdListenerConfig)
+        self.assertEqual(config.fd_name, "matrix-federation")
+        self.assertEqual(config.type, "http")
+        self.assertFalse(config.is_tls())
+        self.assertEqual(config.get_site_tag(), "matrix-federation")
+
+    def test_systemd_listener_tls(self) -> None:
+        config = parse_listener_def(
+            0,
+            {"type": "http", "path": "systemd:matrix-federation", "tls": True},
+        )
+        self.assertIsInstance(config, SystemdListenerConfig)
+        assert isinstance(config, SystemdListenerConfig)
+        self.assertTrue(config.is_tls())
+
+    def test_systemd_listener_requires_a_name(self) -> None:
+        with self.assertRaises(ConfigError):
+            parse_listener_def(0, {"type": "http", "path": "systemd:"})
+
+    def test_systemd_listener_rejects_port(self) -> None:
+        with self.assertRaises(ConfigError):
+            parse_listener_def(
+                0,
+                {
+                    "type": "http",
+                    "path": "systemd:matrix-federation",
+                    "port": 8448,
+                },
+            )
 
 
 class GenerateIpSetTestCase(unittest.TestCase):


### PR DESCRIPTION
Fixes #1329

This PR adds support for fd-passed sockets from systemd. The main benefit (as I see it) is that it allows the workers to start in parallel with the master process, and removes the need for this sort of hack: https://md.darmstadt.ccc.de/synapse-at-work#Worker-systemd-units

Keeping as draft until I've tested it a bit better interactively.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
