### PR TITLE
Omit `og:image` entirely if the media is quarantined when handling /preview_url

### DIFF
--- a/changelog.d/19987.bugfix
+++ b/changelog.d/19987.bugfix
@@ -1,0 +1,1 @@
+Do not include a media ID in URL previews when the media was automatically quarantined by hash matching; such media is now discarded entirely rather than stored.

--- a/changelog.d/19987.bugfix
+++ b/changelog.d/19987.bugfix
@@ -1,1 +1,0 @@
-Do not include a media ID in URL previews when the media was automatically quarantined by hash matching; such media is now discarded entirely rather than stored.

--- a/changelog.d/20211.bugfix
+++ b/changelog.d/20211.bugfix
@@ -1,0 +1,1 @@
+Do not include `og:image` in responses to `/preview_url` when the media was automatically quarantined by hash matching.

--- a/synapse/media/media_storage.py
+++ b/synapse/media/media_storage.py
@@ -507,6 +507,12 @@ class SpamMediaException(NotFoundError):
     """
 
 
+class QuarantinedMediaException(NotFoundError):
+    """The media matched the hash of existing quarantined media, so we 404 the
+    request (in the same way as if the media itself had been quarantined).
+    """
+
+
 @attr.s(slots=True, auto_attribs=True)
 class ReadableFileWrapper:
     """Wrapper that allows reading a file in chunks, yielding to the reactor,

--- a/synapse/media/url_previewer.py
+++ b/synapse/media/url_previewer.py
@@ -41,7 +41,11 @@ from synapse.api.errors import Codes, SynapseError
 from synapse.http.client import SimpleHttpClient
 from synapse.logging.context import make_deferred_yieldable, run_in_background
 from synapse.media._base import FileInfo, get_filename_from_headers
-from synapse.media.media_storage import MediaStorage, SHA256TransparentIOWriter
+from synapse.media.media_storage import (
+    MediaStorage,
+    QuarantinedMediaException,
+    SHA256TransparentIOWriter,
+)
 from synapse.media.oembed import OEmbedProvider
 from synapse.media.preview_html import decode_body, parse_html_to_open_graph
 from synapse.types import JsonDict, UserID
@@ -63,6 +67,30 @@ OG_TAG_VALUE_MAXLEN = 1000
 ONE_HOUR = 60 * 60 * 1000
 ONE_DAY = 24 * ONE_HOUR
 IMAGE_CACHE_EXPIRY_MS = 2 * ONE_DAY
+
+
+def _try_remove_parent_dirs(dirs: Iterable[str]) -> None:
+    """Attempt to remove the given chain of parent directories
+
+    Args:
+        dirs: The list of directory paths to delete, with children appearing
+            before their parents.
+    """
+    for dir in dirs:
+        try:
+            os.rmdir(dir)
+        except FileNotFoundError:
+            # Already deleted, continue with deleting the rest
+            pass
+        except OSError as e:
+            # Failed, skip deleting the rest of the parent dirs
+            if e.errno != errno.ENOTEMPTY:
+                logger.warning(
+                    "Failed to remove media directory while clearing url preview cache: %r: %s",
+                    dir,
+                    e,
+                )
+            break
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
@@ -613,15 +641,20 @@ class UrlPreviewer:
             else:
                 download_result = await self._download_url(url, sha256writer.wrap())
 
+        sha256 = sha256writer.hexdigest()
+        if await self.store.get_is_hash_quarantined(sha256):
+            # The media matches something that has been quarantined. Rather than
+            # storing it (and handing the client an mxc:// URI that will always
+            # 404), throw the download away entirely and let the caller decide
+            # how to cope without it.
+            logger.warning(
+                "Discarding %s from URL preview as it matched existing quarantined media",
+                url,
+            )
+            self._delete_url_cache_file(file_id)
+            raise QuarantinedMediaException()
+
         try:
-            sha256 = sha256writer.hexdigest()
-            should_quarantine = await self.store.get_is_hash_quarantined(sha256)
-
-            if should_quarantine:
-                logger.warning(
-                    "Media has been automatically quarantined as it matched existing quarantined media"
-                )
-
             time_now_ms = self.clock.time_msec()
 
             await self.store.store_local_media(
@@ -633,7 +666,6 @@ class UrlPreviewer:
                 user_id=user,
                 url_cache=url,
                 sha256=sha256,
-                quarantined_by="system" if should_quarantine else None,
             )
 
         except Exception as e:
@@ -654,6 +686,26 @@ class UrlPreviewer:
             response_code=download_result.response_code,
             expires=download_result.expires,
             etag=download_result.etag,
