### PR TITLE
Fixes to the profile update stream when a user leaves a room

### DIFF
--- a/changelog.d/20203.bugfix
+++ b/changelog.d/20203.bugfix
@@ -1,0 +1,2 @@
+Ensure when a user leaves a room, the profile update stream is correctly updated for users they no longer
+share rooms with.

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -2237,7 +2237,8 @@ class PersistEventsStore:
             (*user_args, user_id.to_string()),
         )
 
-        # Now record the "left room" action in the stream
+        # Now record the "left room" action in the stream for each user
+        # in the room that no longer shares a room with the user who left the room.
         self.store.record_profile_updates_txn(
             txn=txn,
             user_id=user_id,
@@ -2245,6 +2246,17 @@ class PersistEventsStore:
             field_names=[],
             target_users=users_no_longer_sharing_rooms,
         )
+        # We also need to record things in reverse. The user, who left the
+        # room, needs to get profile update rows for every user they no longer
+        # share a room with.
+        for user in users_no_longer_sharing_rooms:
+            self.store.record_profile_updates_txn(
+                txn=txn,
+                user_id=UserID.from_string(user),
+                action=ProfileUpdateAction.LEFT_ROOM,
+                field_names=[],
+                target_users={user_id.to_string()},
+            )
 
     @classmethod
     def _get_relevant_sliding_sync_current_state_event_ids_txn(

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -2246,9 +2246,22 @@ class PersistEventsStore:
             field_names=[],
             target_users=users_no_longer_sharing_rooms,
         )
+
         # We also need to record things in reverse. The user, who left the
         # room, needs to get profile update rows for every user they no longer
         # share a room with.
