### PR TITLE
Fix `Schema Diff` CI failing to post comment on PRs from forks

### DIFF
--- a/.github/workflows/schema_diff.yml
+++ b/.github/workflows/schema_diff.yml
@@ -95,9 +95,27 @@ jobs:
           echo "⚠️ Schema diff generation failed. See job logs for details." \
             > "${{ runner.temp }}/schema_diff.md"
 
+      # PRs from forks get a read-only GITHUB_TOKEN, which isn't enough to
+      # post a PR comment. Post directly only for same-repo PRs; forked PRs
+      # instead have their diff uploaded as an artifact below, which a
+      # separate, more privileged workflow picks up to post the comment.
       - name: Post sticky PR comment
         uses: marocchino/sticky-pull-request-comment@3d7b8546315c63df45a03981d50a43ec19237f80 # v3
-        if: always()
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         with:
           header: schema-diff
           path: ${{ runner.temp }}/schema_diff.md
+
+      - name: Save PR number for forked PRs
+        if: always() && github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "${{ github.event.pull_request.number }}" > "${{ runner.temp }}/pr_number"
+
+      - name: Upload schema diff artifact for forked PRs
+        if: always() && github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: schema-diff
+          path: |
+            ${{ runner.temp }}/schema_diff.md
+            ${{ runner.temp }}/pr_number
+          retention-days: 1

--- a/.github/workflows/schema_diff.yml
+++ b/.github/workflows/schema_diff.yml
@@ -1,4 +1,4 @@
-name: Schema Diff
+name: Schema Diff  # If this is changed, need to update `schema_diff_comment.yml` as well
 
 on:
   pull_request:
@@ -95,22 +95,29 @@ jobs:
           echo "⚠️ Schema diff generation failed. See job logs for details." \
             > "${{ runner.temp }}/schema_diff.md"
 
-      # PRs from forks get a read-only GITHUB_TOKEN, which isn't enough to
-      # post a PR comment. Post directly only for same-repo PRs; forked PRs
-      # instead have their diff uploaded as an artifact below, which a
-      # separate, more privileged workflow picks up to post the comment.
+      # Post a comment.
+      #
+      # For same-repo PRs, we can do this directly and we are done.
       - name: Post sticky PR comment
         uses: marocchino/sticky-pull-request-comment@3d7b8546315c63df45a03981d50a43ec19237f80 # v3
+        # Only run for same-repo PRs
         if: always() && github.event.pull_request.head.repo.full_name == github.repository
         with:
           header: schema-diff
           path: ${{ runner.temp }}/schema_diff.md
 
+      # For PRs from forks, we only have a read-only `GITHUB_TOKEN` here and need to work around
+      # by triggering a `workflow_run` onto the main repo.
+      #
+      # We upload an artifact and the `schema_diff_comment.yml` workflow will be triggered
+      # on the main repo by this workflow exiting.
       - name: Save PR number for forked PRs
+        # Only run for fork PRs
         if: always() && github.event.pull_request.head.repo.full_name != github.repository
         run: echo "${{ github.event.pull_request.number }}" > "${{ runner.temp }}/pr_number"
 
       - name: Upload schema diff artifact for forked PRs
+        # Only run for fork PRs
         if: always() && github.event.pull_request.head.repo.full_name != github.repository
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/schema_diff_comment.yml
+++ b/.github/workflows/schema_diff_comment.yml
@@ -5,31 +5,35 @@ name: Post schema diff comment for forked PRs
 # uploads the diff (and PR number) as an artifact, which we pick up here and
 # post as a comment.
 #
-# This workflow runs in the context of the base repository (not
-# `pull_request_target`), so its GITHUB_TOKEN has write access. The
-# downloaded artifact comes from an untrusted fork though, so it must only
+# This workflow runs in the context of the main repository, so its
+# `GITHUB_TOKEN` can have write access.
+# The downloaded artifact comes from an untrusted fork though, so it must only
 # ever be treated as inert comment text, never executed.
+# The PR number it carries is likewise untrusted: we cross-check it against the trusted
+# `workflow_run` event before posting, so a fork PR can't point the comment
+# at some other PR or issue.
 on:
   workflow_run:
     workflows: ["Schema Diff"]
     types: [completed]
 
+# DANGER: Due to untrusted input and untrusted triggers,
+# think very carefully before expanding the permissions
 permissions:
+  # To read the artifacts from the `schema_diff.yml` run
   actions: read
+  # To post a comment to the PR
   pull-requests: write
 
 jobs:
   comment:
     name: Post schema diff comment
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request'
+    # Only run when triggered by a pull request and only on a PR from a fork
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name != github.repository
     steps:
-      # Only PRs from forks upload this artifact (see schema_diff.yml), so
-      # this step will fail for same-repo PRs, which already got their
-      # comment posted directly.
       - name: Download schema diff artifact
         id: download