+        )
+
+    def _delete_url_cache_file(self, file_id: str) -> None:
+        """Remove a file from the url cache directory, along with any parent
+        directories left empty by its removal.
+
+        Note that url cache files are never handed to the storage providers (see
+        `StorageProviderWrapper.store_file`), so the local file is the only copy.
+        """
+        fname = self.filepaths.url_cache_filepath(file_id)
+        try:
+            os.remove(fname)
+        except FileNotFoundError:
+            pass  # If the path doesn't exist, meh
+        except OSError as e:
+            logger.warning("Failed to remove media from url preview cache: %r", e)
+            return
+
+        _try_remove_parent_dirs(
+            self.filepaths.url_cache_filepath_dirs_to_delete(file_id)
         )
 
     async def _precache_image_url(
@@ -760,29 +812,6 @@ class UrlPreviewer:
 
         logger.debug("Running url preview cache expiry")
 
-        def try_remove_parent_dirs(dirs: Iterable[str]) -> None:
-            """Attempt to remove the given chain of parent directories
-
-            Args:
-                dirs: The list of directory paths to delete, with children appearing
-                    before their parents.
-            """
-            for dir in dirs:
-                try:
-                    os.rmdir(dir)
-                except FileNotFoundError:
-                    # Already deleted, continue with deleting the rest
-                    pass
-                except OSError as e:
-                    # Failed, skip deleting the rest of the parent dirs
-                    if e.errno != errno.ENOTEMPTY:
-                        logger.warning(
-                            "Failed to remove media directory while clearing url preview cache: %r: %s",
-                            dir,
-                            e,
-                        )
-                    break
-
         # First we delete expired url cache entries
         media_ids = await self.store.get_expired_url_cache(now)
 
@@ -804,7 +833,7 @@ class UrlPreviewer:
             removed_media.append(media_id)
 
             dirs = self.filepaths.url_cache_filepath_dirs_to_delete(media_id)
-            try_remove_parent_dirs(dirs)
+            _try_remove_parent_dirs(dirs)
 
         await self.store.delete_url_cache(removed_media)
 
@@ -836,7 +865,7 @@ class UrlPreviewer:
                 continue
 
             dirs = self.filepaths.url_cache_filepath_dirs_to_delete(media_id)
-            try_remove_parent_dirs(dirs)
+            _try_remove_parent_dirs(dirs)
 
             thumbnail_dir = self.filepaths.url_cache_thumbnail_directory(media_id)
             try:
@@ -854,7 +883,7 @@ class UrlPreviewer:
             dirs = self.filepaths.url_cache_thumbnail_dirs_to_delete(media_id)
             # Note that one of the directories to be deleted has already been
             # removed by the `rmtree` above.
-            try_remove_parent_dirs(dirs)
+            _try_remove_parent_dirs(dirs)
 
         await self.store.delete_url_cache_media(removed_media)
 

--- a/tests/rest/media/test_url_preview.py
+++ b/tests/rest/media/test_url_preview.py
@@ -19,6 +19,7 @@
 #
 #
 import base64
+import hashlib
 import json
 import os
 import re
@@ -35,7 +36,7 @@ from twisted.web.resource import Resource
 from synapse.config.oembed import OEmbedEndpointConfig
 from synapse.media.url_previewer import IMAGE_CACHE_EXPIRY_MS
 from synapse.server import HomeServer
-from synapse.types import JsonDict
+from synapse.types import JsonDict, UserID
 from synapse.util.clock import Clock
 from synapse.util.stringutils import parse_and_validate_mxc_uri
 
@@ -766,6 +767,142 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         # The image should not be in the result.
         self.assertEqual(channel.code, 200)
         self.assertNotIn("og:image", channel.json_body)
+
+    def _quarantine_hash(self, content: bytes) -> None:
+        """Mark the sha256 of `content` as belonging to quarantined media."""
+        store = self.hs.get_datastores().main
+
+        # `get_is_hash_quarantined` returns False until the sha256 indexes have
+        # been built, which would make the tests below pass for the wrong reason.
+        self.wait_for_background_updates()
+
+        self.get_success(
+            store.store_local_media(
+                media_id="quarantinedmedia",
+                media_type="image/png",
+                time_now_ms=self.clock.time_msec(),
+                upload_name="quarantined.png",
+                media_length=len(content),
+                user_id=UserID.from_string(self.user_id),
+                sha256=hashlib.sha256(content).hexdigest(),
+            )
+        )
+        self.get_success(
+            store.quarantine_media_by_id("test", "quarantinedmedia", "@admin:test")
+        )
+
+    def _count_url_cache_files(self) -> int:
+        """The number of files stored in the url preview cache."""
+        return sum(
+            len(files)
+            for _, _, files in os.walk(os.path.join(self.media_store_path, "url_cache"))
+        )
+
+    def test_image_quarantined_by_hash(self) -> None:
+        """An image which matches a quarantined hash should be left out of the
+        preview entirely, rather than returned as an unfetchable mxc:// URI."""
+        self._quarantine_hash(SMALL_PNG)
+
+        self.lookups["matrix.org"] = [(IPv4Address, "10.1.2.3")]
+        self.lookups["cdn.matrix.org"] = [(IPv4Address, "10.1.2.4")]
+
+        result = (
+            b"""<html><body><img src="http://cdn.matrix.org/foo.png"></body></html>"""
+        )
+
+        channel = self.make_request(
+            "GET",
+            "/_matrix/media/v3/preview_url?url=http://matrix.org",
+            shorthand=False,
+            await_result=False,
+        )
+        self.pump()
+
+        # Respond with the HTML.
+        client = self.reactor.tcpClients[0][2].buildProtocol(None)
+        server = AccumulatingProtocol()
+        server.makeConnection(FakeTransport(client, self.reactor))
+        client.makeConnection(FakeTransport(server, self.reactor))
+        client.dataReceived(
+            (
+                b"HTTP/1.0 200 OK\r\nContent-Length: %d\r\n"
+                b'Content-Type: text/html; charset="utf8"\r\n\r\n'
+            )
+            % (len(result),)
+            + result
+        )
+        self.pump()
+
+        # Respond with the photo.
+        client = self.reactor.tcpClients[1][2].buildProtocol(None)
+        server = AccumulatingProtocol()
+        server.makeConnection(FakeTransport(client, self.reactor))
+        client.makeConnection(FakeTransport(server, self.reactor))
+        client.dataReceived(
+            (
+                b"HTTP/1.0 200 OK\r\nContent-Length: %d\r\n"
+                b"Content-Type: image/png\r\n\r\n"
+            )
+            % (len(SMALL_PNG),)
+            + SMALL_PNG
+        )
+        self.pump()
+
+        # The rest of the preview is returned, but without any image.
+        self.assertEqual(channel.code, 200)
+        self.assertNotIn("og:image", channel.json_body)
+        self.assertNotIn("og:image:type", channel.json_body)
+        self.assertNotIn("og:image:width", channel.json_body)
+        self.assertNotIn("og:image:height", channel.json_body)
+        self.assertNotIn("matrix:image:size", channel.json_body)
+
+        # No reference to the image should have been kept: the only url cache
+        # media is the previewed page itself.
+        media = self.get_success(
+            self.hs.get_datastores().main.db_pool.simple_select_onecol(
+                "local_media_repository",
+                {},
+                "url_cache",
+                desc="test_url_cache_media",
+            )
+        )
+        self.assertEqual(
+            [url for url in media if url is not None], ["http://matrix.org"]
+        )
+        self.assertEqual(self._count_url_cache_files(), 1)
+
+    def test_direct_image_quarantined_by_hash(self) -> None:
+        """Previewing an image which itself matches a quarantined hash should
+        404, in the same way as fetching the quarantined media would."""
+        self._quarantine_hash(SMALL_PNG)
+
+        self.lookups["cdn.matrix.org"] = [(IPv4Address, "10.1.2.4")]
+
+        channel = self.make_request(
+            "GET",
+            "/_matrix/media/v3/preview_url?url=http://cdn.matrix.org/foo.png",
+            shorthand=False,
+            await_result=False,
+        )
+        self.pump()
+
+        client = self.reactor.tcpClients[0][2].buildProtocol(None)
+        server = AccumulatingProtocol()
+        server.makeConnection(FakeTransport(client, self.reactor))
+        client.makeConnection(FakeTransport(server, self.reactor))
+        client.dataReceived(
+            (
+                b"HTTP/1.0 200 OK\r\nContent-Length: %d\r\n"
+                b"Content-Type: image/png\r\n\r\n"
+            )
+            % (len(SMALL_PNG),)
+            + SMALL_PNG
+        )
+        self.pump()
+
+        self.assertEqual(channel.code, 404)
+        self.assertEqual(channel.json_body["errcode"], "M_NOT_FOUND")
+        self.assertEqual(self._count_url_cache_files(), 0)
 
     @unittest.override_config(
         {"url_preview_url_blacklist": [{"netloc": "cdn.matrix.org"}]}


### PR DESCRIPTION
This is to prevent the case where URL previews return a MXC that immediately 404s because the media in question has been quarantined. This is mostly to help implementations which currently show an ugly empty preview due to the MXC being sent down, despite being invalid.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
