### PR TITLE
Make Sentry events follow the request logcontext

### DIFF
--- a/changelog.d/20213.feature
+++ b/changelog.d/20213.feature
@@ -1,0 +1,1 @@
+Stop attaching Matrix IDs and client IP addresses to Sentry events: events now identify the user by a pseudonymous hash, carry only the current request's breadcrumbs (configurable with `sentry.max_breadcrumbs`), and record the servlet, method and listener as tags.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3175,11 +3175,17 @@ An optional `environment` field can be used to specify an environment. This allo
 
 NOTE: While attempts are made to ensure that the logs don't contain any sensitive information, this cannot be guaranteed. By enabling this option the sentry server may therefore receive sensitive information, and it in turn may then disseminate sensitive information through insecure notification channels if so configured.
 
+What Synapse sends to Sentry: the exception or log message that triggered the event; its stack trace, including each frame's local variables; the servlet, HTTP method and listener (`site_tag`) handling the request, as tags; a pseudonymous user id; the request path with its query string removed and the `User-Agent` header; and the last `max_breadcrumbs` log lines of that request. Synapse never attaches the client's IP address itself, but `sentry_sdk` sends local variables as it finds them, so an IP held in one can still reach Sentry.
+
+The pseudonymous user id is an unsalted, truncated SHA-256 of the Matrix ID. It is stable, so one user's events can be correlated with each other, and anyone holding a candidate Matrix ID can confirm whether it matches.
+
 This setting has the following sub-options:
 
 * `dsn` (string|null): The DSN assigned by sentry. If unset or null, sentry integration is disabled. Defaults to `null`.
 
 * `environment` (string|null): Sentry environment. Defaults to `null`.