-        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: schema-diff
@@ -37,15 +41,31 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Read PR number
-        if: steps.download.outcome == 'success'
-        id: pr_number
-        run: echo "number=$(cat schema-diff/pr_number)" >> "$GITHUB_OUTPUT"
+      # The artifact (including the PR number) comes from an untrusted fork.
+      # Cross-check the number against the trusted workflow_run event before
+      # posting, so a fork PR cannot target another PR or issue.
+      - name: Verify PR matches the run that produced the artifact
+        id: verify
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No checkout in this job, so tell gh which repo to talk to.
+          GH_REPO: ${{ github.repository }}
+          EXPECTED_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          EXPECTED_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+        run: |
+          pr_number="$(cat schema-diff/pr_number)"
+          read -r pr_branch pr_head_repo < <(
+            gh api "repos/{owner}/{repo}/pulls/$pr_number" --jq '.head.ref + " " + .head.repo.full_name'
+          )
+          if [ "$pr_branch" != "$EXPECTED_BRANCH" ] || [ "$pr_head_repo" != "$EXPECTED_HEAD_REPO" ]; then
+            echo "::error::Artifact PR $pr_number does not match the triggering run; refusing to post a comment"
+            exit 1
+          fi
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
 
       - name: Post sticky PR comment
-        if: steps.download.outcome == 'success'
         uses: marocchino/sticky-pull-request-comment@3d7b8546315c63df45a03981d50a43ec19237f80 # v3
         with:
           header: schema-diff
-          number_force: ${{ steps.pr_number.outputs.number }}
+          number_force: ${{ steps.verify.outputs.number }}
           path: schema-diff/schema_diff.md

--- a/.github/workflows/schema_diff_comment.yml
+++ b/.github/workflows/schema_diff_comment.yml
@@ -30,7 +30,7 @@ jobs:
     name: Post schema diff comment
     runs-on: ubuntu-latest
     # Only run when triggered by a pull request and only on a PR from a fork
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name != github.repository
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name != github.repository && github.event.workflow_run.conclusion != 'cancelled'
     steps:
       - name: Download schema diff artifact
         id: download

--- a/.github/workflows/schema_diff_comment.yml
+++ b/.github/workflows/schema_diff_comment.yml
@@ -1,0 +1,51 @@
+name: Post schema diff comment for forked PRs
+
+# The "Schema Diff" workflow can't post a PR comment for PRs from forks,
+# since GITHUB_TOKEN is downgraded to read-only in that context. Instead it
+# uploads the diff (and PR number) as an artifact, which we pick up here and
+# post as a comment.
+#
+# This workflow runs in the context of the base repository (not
+# `pull_request_target`), so its GITHUB_TOKEN has write access. The
+# downloaded artifact comes from an untrusted fork though, so it must only
+# ever be treated as inert comment text, never executed.
+on:
+  workflow_run:
+    workflows: ["Schema Diff"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post schema diff comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      # Only PRs from forks upload this artifact (see schema_diff.yml), so
+      # this step will fail for same-repo PRs, which already got their
+      # comment posted directly.
+      - name: Download schema diff artifact
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: schema-diff
+          path: schema-diff
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        if: steps.download.outcome == 'success'
+        id: pr_number
+        run: echo "number=$(cat schema-diff/pr_number)" >> "$GITHUB_OUTPUT"
+
+      - name: Post sticky PR comment
+        if: steps.download.outcome == 'success'
+        uses: marocchino/sticky-pull-request-comment@3d7b8546315c63df45a03981d50a43ec19237f80 # v3
+        with:
+          header: schema-diff
+          number_force: ${{ steps.pr_number.outputs.number }}
+          path: schema-diff/schema_diff.md

--- a/changelog.d/20207.misc
+++ b/changelog.d/20207.misc
@@ -1,0 +1,1 @@
+Fix the `Schema Diff` CI check failing to post a comment on pull requests from forks.


### PR DESCRIPTION
### Summary
Fixes #20167.

The `Schema Diff` workflow posts a PR comment showing the effective schema diff. For PRs from forks, `GITHUB_TOKEN` is downgraded to read-only, so the comment-posting step was silently failing.

### Changes
- `schema_diff.yml`: only post the comment directly when the PR is from the same repository. For forked PRs, upload the diff (and PR number) as a short-lived artifact instead of trying to comment.
- `schema_diff_comment.yml` (new): triggered by `workflow_run` after `Schema Diff` completes, with `pull-requests: write` permission (granted because this workflow always runs in the context of the base repository). It downloads the artifact, if present, and posts the comment on behalf of the forked PR.

This avoids `pull_request_target`, per the security concerns raised in the issue (zizmor flags it as dangerous). The new workflow only ever treats the downloaded artifact as inert comment text -- it is never executed.

### Testing
- Validated both workflow files as valid YAML.
- This is a CI workflow-only change with no unit tests to run; behavior will be validated by CI itself running on this PR (same-repo, so it should still post directly) and can be spot-checked against a fork PR.
