### PR TITLE
Document MAS admin APIs as being workerisable

### DIFF
--- a/changelog.d/20209.doc
+++ b/changelog.d/20209.doc
@@ -1,0 +1,1 @@
+Document the paths that can be handled on workers with stabilised delegated authentication.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -318,7 +318,7 @@ for the room are in flight:
 
 Additionally, the following endpoints should be included if Synapse is configured
 to use SSO (you only need to include the ones for whichever SSO provider you're
-using):
+using) and delegated authentication isn't enabled:
 
     # for all SSO providers
     ^/_matrix/client/(api/v1|r0|v3|unstable)/login/sso/redirect

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -291,6 +291,9 @@ information.
     # Unstable MSC4140 support
     ^/_matrix/client/unstable/org.matrix.msc4140/delayed_events(/.*/restart)?$
 
+    # Stabilised Delegated Authentication support (`matrix_authentication_service.enabled: true`)
+    ^/_synapse/mas/
+
 Additionally, the following REST endpoints can be handled for GET requests:
 
     # Push rules requests


### PR DESCRIPTION
### Pull Request Checklist

Replacement for https://github.com/element-hq/synapse/pull/19752 as that has bit-rotted with https://github.com/element-hq/synapse/pull/19895 being merged.

`/_synapse/mas` is mounted on a worker on matrix.org and can be seen to be workerisable via
* https://github.com/element-hq/synapse/blob/v1.160.0/synapse/app/generic_worker.py#L202
* https://github.com/element-hq/synapse/blob/v1.160.0/synapse/rest/synapse/client/__init__.py#L71
* https://github.com/element-hq/synapse/blob/v1.160.0/synapse/rest/synapse/mas/__init__.py#L46-L71

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