+        # First clear old rows between these users.
+        txn.execute(
+            f"""
+                DELETE FROM profile_updates_per_user
+                    WHERE user_id = ?
+                    AND stream_id IN (
+                        SELECT stream_id FROM profile_updates WHERE {user_clause}
+                    )
+            """,
+            (user_id.to_string(), *user_args),
+        )
+        # Then add the left room action rows in the stream.
         for user in users_no_longer_sharing_rooms:
             self.store.record_profile_updates_txn(
                 txn=txn,

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -659,7 +659,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                     affected_fields=None,
                 ),
                 ProfileUpdate(
-                    stream_id=7,
+                    stream_id=9,
                     user_id="@gracie:test",
                     action="left_room",
                     affected_fields=None,
@@ -684,6 +684,51 @@ class ProfileTestCase(unittest.HomeserverTestCase):
                     user_id=self.frank.to_string(),
                     action="update",
                     affected_fields=frozenset({"m.status"}),
+                ),
+            ],
+        )
+
+    @override_config({"include_profile_updates_in_sync": True})
+    def test_left_room_event_if_we_leave_the_last_shared_room(
+        self,
+    ) -> None:
+        """Test that when we leave a room, we get profile update rows with a "left room"
+        action for users we no longer share a room with.
+        """
+        self.register_user("roger", "password")
+        roger_token = self.login("roger", "password")
+        room_id = self.helper.create_room_as(
+            room_creator=self.frank.to_string(),
+            tok=self.frank_token,
+        )
+        self.helper.join(room_id, "@roger:test", tok=roger_token)
+
+        # Make us leave the room
+        self.helper.leave(room_id, self.frank.to_string(), tok=self.frank_token)
+        per_user_updates = self.get_success(
+            self.store.get_profile_updates_for_user_and_fields(
+                from_id=0,
+                to_id=10,
+                user_id=self.frank.to_string(),
+                field_names={"m.status"},
+            )
+        )
+        # We're no longer in any rooms with roger, and the profile update stream
+        # should have an update regarding that.
+        self.assertEqual(
+            per_user_updates,
+            [
+                ProfileUpdate(
+                    stream_id=2,
+                    user_id="@roger:test",
+                    action="joined_room",
+                    affected_fields=None,
+                ),
+                ProfileUpdate(
+                    stream_id=4,
+                    user_id="@roger:test",
+                    action="left_room",
+                    affected_fields=None,
                 ),
             ],
         )

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -719,12 +719,6 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             per_user_updates,
             [
                 ProfileUpdate(
-                    stream_id=2,
-                    user_id="@roger:test",
-                    action="joined_room",
-                    affected_fields=None,
-                ),
-                ProfileUpdate(
                     stream_id=4,
                     user_id="@roger:test",
                     action="left_room",

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -2064,7 +2064,8 @@ class SyncProfileUpdatesTestCase(tests.unittest.HomeserverTestCase):
         self,
     ) -> None:
         """Test that with `include_profile_updates_in_sync` enabled the incremental
-        sync response includes a 'null' for users who are no longer sharing rooms.
+        sync response includes a 'null' for users who are no longer sharing rooms, due
+        to the other user leaving the last room.
         """
         requester = create_requester(self.user)
         initial_result = self.get_success(
@@ -2086,6 +2087,59 @@ class SyncProfileUpdatesTestCase(tests.unittest.HomeserverTestCase):
         )
         self.helper.leave(
             room=self.joined_room, user=self.other_user, tok=self.other_tok
+        )
+        incremental_result = self.get_success(
+            self.sync_handler.wait_for_sync_for_user(
+                requester,
+                since_token=initial_result.next_batch,
+                sync_config=generate_sync_config(
+                    user_id=self.user,
+                    filter_collection=FilterCollection(
+                        hs=self.hs,
+                        filter_json={
+                            "org.matrix.msc4429.profile_fields": {
+                                "ids": ["m.status", "displayname", "avatar_url"]
+                            }
+                        },
+                    ),
+                ),
+                request_key=generate_request_key(),
+            )
+        )
+        self.assertIsNone(
+            incremental_result.profile_updates["@other_user:test"],
+        )
+
+    @override_config({"include_profile_updates_in_sync": True})
+    def test_incremental_sync_sends_down_null_profile_we_no_longer_sharing_rooms(
+        self,
+    ) -> None:
+        """Test that with `include_profile_updates_in_sync` enabled the incremental
+        sync response includes a 'null' for users who are no longer sharing rooms, due
+        us leaving the last shared room.
+        """
+        requester = create_requester(self.user)
+        initial_result = self.get_success(
+            self.sync_handler.wait_for_sync_for_user(
+                requester,
+                sync_config=generate_sync_config(
+                    user_id=self.user,
+                    filter_collection=FilterCollection(
+                        hs=self.hs,
+                        filter_json={
+                            "org.matrix.msc4429.profile_fields": {
+                                "ids": ["m.status", "displayname", "avatar_url"]
+                            }
+                        },
+                    ),
+                ),
+                request_key=generate_request_key(),
+            )
+        )
+        self.helper.leave(
+            room=self.joined_room,
+            user=self.user,
+            tok=self.tok,
         )
         incremental_result = self.get_success(
             self.sync_handler.wait_for_sync_for_user(

--- a/tests/rest/client/sliding_sync/test_extension_profiles.py
+++ b/tests/rest/client/sliding_sync/test_extension_profiles.py
@@ -526,7 +526,7 @@ class SlidingSyncProfilesTestCase(SlidingSyncBase):
     ) -> None:
         """
         Test that profile extension response returns a null for the user in
-        incremental sync.
+        incremental sync, if the user left the last shared room.
         """
         # Make an initial Sliding Sync request with the profiles extension enabled
         profiles_config: dict = {
@@ -543,6 +543,46 @@ class SlidingSyncProfilesTestCase(SlidingSyncBase):
         response_body, from_token = self.do_sync(sync_body, tok=self.tok)
 
         self.helper.leave(self.joined_room, self.other_user, tok=self.other_tok)
+
+        # Make an incremental Sliding Sync request
+        response_body, _ = self.do_sync(sync_body, since=from_token, tok=self.tok)
+        # We should see a null profile
+        self.assertIsNone(
+            response_body["extensions"]["org.matrix.msc4262.profiles"]["users"][
+                "@other_user:test"
+            ],
+        )
+
+    @parameterized.expand(
+        [
+            True,
+            False,
+        ]
+    )
+    @override_config({"include_profile_updates_in_sync": True})
+    def test_null_profile_returned_we_left_all_rooms(
+        self,
+        request_fields: bool,
+    ) -> None:
+        """
+        Test that profile extension response returns a null for the user in
+        incremental sync, if we left the last shared room with a user.
+        """
+        # Make an initial Sliding Sync request with the profiles extension enabled
+        profiles_config: dict = {
+            "enabled": True,
+        }
+        if request_fields:
+            profiles_config["fields"] = ["field"]
+        sync_body = {
+            "lists": {},
+            "extensions": {
+                "org.matrix.msc4262.profiles": profiles_config,
+            },
+        }
+        response_body, from_token = self.do_sync(sync_body, tok=self.tok)
+
+        self.helper.leave(self.joined_room, self.user, tok=self.tok)
 
         # Make an incremental Sliding Sync request
         response_body, _ = self.do_sync(sync_body, since=from_token, tok=self.tok)


### PR DESCRIPTION
This pull request fixes a few issues with the profile update stream, when a user leaves a room. This is basically just mimicking what we already had for when someone leaves a room, and they no longer share any rooms, but in reverse - ie when we leave a room, and no longer share rooms with some users. This was missed in the implementation when adding the profile update stream for legacy and sliding sync.

[Fix missing profile update stream rows on user leaving room](https://github.com/element-hq/synapse/commit/e953322226731a99718ebe13139b9c5f05ae4b62)

When a user leaves a room, profile update stream rows are generated with the `LEFT_ROOM` action for each user in the room that no longer shares a room with the user who left the room.

This also needs to happen in reverse. The user who left the room needs to have a profile update stream row for each user they no longer share a room with.

If we don't do this, clients may keep stale data around even after they don't share a room with a user, which may mean they don't know when to refetch profiles after re-joining a room with the stale profile data user.

[Clear out old profile update stream rows when leaving a room](https://github.com/element-hq/synapse/commit/e7642bf141b098c1eefaf74655e5e7e18415500b)

When we leave a room, ensure profile update stream rows are cleared out for every user we no longer share a room with. This is the same as what happens when someone else leaves a room, but in reverse. The only remaining profile update stream row should be the `LEFT_ROOM` action.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