+
+* `max_breadcrumbs` (integer): The number of recent log lines to attach to each sentry event as breadcrumbs. Synapse collects breadcrumbs per request, so a larger value costs memory for every request in flight. Defaults to `50`.
 
 Example configuration:
 ```yaml

--- a/poetry.lock
+++ b/poetry.lock
@@ -3784,4 +3784,4 @@ url-preview = ["lxml"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<4.0.0"
-content-hash = "53ecef32887866656603697f9e11043dae7b2917b1a2e7727f5133f604acf9de"
+content-hash = "53a00d7a818dd0388bd4e434df30586b038ff5cee472609291ef3a9f6eb28c66"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ saml2 = [
 ]
 oidc = ["authlib>=0.15.1"]
 url-preview = ["lxml>=4.6.3"]
-sentry = ["sentry-sdk>=0.7.2"]
+sentry = ["sentry-sdk>=2.0.0"]
 opentracing = [
     "jaeger-client>=4.2.0",
     "opentracing>=2.2.0",
@@ -182,7 +182,7 @@ all = [
     # url-preview
     "lxml>=4.6.3",
     # sentry
-    "sentry-sdk>=0.7.2",
+    "sentry-sdk>=2.0.0",
     # opentracing
     "jaeger-client>=4.2.0", "opentracing>=2.2.0",
     # redis

--- a/schema/synapse-config.schema.yaml
+++ b/schema/synapse-config.schema.yaml
@@ -3634,6 +3634,21 @@ properties:
       the sentry server may therefore receive sensitive information, and it in
       turn may then disseminate sensitive information through insecure
       notification channels if so configured.
+
+
+      What Synapse sends to Sentry: the exception or log message that triggered
+      the event; its stack trace, including each frame's local variables; the
+      servlet, HTTP method and listener (`site_tag`) handling the request, as
+      tags; a pseudonymous user id; the request path with its query string
+      removed and the `User-Agent` header; and the last `max_breadcrumbs` log
+      lines of that request. Synapse never attaches the client's IP address
+      itself, but `sentry_sdk` sends local variables as it finds them, so an IP
+      held in one can still reach Sentry.
+
+
+      The pseudonymous user id is an unsalted, truncated SHA-256 of the Matrix
+      ID. It is stable, so one user's events can be correlated with each other,
+      and anyone holding a candidate Matrix ID can confirm whether it matches.
     properties:
       dsn:
         type: ["string", "null"]
@@ -3645,6 +3660,14 @@ properties:
         type: ["string", "null"]
         description: Sentry environment.
         default: null
+      max_breadcrumbs:
+        type: integer
+        description: >-
+          The number of recent log lines to attach to each sentry event as
+          breadcrumbs. Synapse collects breadcrumbs per request, so a larger
+          value costs memory for every request in flight.
+        minimum: 0
+        default: 50
     examples:
       - environment: production
         dsn: ...

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -84,7 +84,6 @@ from synapse.module_api.callbacks.third_party_event_rules_callbacks import (
     load_legacy_third_party_event_rules,
 )
 from synapse.types import ISynapseReactor, StrCollection
-from synapse.util import SYNAPSE_VERSION
 from synapse.util.caches.lrucache import setup_expire_lru_cache_entries
 from synapse.util.daemonize import daemonize_process
 from synapse.util.gai_resolver import GAIResolver
@@ -831,26 +830,11 @@ def setup_sentry(hs: "HomeServer") -> None:
     if not hs.config.metrics.sentry_enabled:
         return
 
-    import sentry_sdk
+    # `sentry_sdk` is an optional dependency, so the module that imports it is only
+    # pulled in once we know Sentry is enabled.
+    from synapse.logging.sentry import setup_sentry as setup
 
-    sentry_sdk.init(
-        dsn=hs.config.metrics.sentry_dsn,
-        release=SYNAPSE_VERSION,
-        environment=hs.config.metrics.sentry_environment,
-    )
-
-    # We set some default tags that give some context to this instance
-    global_scope = sentry_sdk.Scope.get_global_scope()
-    global_scope.set_tag("matrix_server_name", hs.config.server.server_name)
-
-    app = (
-        hs.config.worker.worker_app
-        if hs.config.worker.worker_app
-        else "synapse.app.homeserver"
-    )
-    name = hs.get_instance_name()
-    global_scope.set_tag("worker_app", app)
-    global_scope.set_tag("worker_name", name)
+    setup(hs)
 
 
 def setup_sdnotify(hs: "HomeServer") -> None:

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -74,6 +74,22 @@ class MetricsConfig(Config):
                     "sentry.dsn field is required when sentry integration is enabled"
                 )
 
+            # Half the `sentry_sdk` default of 100: the ring is kept per in-flight
+            # request rather than once per worker, so the memory cost scales with
+            # concurrency. Arbitrary beyond that.
+            self.sentry_max_breadcrumbs = config["sentry"].get("max_breadcrumbs", 50)
+            # `deque(maxlen=...)` would otherwise raise on the first request, well
+            # after the server has come up.
+            if (
+                not isinstance(self.sentry_max_breadcrumbs, int)
+                or isinstance(self.sentry_max_breadcrumbs, bool)
+                or self.sentry_max_breadcrumbs < 0
+            ):
+                raise ConfigError(
+                    "sentry.max_breadcrumbs must be a non-negative integer, got %r"
+                    % (self.sentry_max_breadcrumbs,)
+                )
+
     def generate_config_section(
         self,
         report_stats: bool | None = None,

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -329,7 +329,7 @@ class _AsyncResource(resource.Resource, metaclass=abc.ABCMeta):
         exceptions, return values, metrics, etc.
         """
         try:
-            request.request_metrics.name = self.__class__.__name__
+            request.set_servlet_name(self.__class__.__name__)
 
             with trace_servlet(request, self._extract_context):
                 try:
@@ -558,7 +558,7 @@ class JsonResource(DirectServeJsonResource):
 
         # Make sure we have an appropriate name for this handler in prometheus
         # (rather than the default of JsonResource).
-        request.request_metrics.name = servlet_classname
+        request.set_servlet_name(servlet_classname)
 
         # Now trigger the callback. If it returns a response, we send it
         # here. If it throws an exception, that is handled by the wrapper

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -574,6 +574,21 @@ class SynapseRequest(Request):
             else:
                 self._finished_processing()
 
+    def set_servlet_name(self, servlet_name: str) -> None:
+        """Record which servlet is handling this request.
+
+        Callers narrow the name down as dispatch progresses, from the resource class
+        to the servlet class that ends up handling the request.
+        """
+        # A logging context should exist by now (and have a ContextRequest): `render`
+        # builds it before `_started_processing`, and the `server.py` callers run
+        # inside `Request.render`.
+        assert self.logcontext is not None
+        assert self.logcontext.request is not None
+
+        self.request_metrics.name = servlet_name
+        self.logcontext.request.servlet_name = servlet_name
+
     def _started_processing(self, servlet_name: str) -> None:
         """Record the fact that we are processing this request.
 
@@ -584,14 +599,15 @@ class SynapseRequest(Request):
             servlet_name: the name of the servlet which will be
                 processing this request. This is used in the metrics.
 
-                It is possible to update this afterwards by updating
-                self.request_metrics.name.
+                It is possible to update this afterwards by calling
+                `set_servlet_name`.
         """
         self.start_time = time.time()
         self.request_metrics = RequestMetrics(our_server_name=self.our_server_name)
         self.request_metrics.start(
             self.start_time, name=servlet_name, method=self.get_method()
         )
+        self.set_servlet_name(servlet_name)
 
         self.synapse_site.access_logger.debug(
             "%s - %s - Received request: %s %s",

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -235,6 +235,10 @@ class ContextRequest:
     url: str
     protocol: str
     user_agent: str
+    # Unset until the request is routed; narrowed from the resource class name to
+    # the servlet class name as dispatch progresses (see
+    # `SynapseRequest.set_servlet_name`).
+    servlet_name: str | None = None
 
 
 LoggingContextOrSentinel = Union["LoggingContext", "_Sentinel"]

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -33,6 +33,7 @@ See doc/log_contexts.rst for details on how this works.
 import logging
 import threading
 import typing
+from collections import deque
 from types import TracebackType
 from typing import (
     TYPE_CHECKING,
@@ -55,6 +56,8 @@ from synapse.logging.loggers import ExplicitlyConfiguredLogger
 from synapse.util.stringutils import random_string_insecure_fast
 
 if TYPE_CHECKING:
+    from sentry_sdk.types import Breadcrumb
+
     from synapse.logging.scopecontextmanager import _LogContextScope
     from synapse.types import ISynapseReactor
 
@@ -102,6 +105,22 @@ except Exception:
 # a hook which can be set during testing to assert that we aren't abusing logcontexts.
 def logcontext_error(msg: str) -> None:
     logger.warning(msg)
+
+
+_sentry_breadcrumb_ring_size: int | None = None
+"""
+Size of the Sentry breadcrumb ring each logcontext keeps, or `None` while Sentry is
+disabled.
+
+Set by `synapse.logging.sentry`: `sentry_sdk` is an optional dependency, so this module
+cannot import it.
+"""
+
+
+def set_sentry_breadcrumb_ring_size(size: int) -> None:
+    """Start keeping a Sentry breadcrumb ring of the given size on each logcontext."""
+    global _sentry_breadcrumb_ring_size
+    _sentry_breadcrumb_ring_size = size
 
 
 # get an id for the current thread.
@@ -263,6 +282,7 @@ class _Sentinel:
         "server_name",
         "request",
         "tag",
+        "sentry_breadcrumbs",
     ]
 
     def __init__(self) -> None:
@@ -273,6 +293,7 @@ class _Sentinel:
         self.request = None
         self.scope = None
         self.tag = None
+        self.sentry_breadcrumbs: "deque[Breadcrumb] | None" = None
 
     def __str__(self) -> str:
         return "sentinel"
@@ -330,6 +351,7 @@ class LoggingContext:
         "request",
         "tag",
         "scope",
+        "sentry_breadcrumbs",
     ]
 
     def __init__(
@@ -362,6 +384,21 @@ class LoggingContext:
         self.finished = False
 
         self.parent_context = parent_context
+
+        # Sentry breadcrumbs recorded under this context, or `None` while Sentry is
+        # disabled. Children (including database threads) share their parent's ring so
+        # that a request's breadcrumbs stay together and separate from other requests'.
+        # `synapse.logging.sentry._snapshot_breadcrumbs` covers what makes reading a
+        # ring that other threads are appending to safe.
+        self.sentry_breadcrumbs: "deque[Breadcrumb] | None" = None
+        if _sentry_breadcrumb_ring_size is not None:
+            if (
+                parent_context is not None
+                and parent_context.sentry_breadcrumbs is not None
+            ):
+                self.sentry_breadcrumbs = parent_context.sentry_breadcrumbs
+            else:
+                self.sentry_breadcrumbs = deque(maxlen=_sentry_breadcrumb_ring_size)
 
         # Inherit some fields from the parent context
         if self.parent_context is not None:

--- a/synapse/logging/sentry.py
+++ b/synapse/logging/sentry.py
@@ -1,0 +1,184 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 Element Creations Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+
+"""Sentry integration.
+
+Sentry keeps its own per-request state (scopes) in contextvars. Twisted runs
+coroutines in copied contextvars contexts and fires Deferred callbacks in whichever
+context happens to be current, so a scope forked per request does not reliably follow
+the request. Synapse's own request identity is the thread-local logcontext, which
+Synapse's logcontext discipline keeps tied to the request across those same callback
+restores, so everything here reads the logcontext at send time instead of using Sentry
+scopes.
+"""
+
+from typing import TYPE_CHECKING
+
+import sentry_sdk
+
+from synapse.logging.context import ContextRequest, LoggingContext, current_context
+from synapse.metrics.background_process_metrics import BackgroundProcessLoggingContext
+from synapse.types import UserID
+from synapse.util import SYNAPSE_VERSION
+from synapse.util.hash import sha256_and_url_safe_base64
+
+if TYPE_CHECKING:
+    from sentry_sdk.types import Event, Hint
+
+    from synapse.server import HomeServer
+
+
+# `sentry_sdk`'s logging integration copies every log record attribute it doesn't
+# recognise into `event["extra"]`. `LoggingContextFilter` sets these, which would put
+# Matrix IDs and IP addresses into Sentry in the clear; the request fields we do want
+# are set explicitly by `before_send`.
+_LOGCONTEXT_RECORD_ATTRIBUTES = frozenset(
+    {
+        "request",
+        "server_name",
+        "ip_address",
+        "site_tag",
+        "requester",
+        "authenticated_entity",
+        "method",
+        "url",
+        "protocol",
+        "user_agent",
+    }
+)
+
+# `sys.argv` comes from `sentry_sdk`'s argv integration and `asctime` from formatting
+# the record; neither says anything the rest of the event doesn't.
+_UNINTERESTING_EXTRA_KEYS = frozenset({"sys.argv", "asctime"})
+
+_STRIPPED_EXTRA_KEYS = _LOGCONTEXT_RECORD_ATTRIBUTES | _UNINTERESTING_EXTRA_KEYS
+
+
+def _pseudonymous_user_id(identifier: str) -> str:
+    """Derive an opaque, stable id from a Matrix ID.
+
+    This is a pseudonym, not anonymisation: it lets events from one user be
+    correlated with each other without putting Matrix IDs into Sentry, but anyone
+    with a candidate Matrix ID can confirm whether it matches.
+
+    The digest is truncated to keep the id readable in the Sentry UI; the remaining
+    96 bits are far more than enough to keep one homeserver's users apart.
+    """
+    return sha256_and_url_safe_base64(identifier)[:16]
+
+
+def _strip_query_string(url: str) -> str:
+    """Drop the query string from a URI.
+
+    Query parameters carry room, event and user identifiers which Sentry has no use
+    for.
+    """
+    return url.partition("?")[0]
+
+
+def _attach_request(event: "Event", request: ContextRequest) -> None:
+    """Describe the HTTP request being served on an outgoing event.
+
+    The client's IP address is not attached: Sentry is not where Synapse's
+    operators should be reading IP addresses from.
+    """
+    if request.servlet_name is not None:
+        event["transaction"] = request.servlet_name
+
+    tags = event.setdefault("tags", {})
+    # Only low-cardinality values belong in tags; the request ID goes in the context
+    # below instead.
+    if request.servlet_name is not None:
+        tags["servlet"] = request.servlet_name
+    tags["site_tag"] = request.site_tag
+    tags["method"] = request.method
+
+    synapse_request: dict[str, object] = {
+        "request_id": request.request_id,
+        "servlet": request.servlet_name,
+        "protocol": request.protocol,
+    }
+
+    # `requester` is the user the request is being made on behalf of: for a puppeting
+    # request that is the puppeted user, and the admin who authenticated is not sent.
+    if request.requester is not None:
+        if UserID.is_valid(request.requester):
+            event["user"] = {"id": _pseudonymous_user_id(request.requester)}
+        else:
+            # A federation request's requester is the origin server name, which is
+            # public, so hashing it would only cost the ability to group errors by
+            # origin. A context is not a tag, so its cardinality is free.
+            synapse_request["requester"] = request.requester
+
+    event.setdefault("contexts", {})["synapse_request"] = synapse_request
+
+    event["request"] = {
+        "method": request.method,
+        "url": _strip_query_string(request.url),
+        "headers": {"User-Agent": request.user_agent},
+    }
+
+
+def before_send(event: "Event", hint: "Hint") -> "Event | None":
+    """Rewrite an outgoing Sentry event to carry the current logcontext's request.
+
+    Registered as `sentry_sdk.init(before_send=...)`, so it runs after every event
+    processor, on the thread and stack frame that captured the event. The SDK only
+    calls it for error events, so a transaction event (were `traces_sample_rate` ever
+    set) would go out untouched, still carrying the SDK's own cross-request state.
+    """
+    extra = event.get("extra")
+    if extra is not None:
+        for key in _STRIPPED_EXTRA_KEYS:
+            extra.pop(key, None)
+
+    context = current_context()
+    if not isinstance(context, LoggingContext):
+        # The sentinel context has no request to describe.
+        return event
+
+    if isinstance(context, BackgroundProcessLoggingContext):
+        event.setdefault("tags", {})["background_process"] = context.desc
+
+    if context.request is not None:
+        _attach_request(event, context.request)
+
+    return event
+
+
+def setup_sentry(hs: "HomeServer") -> None:
+    """Enable the Sentry integration."""
+
+    sentry_sdk.init(
+        dsn=hs.config.metrics.sentry_dsn,
+        release=SYNAPSE_VERSION,
+        environment=hs.config.metrics.sentry_environment,
+        # Everything the events say about the request is assembled by `before_send`,
+        # in a pseudonymised form.
+        send_default_pii=False,
+        before_send=before_send,
+    )
+
+    # We set some default tags that give some context to this instance
+    global_scope = sentry_sdk.Scope.get_global_scope()
+    global_scope.set_tag("matrix_server_name", hs.config.server.server_name)
+
+    app = (
+        hs.config.worker.worker_app
+        if hs.config.worker.worker_app
+        else "synapse.app.homeserver"
+    )
+    name = hs.get_instance_name()
+    global_scope.set_tag("worker_app", app)
+    global_scope.set_tag("worker_name", name)

--- a/synapse/logging/sentry.py
+++ b/synapse/logging/sentry.py
@@ -23,18 +23,26 @@ restores, so everything here reads the logcontext at send time instead of using 
 scopes.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
+from sentry_sdk.serializer import serialize
 
-from synapse.logging.context import ContextRequest, LoggingContext, current_context
+from synapse.logging.context import (
+    ContextRequest,
+    LoggingContext,
+    current_context,
+    set_sentry_breadcrumb_ring_size,
+)
 from synapse.metrics.background_process_metrics import BackgroundProcessLoggingContext
 from synapse.types import UserID
 from synapse.util import SYNAPSE_VERSION
 from synapse.util.hash import sha256_and_url_safe_base64
 
 if TYPE_CHECKING:
-    from sentry_sdk.types import Event, Hint
+    from collections import deque
+
+    from sentry_sdk.types import Breadcrumb, BreadcrumbHint, Event, Hint
 
     from synapse.server import HomeServer
 
@@ -63,6 +71,10 @@ _LOGCONTEXT_RECORD_ATTRIBUTES = frozenset(
 _UNINTERESTING_EXTRA_KEYS = frozenset({"sys.argv", "asctime"})
 
 _STRIPPED_EXTRA_KEYS = _LOGCONTEXT_RECORD_ATTRIBUTES | _UNINTERESTING_EXTRA_KEYS
+
+# Breadcrumb categories are logger names; these are the access log's, one per listener
+# protocol.
+_ACCESS_LOG_CATEGORY_PREFIXES = ("synapse.access.http.", "synapse.access.https.")
 
 
 def _pseudonymous_user_id(identifier: str) -> str:
@@ -130,6 +142,21 @@ def _attach_request(event: "Event", request: ContextRequest) -> None:
     }
 
 
+def _snapshot_breadcrumbs(breadcrumbs: "deque[Breadcrumb]") -> list["Breadcrumb"]:
+    """Copy a logcontext's breadcrumb ring.
+
+    Appends happen from database threads, which run in a child logcontext sharing the
+    ring, while this runs on the reactor thread. `list()` on a deque is a single
+    C-level loop, so the GIL is not released mid-iteration on the standard build, but
+    that is an implementation detail; if it ever does raise, losing the breadcrumbs is
+    better than losing the event.
+    """
+    try:
+        return list(breadcrumbs)
+    except RuntimeError:
+        return []
+
+
 def before_send(event: "Event", hint: "Hint") -> "Event | None":
     """Rewrite an outgoing Sentry event to carry the current logcontext's request.
 
@@ -161,21 +188,94 @@ def before_send(event: "Event", hint: "Hint") -> "Event | None":
     if context.request is not None:
         _attach_request(event, context.request)
 
+    if context.sentry_breadcrumbs is not None:
+        # Replace whatever the SDK collected in its shared ring with this request's
+        # own breadcrumbs.
+        event["breadcrumbs"] = {
+            "values": _snapshot_breadcrumbs(context.sentry_breadcrumbs)
+        }
+
     return event
+
+
+def before_breadcrumb(
+    crumb: "Breadcrumb", hint: "BreadcrumbHint"
+) -> "Breadcrumb | None":
+    """Record a breadcrumb against the current logcontext rather than the SDK.
+
+    Registered as `sentry_sdk.init(before_breadcrumb=...)`. The SDK keeps one
+    breadcrumb ring per isolation scope, which every request on a worker shares, so
+    returning `None` here keeps the crumb out of it; `before_send` reads the
+    logcontext's ring instead.
+    """
+    category = crumb.get("category")
+    if category is not None and category.startswith(_ACCESS_LOG_CATEGORY_PREFIXES):
+        # The access log names other users' request paths and Matrix IDs, and is
+        # already in the normal logs keyed by request ID.
+        return None
+
+    breadcrumbs = current_context().sentry_breadcrumbs
+    if breadcrumbs is None:
+        # Outside any logcontext, leave the SDK to its default behaviour; events
+        # captured there have no request to keep the crumbs apart from.
+        return crumb
+
+    # The SDK serialises the event and runs `EventScrubber` over it before it calls
+    # `before_send`, so crumbs attached there miss both passes: strip the
+    # `LoggingContextFilter` record attributes the SDK's breadcrumb handler copies
+    # into `data`, as `before_send` does for `extra`, and serialise the crumb so that
+    # the `datetime` the SDK leaves in `timestamp` cannot fail to JSON-encode in the
+    # transport and take the whole event down with it. `serialize` is
+    # `sentry_sdk`-internal API, and sees the crumb as a top-level object, so the SDK's
+    # databag trimming does not reach `data`; strings are still capped at
+    # `max_value_length`.
+    data = crumb.get("data")
+    if data is not None:
+        for key in _STRIPPED_EXTRA_KEYS:
+            data.pop(key, None)
+
+    options = sentry_sdk.get_client().options
+    breadcrumbs.append(
+        serialize(dict(crumb), max_value_length=options.get("max_value_length"))
+    )
+    return None
+
+
+def sentry_sdk_options(
+    *, dsn: str | None, environment: str | None, max_breadcrumbs: int
+) -> dict[str, Any]:
+    """The options Synapse initialises `sentry_sdk` with.
+
+    Kept out of `setup_sentry` so that tests can drive the SDK end to end with their
+    own transport and the options Synapse runs with.
+    """
+    return {
+        "dsn": dsn,
+        "release": SYNAPSE_VERSION,
+        "environment": environment,
+        # Everything the events say about the request is assembled by `before_send`,
+        # in a pseudonymised form.
+        "send_default_pii": False,
+        "before_send": before_send,
+        "before_breadcrumb": before_breadcrumb,
+        "max_breadcrumbs": max_breadcrumbs,
+    }
 
 
 def setup_sentry(hs: "HomeServer") -> None:
     """Enable the Sentry integration."""
 
+    max_breadcrumbs = hs.config.metrics.sentry_max_breadcrumbs
+
     sentry_sdk.init(
-        dsn=hs.config.metrics.sentry_dsn,
-        release=SYNAPSE_VERSION,
-        environment=hs.config.metrics.sentry_environment,
-        # Everything the events say about the request is assembled by `before_send`,
-        # in a pseudonymised form.
-        send_default_pii=False,
-        before_send=before_send,
+        **sentry_sdk_options(
+            dsn=hs.config.metrics.sentry_dsn,
+            environment=hs.config.metrics.sentry_environment,
+            max_breadcrumbs=max_breadcrumbs,
+        )
     )
+
+    set_sentry_breadcrumb_ring_size(max_breadcrumbs)
 
     # We set some default tags that give some context to this instance
     global_scope = sentry_sdk.Scope.get_global_scope()

--- a/synapse/logging/sentry.py
+++ b/synapse/logging/sentry.py
@@ -143,6 +143,13 @@ def before_send(event: "Event", hint: "Hint") -> "Event | None":
         for key in _STRIPPED_EXTRA_KEYS:
             extra.pop(key, None)
 
+    record = hint.get("log_record")
+    if record is not None and "exception" not in event:
+        # Sentry groups these events on the formatted message, and its normalisation
+        # does not cover Matrix room or event IDs, so a `%s`-templated log line
+        # otherwise fragments into one issue per room. Group on the template instead.
+        event["fingerprint"] = [record.name, str(record.msg)]
+
     context = current_context()
     if not isinstance(context, LoggingContext):
         # The sentinel context has no request to describe.

--- a/synapse/metrics/background_process_metrics.py
+++ b/synapse/metrics/background_process_metrics.py
@@ -479,7 +479,7 @@ class BackgroundProcessLoggingContext(LoggingContext):
     processes.
     """
 
-    __slots__ = ["_proc"]
+    __slots__ = ["_proc", "desc"]
 
     def __init__(
         self,
@@ -502,6 +502,9 @@ class BackgroundProcessLoggingContext(LoggingContext):
         if instance_id is None:
             instance_id = id(self)
         super().__init__(name="%s-%s" % (name, instance_id), server_name=server_name)
+        # `LoggingContext.name` has the instance id appended, so keep the bare
+        # description around for low-cardinality labelling.
+        self.desc = name
         self._proc: _BackgroundProcess | None = _BackgroundProcess(
             desc=name, server_name=server_name, ctx=self
         )

--- a/tests/config/test_metrics.py
+++ b/tests/config/test_metrics.py
@@ -1,0 +1,45 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 Element Creations Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+
+from synapse.config import ConfigError
+from synapse.config.homeserver import HomeServerConfig
+from synapse.types import JsonDict
+
+from tests.unittest import TestCase
+from tests.utils import default_config
+
+
+class SentryConfigTestCase(TestCase):
+    def _parse(self, sentry: JsonDict) -> HomeServerConfig:
+        config_dict = default_config(server_name="test")
+        config_dict["sentry"] = sentry
+
+        config = HomeServerConfig()
+        config.parse_config_dict(config_dict, "", "")
+        return config
+
+    def test_max_breadcrumbs_default(self) -> None:
+        """`max_breadcrumbs` is optional."""
+        config = self._parse({"dsn": "https://key@example.invalid/1"})
+
+        self.assertEqual(config.metrics.sentry_max_breadcrumbs, 50)
+
+    def test_max_breadcrumbs_must_be_a_non_negative_integer(self) -> None:
+        """A bad `max_breadcrumbs` is rejected at config load (see the
+        validation comment in `synapse/config/metrics.py` for why)."""
+        for value in (-1, 1.5, True, "many"):
+            with self.assertRaises(ConfigError):
+                self._parse(
+                    {"dsn": "https://key@example.invalid/1", "max_breadcrumbs": value}
+                )

--- a/tests/logging/test_sentry.py
+++ b/tests/logging/test_sentry.py
@@ -13,6 +13,7 @@
 #
 
 import hashlib
+import logging
 from typing import TYPE_CHECKING
 
 import unpaddedbase64
@@ -218,3 +219,52 @@ class BeforeSendTestCase(TestCase):
 
         assert result is not None
         self.assertEqual(result, {"extra": {}})
+
+
+class FingerprintTestCase(TestCase):
+    def _make_record(self) -> logging.LogRecord:
+        return logging.LogRecord(
+            name="synapse.storage.databases.main.event_federation",
+            level=logging.WARNING,
+            pathname=__file__,
+            lineno=1,
+            msg="Unexpectedly found that events don't have chain IDs in room %s: %s",
+            args=("!room:example.com", "$event"),
+            exc_info=None,
+        )
+
+    def test_message_event_grouped_by_template(self) -> None:
+        """Message events group on the logger name and the unformatted template."""
+        event: "Event" = {}
+        hint: "Hint" = {"log_record": self._make_record()}
+
+        result = before_send(event, hint)
+
+        assert result is not None
+        self.assertEqual(
+            result["fingerprint"],
+            [
+                "synapse.storage.databases.main.event_federation",
+                "Unexpectedly found that events don't have chain IDs in room %s: %s",
+            ],
+        )
+
+    def test_exception_event_keeps_default_grouping(self) -> None:
+        """Exceptions group on their stack trace, which is already specific."""
+        event: "Event" = {"exception": {"values": []}}
+        hint: "Hint" = {"log_record": self._make_record()}
+
+        result = before_send(event, hint)
+
+        assert result is not None
+        self.assertNotIn("fingerprint", result)
+
+    def test_event_without_log_record(self) -> None:
+        """Events that didn't come from a log record are left to group themselves."""
+        event: "Event" = {}
+        hint: "Hint" = {}
+
+        result = before_send(event, hint)
+
+        assert result is not None
+        self.assertNotIn("fingerprint", result)

--- a/tests/logging/test_sentry.py
+++ b/tests/logging/test_sentry.py
@@ -1,0 +1,220 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 Element Creations Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+
+import hashlib
+from typing import TYPE_CHECKING
+
+import unpaddedbase64
+
+from synapse.logging.context import ContextRequest, LoggingContext
+from synapse.logging.sentry import before_send
+from synapse.metrics.background_process_metrics import BackgroundProcessLoggingContext
+
+from tests.unittest import TestCase
+
+if TYPE_CHECKING:
+    from sentry_sdk.types import Event, Hint
+
+SERVER_NAME = "test_server"
+
+
+def make_context_request(**kwargs: object) -> ContextRequest:
+    """Build a `ContextRequest` that looks like one from a real request."""
+    defaults: dict = {
+        "request_id": "GET-42",
+        "ip_address": "1.2.3.4",
+        "site_tag": "8008",
+        "requester": "@alice:example.com",
+        "authenticated_entity": "@alice:example.com",
+        "method": "GET",
+        "url": "/_matrix/client/v3/rooms/!room:example.com/messages?from=s1&limit=10",
+        "protocol": "HTTP/1.1",
+        "user_agent": "Element/1.0",
+        "servlet_name": "RoomMessageListRestServlet",
+    }
+    defaults.update(kwargs)
+    return ContextRequest(**defaults)
+
+
+def pseudonym(identifier: str) -> str:
+    """The pseudonymous id `before_send` is expected to derive from `identifier`."""
+    digest = hashlib.sha256(identifier.encode("utf-8")).digest()
+    return unpaddedbase64.encode_base64(digest, urlsafe=True)[:16]
+
+
+class BeforeSendTestCase(TestCase):
+    def test_request_attached(self) -> None:
+        """Request details from the logcontext are mapped onto the event."""
+        request = make_context_request()
+        event: "Event" = {}
+        hint: "Hint" = {}
+
+        with LoggingContext(name="GET-42", server_name=SERVER_NAME, request=request):
+            result = before_send(event, hint)
+
+        assert result is not None
+
+        self.assertEqual(result["transaction"], "RoomMessageListRestServlet")
+        self.assertEqual(
+            result["tags"],
+            {
+                "servlet": "RoomMessageListRestServlet",
+                "site_tag": "8008",
+                "method": "GET",
+            },
+        )
+        self.assertEqual(
+            result["contexts"]["synapse_request"],
+            {
+                "request_id": "GET-42",
+                "servlet": "RoomMessageListRestServlet",
+                "protocol": "HTTP/1.1",
+            },
+        )
+        self.assertEqual(
+            result["request"],
+            {
+                "method": "GET",
+                # The query string is dropped.
+                "url": "/_matrix/client/v3/rooms/!room:example.com/messages",
+                "headers": {"User-Agent": "Element/1.0"},
+            },
+        )
+
+    def test_user_is_pseudonymous(self) -> None:
+        """The Matrix ID is replaced by a stable hash of itself."""
+        event: "Event" = {}
+        hint: "Hint" = {}
+
+        with LoggingContext(
+            name="GET-42", server_name=SERVER_NAME, request=make_context_request()
+        ):
+            result = before_send(event, hint)
+
+        assert result is not None
+        self.assertEqual(result["user"], {"id": pseudonym("@alice:example.com")})
+
+    def test_puppeted_user_is_the_pseudonymous_user(self) -> None:
+        """When an admin puppets a user, the event names the puppeted user."""
+        request = make_context_request(
+            requester="@bob:example.com",
+            authenticated_entity="@admin:example.com",
+        )
+        event: "Event" = {}
+        hint: "Hint" = {}
+
+        with LoggingContext(name="PUT-1", server_name=SERVER_NAME, request=request):
+            result = before_send(event, hint)
+
+        assert result is not None
+        self.assertEqual(result["user"], {"id": pseudonym("@bob:example.com")})
+        self.assertNotIn("@admin:example.com", repr(result))
+
+    def test_federation_requester_is_the_origin_server(self) -> None:
+        """A requester that isn't a Matrix ID is a server name, kept as context."""
+        request = make_context_request(
+            requester="remote.example.com",
+            authenticated_entity="remote.example.com",
+        )
+        event: "Event" = {}
+        hint: "Hint" = {}
+
+        with LoggingContext(name="PUT-1", server_name=SERVER_NAME, request=request):
+            result = before_send(event, hint)
+
+        assert result is not None
+        self.assertNotIn("user", result)
+        self.assertEqual(
+            result["contexts"]["synapse_request"]["requester"], "remote.example.com"
+        )
+
+    def test_unauthenticated_request_has_no_user(self) -> None:
+        """A request that never authenticated identifies no user at all."""
+        request = make_context_request(requester=None, authenticated_entity=None)
+        event: "Event" = {}
+        hint: "Hint" = {}
+
+        with LoggingContext(name="GET-1", server_name=SERVER_NAME, request=request):
+            result = before_send(event, hint)
+
+        assert result is not None
+        self.assertNotIn("user", result)
+
+    def test_ip_address_is_not_sent(self) -> None:
+        """The client's IP address is nowhere on the event."""
+        event: "Event" = {}
+        hint: "Hint" = {}
+
+        with LoggingContext(
+            name="GET-42", server_name=SERVER_NAME, request=make_context_request()
+        ):
+            result = before_send(event, hint)
+
+        assert result is not None
+        self.assertNotIn("1.2.3.4", repr(result))
+
+    def test_logcontext_extra_is_stripped(self) -> None:
+        """The attributes `LoggingContextFilter` puts on records don't reach Sentry."""
+        event: "Event" = {
+            "extra": {
+                "request": "GET-42",
+                "server_name": SERVER_NAME,
+                "ip_address": "1.2.3.4",
+                "site_tag": "8008",
+                "requester": "@alice:example.com",
+                "authenticated_entity": "@alice:example.com",
+                "method": "GET",
+                "url": "/_matrix/client/v3/sync",
+                "protocol": "HTTP/1.1",
+                "user_agent": "Element/1.0",
+                "sys.argv": ["synapse"],
+                "asctime": "2026-01-01 00:00:00",
+                "something_useful": 1,
+            }
+        }
+        hint: "Hint" = {}
+
+        with LoggingContext(
+            name="GET-42", server_name=SERVER_NAME, request=make_context_request()
+        ):
+            result = before_send(event, hint)
+
+        assert result is not None
+        self.assertEqual(result["extra"], {"something_useful": 1})
+
+    def test_background_process(self) -> None:
+        """Background processes are tagged with their description, not their id."""
+        event: "Event" = {}
+        hint: "Hint" = {}
+
+        with BackgroundProcessLoggingContext(
+            name="update_user_directory", server_name=SERVER_NAME, instance_id=1
+        ):
+            result = before_send(event, hint)
+
+        assert result is not None
+        self.assertEqual(
+            result["tags"], {"background_process": "update_user_directory"}
+        )
+        self.assertNotIn("request", result)
+
+    def test_sentinel_context(self) -> None:
+        """Events captured outside any logcontext are passed through untouched."""
+        event: "Event" = {"extra": {"asctime": "now"}}
+        hint: "Hint" = {}
+
+        result = before_send(event, hint)
+
+        assert result is not None
+        self.assertEqual(result, {"extra": {}})

--- a/tests/logging/test_sentry.py
+++ b/tests/logging/test_sentry.py
@@ -13,19 +13,26 @@
 #
 
 import hashlib
+import json
 import logging
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+import sentry_sdk
 import unpaddedbase64
+from sentry_sdk.envelope import Envelope
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.transport import Transport
 
+from synapse.logging import context as logcontext
 from synapse.logging.context import ContextRequest, LoggingContext
-from synapse.logging.sentry import before_send
+from synapse.logging.sentry import before_breadcrumb, before_send, sentry_sdk_options
 from synapse.metrics.background_process_metrics import BackgroundProcessLoggingContext
 
 from tests.unittest import TestCase
 
 if TYPE_CHECKING:
-    from sentry_sdk.types import Event, Hint
+    from sentry_sdk.types import Breadcrumb, Event, Hint
 
 SERVER_NAME = "test_server"
 
@@ -268,3 +275,232 @@ class FingerprintTestCase(TestCase):
 
         assert result is not None
         self.assertNotIn("fingerprint", result)
+
+
+class BreadcrumbTestCase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        # `set_sentry_breadcrumb_ring_size` is what `setup_sentry` calls; it is
+        # process-wide, so put it back afterwards.
+        self.addCleanup(
+            setattr,
+            logcontext,
+            "_sentry_breadcrumb_ring_size",
+            logcontext._sentry_breadcrumb_ring_size,
+        )
+        logcontext.set_sentry_breadcrumb_ring_size(3)
+
+    def _make_crumb(
+        self, message: str, category: str = "synapse.handlers.sync"
+    ) -> "Breadcrumb":
+        return {"category": category, "message": message}
+
+    def test_child_contexts_share_the_ring(self) -> None:
+        """A request's children (including database threads) share its ring."""
+        with LoggingContext(
+            name="GET-42", server_name=SERVER_NAME, request=make_context_request()
+        ) as parent:
+            with LoggingContext(
+                name="child", server_name=SERVER_NAME, parent_context=parent
+            ) as child:
+                self.assertIs(child.sentry_breadcrumbs, parent.sentry_breadcrumbs)
+
+    def test_sibling_contexts_have_separate_rings(self) -> None:
+        """Two unrelated requests keep their breadcrumbs apart."""
+        with LoggingContext(name="GET-1", server_name=SERVER_NAME) as first:
+            pass
+        with LoggingContext(name="GET-2", server_name=SERVER_NAME) as second:
+            pass
+
+        self.assertIsNot(first.sentry_breadcrumbs, second.sentry_breadcrumbs)
+
+    def test_crumbs_go_to_the_current_context(self) -> None:
+        """Crumbs are kept on the logcontext, not handed back to the SDK."""
+        with LoggingContext(name="GET-1", server_name=SERVER_NAME) as first:
+            self.assertIsNone(before_breadcrumb(self._make_crumb("one"), {}))
+        with LoggingContext(name="GET-2", server_name=SERVER_NAME) as second:
+            self.assertIsNone(before_breadcrumb(self._make_crumb("two"), {}))
+
+        assert first.sentry_breadcrumbs is not None
+        assert second.sentry_breadcrumbs is not None
+        self.assertEqual(
+            [crumb["message"] for crumb in first.sentry_breadcrumbs], ["one"]
+        )
+        self.assertEqual(
+            [crumb["message"] for crumb in second.sentry_breadcrumbs], ["two"]
+        )
+
+    def test_crumb_is_stripped_and_serialised(self) -> None:
+        """A kept crumb has the logcontext attributes off it and is JSON-ready."""
+        crumb: "Breadcrumb" = {
+            "category": "synapse.handlers.sync",
+            "message": "hello",
+            "timestamp": datetime(2026, 1, 1, tzinfo=timezone.utc),
+            "data": {
+                "ip_address": "1.2.3.4",
+                "requester": "@alice:example.com",
+                "url": "/_matrix/client/v3/sync?since=s1",
+                "something_useful": 1,
+            },
+        }
+
+        with LoggingContext(name="GET-1", server_name=SERVER_NAME) as context:
+            self.assertIsNone(before_breadcrumb(crumb, {}))
+
+        assert context.sentry_breadcrumbs is not None
+        (kept,) = context.sentry_breadcrumbs
+        self.assertEqual(kept["data"], {"something_useful": 1})
+        # `json.dumps` is what the transport does with the event, and it is given no
+        # `default=`, so a `datetime` left in the ring would drop the whole event.
+        self.assertEqual(
+            json.loads(json.dumps(kept)),
+            {
+                "category": "synapse.handlers.sync",
+                "message": "hello",
+                "timestamp": "2026-01-01T00:00:00.000000Z",
+                "data": {"something_useful": 1},
+            },
+        )
+
+    def test_ring_is_bounded(self) -> None:
+        """Only the most recent crumbs are kept."""
+        with LoggingContext(name="GET-1", server_name=SERVER_NAME) as context:
+            for i in range(5):
+                before_breadcrumb(self._make_crumb(str(i)), {})
+
+        assert context.sentry_breadcrumbs is not None
+        self.assertEqual(
+            [crumb["message"] for crumb in context.sentry_breadcrumbs], ["2", "3", "4"]
+        )
+
+    def test_access_log_crumbs_are_dropped(self) -> None:
+        """The access log repeats other requests' paths, so it is not kept."""
+        with LoggingContext(name="GET-1", server_name=SERVER_NAME) as context:
+            for category in ("synapse.access.http.8008", "synapse.access.https.8448"):
+                self.assertIsNone(
+                    before_breadcrumb(self._make_crumb("nope", category=category), {})
+                )
+
+        assert context.sentry_breadcrumbs is not None
+        self.assertEqual(list(context.sentry_breadcrumbs), [])
+
+    def test_sentinel_context_passes_crumbs_through(self) -> None:
+        """Outside a logcontext, the SDK keeps its own ring."""
+        crumb = self._make_crumb("one")
+        self.assertIs(before_breadcrumb(crumb, {}), crumb)
+
+    def test_before_send_attaches_the_ring(self) -> None:
+        """The event carries this request's crumbs, not the SDK's shared ring."""
+        event: "Event" = {"breadcrumbs": {"values": [{"message": "shared"}]}}
+        hint: "Hint" = {}
+
+        with LoggingContext(
+            name="GET-42", server_name=SERVER_NAME, request=make_context_request()
+        ):
+            before_breadcrumb(self._make_crumb("one"), {})
+            before_breadcrumb(self._make_crumb("two"), {})
+
+            result = before_send(event, hint)
+
+        assert result is not None
+        breadcrumbs = result["breadcrumbs"]
+        assert isinstance(breadcrumbs, dict)
+        self.assertEqual(
+            [crumb["message"] for crumb in breadcrumbs["values"]],
+            ["one", "two"],
+        )
+
+    def test_no_breadcrumbs_when_disabled(self) -> None:
+        """With no ring size set, the SDK's own breadcrumb handling is left alone."""
+        logcontext._sentry_breadcrumb_ring_size = None
+        event: "Event" = {}
+        hint: "Hint" = {}
+
+        with LoggingContext(name="GET-1", server_name=SERVER_NAME) as context:
+            self.assertIsNone(context.sentry_breadcrumbs)
+            crumb = self._make_crumb("one")
+            self.assertIs(before_breadcrumb(crumb, {}), crumb)
+
+            result = before_send(event, hint)
+
+        assert result is not None
+        self.assertNotIn("breadcrumbs", result)
+
+
+class EndToEndTestCase(TestCase):
+    """Drive `sentry_sdk` itself and assert on what reaches the transport.
+
+    The SDK serialises and scrubs an event before it calls `before_send`, and
+    JSON-encodes the envelope afterwards, so only a test which goes through the real
+    client can see what leaves the process.
+
+    `LoggingIntegration` patches `logging.Logger.callHandlers` process-wide and the SDK
+    never undoes it; once the client below is dropped the patch finds no integration on
+    the current client and does nothing.
+    """
+
+    def test_error_logged_during_a_request(self) -> None:
+        """The event carries the request's log lines and none of its identifiers."""
+        envelopes: list[Envelope] = []
+
+        class CapturingTransport(Transport):
+            def capture_envelope(self, envelope: Envelope) -> None:
+                envelopes.append(envelope)
+
+        client = sentry_sdk.Client(
+            **sentry_sdk_options(
+                dsn="https://key@example.invalid/1",
+                environment="test",
+                max_breadcrumbs=10,
+            ),
+            transport=CapturingTransport(),
+            # The SDK's other default integrations reach outside this test (`sys.argv`,
+            # `sys.excepthook`, an `atexit` hook); the logging one is what turns log
+            # lines into events and breadcrumbs.
+            default_integrations=False,
+            integrations=[LoggingIntegration()],
+        )
+        self.addCleanup(client.close)
+
+        self.addCleanup(
+            setattr,
+            logcontext,
+            "_sentry_breadcrumb_ring_size",
+            logcontext._sentry_breadcrumb_ring_size,
+        )
+        logcontext.set_sentry_breadcrumb_ring_size(10)
+
+        logger = logging.getLogger("synapse.handlers.sync")
+        self.addCleanup(logger.setLevel, logger.level)
+        logger.setLevel(logging.INFO)
+
+        with sentry_sdk.new_scope() as scope:
+            # A forked scope drops the client again at the end of the test, where
+            # `sentry_sdk.init` would install it on the global scope.
+            scope.set_client(client)
+
+            with LoggingContext(
+                name="GET-42", server_name=SERVER_NAME, request=make_context_request()
+            ):
+                logger.info("Fetched messages for %s", "!room:example.com")
+                logger.error("Everything is broken")
+
+        (envelope,) = envelopes
+        # `Envelope.serialize` is the JSON encoding the transport does; a value it
+        # chokes on drops the event, logging only "Internal error in sentry_sdk".
+        body = envelope.serialize()
+
+        event = envelope.get_event()
+        assert event is not None
+        breadcrumbs = event["breadcrumbs"]
+        assert isinstance(breadcrumbs, dict)
+        self.assertEqual(
+            [crumb["message"] for crumb in breadcrumbs["values"]],
+            ["Fetched messages for !room:example.com"],
+        )
+        self.assertEqual(event["user"], {"id": pseudonym("@alice:example.com")})
+
+        self.assertNotIn(b"1.2.3.4", body)
+        self.assertNotIn(b"@alice:example.com", body)
+        self.assertNotIn(b"from=s1", body)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -92,6 +92,34 @@ class JsonResourceTests(unittest.TestCase):
 
         self.assertEqual(got_kwargs, {"room_id": "\N{SNOWMAN}"})
 
+    def test_servlet_name_recorded_on_logcontext(self) -> None:
+        """
+        The name of the servlet that handled a request ends up on the request's
+        logcontext, so that out-of-band reporting can name it.
+        """
+
+        def _callback(
+            request: SynapseRequest, **kwargs: object
+        ) -> tuple[int, JsonDict]:
+            return 200, {}
+
+        res = JsonResource(self.homeserver)
+        res.register_paths(
+            "GET", [re.compile("^/_matrix/foo$")], _callback, "test_servlet"
+        )
+
+        channel = make_request(
+            self.reactor, FakeSite(res, self.reactor), b"GET", b"/_matrix/foo"
+        )
+
+        self.assertEqual(channel.code, 200)
+
+        request = channel.request
+        assert isinstance(request, SynapseRequest)
+        assert request.logcontext is not None
+        assert request.logcontext.request is not None
+        self.assertEqual(request.logcontext.request.servlet_name, "test_servlet")
+
     def test_callback_direct_exception(self) -> None:
         """
         If the web callback raises an uncaught exception, it will be translated


### PR DESCRIPTION
Draft: makes Synapse's Sentry events describe the request they belong to, using the logcontext rather than Sentry's own scopes.

### Problem

Looking at what Synapse currently sends to Sentry (observed on the matrix.org deployment):

- **Breadcrumbs are shared across all requests on a worker.** sentry-python keeps its breadcrumb ring on an isolation scope stored in contextvars. Nothing forks a scope per request, so every event ships the last 100 log lines of whatever the worker was doing, including other users' Matrix IDs and request paths from the access log.
- **Request data only reaches Sentry by accident, and as PII.** `LoggingContextFilter` sets `requester`, `ip_address`, `url`, `user_agent`, … on every log record; sentry-python copies unknown record attributes into `event["extra"]`. So MXIDs and client IPs end up in `extra` in the clear, while `user`, `request`, `transaction` and useful tags are never populated.
- **Message-only events fragment.** Sentry groups on the formatted message and its normalisation does not recognise Matrix room/event IDs, so a `%s`-templated `logger.error` such as "Unexpectedly found that events don't have chain IDs in room %s" becomes one issue per room.

### Why not use Sentry scopes

Twisted runs each coroutine in a copied contextvars context and fires Deferred callbacks in whichever context is current, so a scope forked per request does not reliably follow the request (the reactor's base context keeps a stale scope after a callback restores a logcontext). Synapse's request identity is the thread-local logcontext, which is correct by Synapse's own discipline, so everything here reads the logcontext at send time instead.

### Changes (one commit each, reviewable in order)

1. **Record the servlet name in the request's logcontext.** `ContextRequest.servlet_name`, kept in step with `request_metrics.name` via `SynapseRequest.set_servlet_name`.
2. **Attach request information from the logcontext to Sentry events.** New `synapse/logging/sentry.py`; `setup_sentry` moves there. `before_send` sets `transaction` (servlet), low-cardinality tags (`servlet`, `site_tag`, `method`, `background_process`), a `synapse_request` context (request id, protocol, …), `user.id` as a truncated SHA-256 of the requester (a pseudonym for correlation, not anonymisation), and `request` (method, path without query string, User-Agent). It strips the `LoggingContextFilter` attributes plus `sys.argv`/`asctime` from `extra`, and passes `send_default_pii=False`. Synapse itself never attaches the client IP; stack-frame local variables still go out as the SDK finds them (`include_local_variables` is left at its default), so the config docs say so rather than promising more.
3. **Group Sentry log-message events by their message template.** Fingerprint `[logger, record.msg]` for message-only events; exception events keep stack-trace grouping.
4. **Keep Sentry breadcrumbs per request.** Each root logcontext gets its own breadcrumb ring, shared with child contexts (and so with DB threads); `before_breadcrumb` diverts crumbs into it and drops access-log crumbs; `before_send` attaches the request's ring in place of the SDK's shared one. New config option `sentry.max_breadcrumbs` (default 50). `synapse/logging/context.py` does not import `sentry_sdk`; the ring size is injected.

### Testing

- `tests/logging/test_sentry.py`: unit tests for `before_send`/`before_breadcrumb` (field mapping, extra stripping, sentinel context, fingerprinting, ring sharing between nested contexts and isolation between siblings, access-log dropping, federation and puppeting requesters), plus an end-to-end test that builds a real `sentry_sdk.Client` with a capturing transport, logs inside a `LoggingContext`, and asserts on the serialised envelope: the event arrives, carries the request's breadcrumbs, and contains neither the client IP, the Matrix ID nor the query string.
- `tests/config/test_metrics.py`: `sentry.max_breadcrumbs` validation.
- `tests/test_server.py`: servlet name lands on the logcontext after dispatch.
- `trial tests.logging tests.test_server tests.config tests.metrics tests.http` pass at every commit of the stack; `ruff`, `mypy` clean; config docs regenerated from the schema.

### Self-review notes

A first pass of this stack had two bugs that unit-testing the hooks in isolation could not see, both now fixed and covered by the end-to-end test: breadcrumbs attached in `before_send` bypassed the SDK's serialiser (a `datetime` in each crumb made the envelope unserialisable, so every event with breadcrumbs was silently dropped) and bypassed the SDK's scrubber (the crumb `data` carried the same log-record attributes as `extra`, IP included). Crumbs are now stripped and serialised at append time.

Design points a reviewer may want to weigh in on:

- `user.id` is an unsalted truncated hash of the Matrix ID (stable across workers so events correlate; anyone with a candidate MXID can confirm a match). Documented in the config manual.
- For federation requests the requester is the origin server, which is public, so it goes unhashed into the `synapse_request` context rather than into `user`.
- `sentry_sdk.serializer.serialize` is SDK-internal API; the alternative is formatting the timestamp by hand and hoping nothing else non-JSON lands in crumb data.
- The `sentry` extra's floor moves from `sentry-sdk>=0.7.2` to `>=2.0.0` (only the lockfile content hash changes): the pre-existing `Scope.get_global_scope()` call already needed 2.x, and this change imports `sentry_sdk.serializer`.
- Frame local variables are the remaining PII channel (a local named `access_token` or `user_id` reaches Sentry verbatim; the SDK only scrubs by exact key name). Turning `include_local_variables` off is a separate decision.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog)
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

🤖 Generated with [Claude Code](https://claude.com/claude-code)
