### PR TITLE
Keep serving /metrics when a single collector raises

### DIFF
--- a/changelog.d/20214.bugfix
+++ b/changelog.d/20214.bugfix
@@ -1,0 +1,1 @@
+Keep serving `/metrics` when a single metric collector raises, instead of failing the whole scrape with a 500. Introduced in v1.135.0.

--- a/poetry.lock
+++ b/poetry.lock
@@ -3784,4 +3784,4 @@ url-preview = ["lxml"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<4.0.0"
-content-hash = "53ecef32887866656603697f9e11043dae7b2917b1a2e7727f5133f604acf9de"
+content-hash = "68a4783312ab98fd83537812ced6511471902b775e18b3e4c5b7ee5ded190577"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,9 @@ dependencies = [
     "phonenumbers>=8.2.0",
     # we use GaugeHistogramMetric, which was added in prom-client 0.4.0.
     # `Gauge.clear()` was added in 0.10.0.
-    "prometheus-client>=0.10.0",
+    # `listen_metrics` unpacks the `(server, thread)` pair that
+    # `start_http_server()` only returns from 0.20.0.
+    "prometheus-client>=0.20.0",
     # we use `order`, which arrived in attrs 19.2.0.
     # Note: 21.1.0 broke `/sync`, see https://github.com/matrix-org/synapse/issues/9936
     "attrs>=19.2.0,!=21.1.0",

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -315,6 +315,33 @@ def register_start(
     clock.call_when_running(lambda: defer.ensureDeferred(wrapper()))
 
 
+def _handle_metrics_request_error(request: object, client_address: object) -> None:
+    """`socketserver.BaseServer.handle_error` replacement for the metrics listener.
+
+    `ThreadingMixIn.process_request_thread` calls this as a plain function
+    (`self.handle_error(request, client_address)` looks it up on the instance, so no
+    bound `self` is passed) from inside its `except Exception:` block, so
+    `sys.exc_info()` still refers to the exception that was raised while handling the
+    request.
+
+    Without this, `socketserver.BaseServer.handle_error`'s default implementation
+    prints the traceback to `sys.stderr` with one line per `write()` call, and Synapse
+    turns each of those lines into its own ERROR log record.
+    """
+    exc = sys.exc_info()[1]
+    if isinstance(exc, (ConnectionResetError, BrokenPipeError, ConnectionAbortedError)):
+        # The scraper closed the connection while we were reading its request. A
+        # disconnect while the response is being written never gets here:
+        # `wsgiref.handlers.BaseHandler.run` catches these three types itself.
+        logger.debug(
+            "Connection error handling metrics request from %s: %r",
+            client_address,
+            exc,
+        )
+    else:
+        logger.exception("Error handling metrics request from %s", client_address)
+
+
 def listen_metrics(
     bind_addresses: StrCollection, port: int
 ) -> list[tuple[WSGIServer, Thread]]:
@@ -344,6 +371,14 @@ def listen_metrics(
         server, thread = start_http_server_prometheus(
             port, addr=host, registry=RegistryProxy
         )
+        # A scraper disconnecting while its request is being read is the only error
+        # path left that reaches socketserver: collector errors are handled in
+        # `RegistryProxy.collect`, and anything the WSGI app raises is caught by
+        # `wsgiref.handlers.BaseHandler`, which writes the traceback to `wsgi.errors`
+        # instead. The stdlib default here would print the traceback to `sys.stderr`,
+        # which Synapse's stdio-to-logs redirection turns into one ERROR record per
+        # line.
+        server.handle_error = _handle_metrics_request_error  # type: ignore[method-assign]
         servers.append((server, thread))
     return servers
 

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -20,6 +20,7 @@
 #
 #
 
+import copy
 import itertools
 import logging
 import os
@@ -139,11 +140,68 @@ def _set_prometheus_client_use_created_metrics(new_value: bool) -> None:
 _set_prometheus_client_use_created_metrics(False)
 
 
+def _check_registry_collect_internals_are_present() -> None:
+    """
+    `_RegistryProxy.collect` reaches into `CollectorRegistry`'s private
+    `_collector_to_names` and `_lock` attributes (see there) to give each collector
+    its own error boundary. If a `prometheus_client` upgrade renames or removes them,
+    fail at import rather than on every scrape.
+    """
+    if not (hasattr(REGISTRY, "_collector_to_names") and hasattr(REGISTRY, "_lock")):
+        raise Exception(
+            "Can't iterate prometheus_client's collectors one at a time (brittle hack broken?)"
+        )
+
+
+_check_registry_collect_internals_are_present()
+
+
 class _RegistryProxy:
     @staticmethod
     def collect() -> Iterable[Metric]:
-        for metric in REGISTRY.collect():
-            if not metric.name.startswith("__"):
+        # `_collector_to_names` and `_lock` are private `CollectorRegistry` attributes
+        # (see `_check_registry_collect_internals_are_present` above). Snapshotting the
+        # collector set under the lock mirrors `CollectorRegistry.collect`
+        # (prometheus_client/registry.py); unlike that method, we don't need to also
+        # yield a target_info metric here because Synapse's `REGISTRY` never calls
+        # `set_target_info`.
+        with REGISTRY._lock:
+            collectors = copy.copy(REGISTRY._collector_to_names)
+
+        for collector in collectors:
+            try:
+                for metric in collector.collect():
+                    if not metric.name.startswith("__"):
+                        yield metric
+            except Exception:
+                # Collection can run concurrently with the reactor (on the
+                # prometheus_client HTTP server's own thread), so a collector reading
+                # reactor-owned state can raise. Skip it rather than failing the whole
+                # scrape.
+                logger.exception(
+                    "Error collecting metrics from %r (%s); skipping the rest of its "
+                    "metrics for this scrape",
+                    collector,
+                    collectors[collector],
+                )
+
+    @staticmethod
+    def restricted_registry(names: Iterable[str]) -> "_RestrictedRegistryProxy":
+        # `prometheus_client.exposition._bake_output` calls this for `?name[]=` scrapes,
+        # and its own `RestrictedRegistry` collects from the real `REGISTRY`, which
+        # would bypass the error boundary and the `__`-prefix filter in `collect` above.
+        return _RestrictedRegistryProxy(names)
+
+
+class _RestrictedRegistryProxy:
+    """The families of `_RegistryProxy.collect` that a `?name[]=` scrape asked for."""
+
+    def __init__(self, names: Iterable[str]) -> None:
+        self._names = set(names)
+
+    def collect(self) -> Iterable[Metric]:
+        for metric in _RegistryProxy.collect():
+            if metric.name in self._names:
                 yield metric
 
 

--- a/tests/metrics/_collectors.py
+++ b/tests/metrics/_collectors.py
@@ -1,0 +1,52 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 Element Creations Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+
+"""Throwaway collectors shared by the tests that scrape `RegistryProxy`."""
+
+from typing import Iterable
+
+from prometheus_client import Metric
+from prometheus_client.core import GaugeMetricFamily
+
+
+class BrokenCollector:
+    """A collector that raises partway through `collect()`."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def describe(self) -> Iterable[Metric]:
+        # Registering on the default REGISTRY (auto_describe=True) would otherwise call
+        # collect(), which raises, to work out metric names.
+        #
+        # This is a test and does not matter if it uses `SERVER_NAME_LABEL`.
+        yield GaugeMetricFamily(self._name, "unused")  # type: ignore[missing-server-name-label]
+
+    def collect(self) -> Iterable[Metric]:
+        d = {"a": 1, "b": 2}
+        for _ in d:
+            d["c"] = 3  # dictionary changed size during iteration
+        # This is a test and does not matter if it uses `SERVER_NAME_LABEL`.
+        yield GaugeMetricFamily(self._name, "unused")  # type: ignore[missing-server-name-label]
+
+
+class HealthyCollector:
+    """A collector that yields a single gauge family."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def collect(self) -> Iterable[Metric]:
+        # This is a test and does not matter if it uses `SERVER_NAME_LABEL`.
+        yield GaugeMetricFamily(self._name, "unused")  # type: ignore[missing-server-name-label]

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -26,7 +26,8 @@
 # More info here: https://docs.python.org/3/reference/compound_stmts.html#annotations
 from __future__ import annotations
 
-from typing import NoReturn, Protocol
+import logging
+from typing import NoReturn, Protocol, Sequence
 
 from prometheus_client.core import Sample
 
@@ -35,13 +36,16 @@ from synapse.metrics import (
     SERVER_NAME_LABEL,
     InFlightGauge,
     LaterGauge,
+    RegistryProxy,
     all_later_gauges_to_clean_up_on_shutdown,
     generate_latest,
 )
+from synapse.metrics._types import Collector
 from synapse.util.caches.deferred_cache import DeferredCache
 
 from tests import unittest
 from tests.metrics import get_latest_metrics
+from tests.metrics._collectors import BrokenCollector, HealthyCollector
 
 
 def get_sample_labels_value(sample: Sample) -> tuple[dict[str, str], float]:
@@ -391,3 +395,74 @@ class LaterGaugeTests(unittest.HomeserverTestCase):
             f"Missing metric {hs2_metric} in cache metrics {metrics_map}",
         )
         self.assertEqual(hs2_metric_value, "2.0")
+
+
+class RegistryProxyTests(unittest.TestCase):
+    """Tests for `RegistryProxy.collect`, the per-collector error boundary Synapse
+    installs in front of the real `REGISTRY`."""
+
+    def _register(self, collector: Collector) -> None:
+        REGISTRY.register(collector)
+        self.addCleanup(REGISTRY.unregister, collector)
+
+    def _records_naming(
+        self, records: Sequence[logging.LogRecord], name: str
+    ) -> Sequence[logging.LogRecord]:
+        """`RegistryProxy.collect` runs over the process-global `REGISTRY`, so any
+        other collector failing during the same scrape would otherwise be counted."""
+        return [record for record in records if name in record.getMessage()]
+
+    def test_broken_collector_does_not_prevent_other_metrics(self) -> None:
+        """A collector whose `collect()` raises is skipped, but other collectors'
+        metrics are still yielded, with one ERROR record logged naming it."""
+        broken_collector = BrokenCollector("test_registry_proxy_broken_collector")
+        self._register(broken_collector)
+        self._register(HealthyCollector("test_registry_proxy_healthy_collector"))
+
+        with self.assertLogs("synapse.metrics", level="ERROR") as cm:
+            names = {metric.name for metric in RegistryProxy.collect()}
+
+        self.assertIn("test_registry_proxy_healthy_collector", names)
+        self.assertNotIn("test_registry_proxy_broken_collector", names)
+
+        records = self._records_naming(
+            cm.records, "test_registry_proxy_broken_collector"
+        )
+        self.assertEqual(len(records), 1)
+        self.assertIsNotNone(records[0].exc_info)
+        self.assertIn(repr(broken_collector), records[0].getMessage())
+
+    def test_dunder_prefixed_families_are_filtered(self) -> None:
+        """Metric families whose name starts with `__` are filtered out."""
+        self._register(HealthyCollector("__test_registry_proxy_hidden_collector"))
+
+        names = {metric.name for metric in RegistryProxy.collect()}
+        self.assertNotIn("__test_registry_proxy_hidden_collector", names)
+
+    def test_restricted_registry_keeps_the_boundary_and_the_filter(self) -> None:
+        """A `?name[]=` scrape, which `prometheus_client.exposition._bake_output`
+        serves from `restricted_registry`, gets the requested families through the
+        same error boundary and `__`-prefix filter as a full scrape."""
+        broken_collector = BrokenCollector("test_registry_proxy_restricted_broken")
+        self._register(broken_collector)
+        self._register(HealthyCollector("test_registry_proxy_restricted_healthy"))
+        self._register(HealthyCollector("__test_registry_proxy_restricted_hidden"))
+        self._register(HealthyCollector("test_registry_proxy_restricted_unasked"))
+
+        restricted = RegistryProxy.restricted_registry(
+            [
+                "test_registry_proxy_restricted_broken",
+                "test_registry_proxy_restricted_healthy",
+                "__test_registry_proxy_restricted_hidden",
+            ]
+        )
+        with self.assertLogs("synapse.metrics", level="ERROR") as cm:
+            names = {metric.name for metric in restricted.collect()}
+
+        self.assertEqual(names, {"test_registry_proxy_restricted_healthy"})
+
+        records = self._records_naming(
+            cm.records, "test_registry_proxy_restricted_broken"
+        )
+        self.assertEqual(len(records), 1)
+        self.assertIsNotNone(records[0].exc_info)

--- a/tests/metrics/test_metrics_server.py
+++ b/tests/metrics/test_metrics_server.py
@@ -1,0 +1,104 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright (C) 2026 Element Creations Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+
+import logging
+import urllib.request
+from typing import Sequence
+
+from prometheus_client.core import REGISTRY
+
+from synapse.app._base import _handle_metrics_request_error, listen_metrics
+
+from tests import unittest
+from tests.metrics._collectors import BrokenCollector, HealthyCollector
+
+logger_name = "synapse.app._base"
+metrics_logger_name = "synapse.metrics"
+
+
+class HandleMetricsRequestErrorTestCase(unittest.TestCase):
+    """Tests for `_handle_metrics_request_error`, the `server.handle_error`
+    replacement installed by `listen_metrics`."""
+
+    def test_unexpected_exception_is_logged_once_with_traceback(self) -> None:
+        """An unexpected error becomes a single ERROR record carrying its traceback."""
+        try:
+            raise RuntimeError("dictionary changed size during iteration")
+        except RuntimeError:
+            with self.assertLogs(logger_name, level="ERROR") as cm:
+                _handle_metrics_request_error(None, ("127.0.0.1", 12345))
+
+        self.assertEqual(len(cm.records), 1)
+        record = cm.records[0]
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertIsNotNone(record.exc_info)
+        assert record.exc_info is not None
+        self.assertIs(record.exc_info[0], RuntimeError)
+
+    def test_disconnection_errors_are_not_logged_as_errors(self) -> None:
+        """A scraper disconnecting is logged at DEBUG, not ERROR."""
+        for exc_type in (ConnectionResetError, BrokenPipeError, ConnectionAbortedError):
+            with self.subTest(exc_type=exc_type):
+                try:
+                    raise exc_type("boom")
+                except exc_type:
+                    with self.assertLogs(logger_name, level="DEBUG") as cm:
+                        _handle_metrics_request_error(None, ("127.0.0.1", 12345))
+
+                self.assertEqual(len(cm.records), 1)
+                self.assertEqual(cm.records[0].levelno, logging.DEBUG)
+
+
+class ListenMetricsEndToEndTestCase(unittest.TestCase):
+    """End-to-end test that a broken collector doesn't stop the rest of the scrape
+    against a real `listen_metrics`-started server."""
+
+    def test_scrape_survives_a_broken_collector(self) -> None:
+        """A `/metrics` scrape still returns 200 with the healthy metrics when one
+        collector raises, logging one ERROR record for it."""
+        broken_collector = BrokenCollector("test_metrics_server_broken_collector")
+        healthy_collector = HealthyCollector("test_metrics_server_healthy_collector")
+        for collector in (broken_collector, healthy_collector):
+            REGISTRY.register(collector)
+            self.addCleanup(REGISTRY.unregister, collector)
+
+        servers = listen_metrics(["127.0.0.1"], 0)
+        for server, thread in servers:
+            # Cleanups run last-registered-first, so these run in reverse: shutdown,
+            # then server_close, then join.
+            self.addCleanup(thread.join, 10)
+            self.addCleanup(server.server_close)
+            self.addCleanup(server.shutdown)
+
+        host = str(servers[0][0].server_address[0])
+        port = servers[0][0].server_address[1]
+
+        with self.assertLogs(metrics_logger_name, level="ERROR") as cm:
+            response = urllib.request.urlopen(
+                f"http://{host}:{port}/metrics", timeout=10
+            )
+            self.assertEqual(response.status, 200)
+            body = response.read()
+
+        self.assertIn(b"test_metrics_server_healthy_collector", body)
+        self.assertNotIn(b"test_metrics_server_broken_collector", body)
+
+        # The scrape runs over the process-global `REGISTRY`, so any other collector
+        # failing during it would otherwise be counted.
+        records: Sequence[logging.LogRecord] = [
+            record
+            for record in cm.records
+            if "test_metrics_server_broken_collector" in record.getMessage()
+        ]
+        self.assertEqual(len(records), 1)


### PR DESCRIPTION
Draft: keeps `/metrics` scrapes working when one collector raises, and stops metrics-listener tracebacks from arriving in the logs one line at a time.

### Problem

Since #18687 the Prometheus exposition runs on `prometheus_client`'s own HTTP thread, concurrently with the reactor. Gauge callbacks and custom `collect()` methods that read reactor-owned state can therefore raise (seen on matrix.org: `RuntimeError: dictionary changed size during iteration` from `BatchingQueue`'s gauge, `TTLCache.__len__` mutating from the metrics thread, `_BackgroundProcess.update_metrics` hitting a negative counter increment). Today one raising collector fails the whole scrape with a 500, so Prometheus records a gap for every metric on that worker.

On top of that, the stdlib prints the traceback to `sys.stderr`, which Synapse redirects into logging one `write()` at a time. In Sentry this shows up as dozens of "issues" titled `File ".../prometheus_client/metrics.py", line 497, in samples`, `~~~~^^`, `Traceback (most recent call last):`, with the actual exception buried as another line. I reproduced both stdlib paths locally; the install-site comment in `listen_metrics` describes them.

### Fix

- **`RegistryProxy.collect` becomes the error boundary.** `start_http_server(registry=...)` only needs an object with `collect()`, and Synapse already passes its own proxy. It now snapshots the collector set the same way `CollectorRegistry.collect` does and wraps each collector individually: a raising collector is logged once with `logger.exception` (naming the collector and its registered metrics) and skipped, and the scrape returns 200 with every other metric family. This works regardless of how the endpoint is served, and Prometheus keeps the remaining series. It reaches into two private `CollectorRegistry` attributes, so an import-time guard fails if a `prometheus_client` upgrade renames them, following the precedent of the `_use_created` hack in the same module.
- **`restricted_registry` on the proxy**, which `prometheus_client` calls for `?name[]=` scrapes and which the proxy lacked (those scrapes raised `AttributeError`). It returns a proxy of its own so the error boundary and the `__`-prefix filter also apply to `?name[]=` scrapes. The cost is that such a scrape collects everything and then discards what was not asked for, where upstream's `RestrictedRegistry` would collect only the requested collectors.
- **`server.handle_error`** on the metrics server is replaced so that a scraper disconnecting while its request is being read (the only error path left that reaches socketserver) is logged at DEBUG, and anything else as a single `logger.exception` record.
- **`prometheus-client` floor moves to 0.20.0.** `listen_metrics` has unpacked the `(server, thread)` pair that `start_http_server` returns since v1.135.0, but older versions return `None`, so the metrics listener could not start on the declared `>=0.10.0` minimum. This PR's end-to-end test is the first CI coverage of `listen_metrics`, which is how the oldest-deps job caught it. Only the lockfile content hash changes.

The ERROR rate per scrape is unchanged: one record per failing collector per scrape, as `LaterGauge.collect` already does. What changes is that those records group into one issue and the scrape keeps serving. Fixing the racing collectors themselves is a separate follow-up.

### Testing

`tests/metrics/test_metrics.py`: a broken collector is skipped while a healthy one still yields, with one ERROR record naming it; `__`-prefixed families still filtered; `?name[]=` keeps the boundary and the filter. `tests/metrics/test_metrics_server.py`: the two `handle_error` behaviours, plus an end-to-end test starting `listen_metrics` on an ephemeral port with a broken and a healthy collector and asserting a 200 containing the healthy metric and one ERROR record. `trial tests.metrics tests.app`, `ruff`, `mypy` clean; `poetry check --lock` passes.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog)
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

🤖 Generated with [Claude Code](https://claude.com/claude-code)
