### PR TITLE
Fix warnings generated by `mdbook build`

### DIFF
--- a/changelog.d/20217.doc
+++ b/changelog.d/20217.doc
@@ -1,0 +1,1 @@
+Fix small warnings in documentation building tooling output.

--- a/docs/development/synapse_architecture/cancellation.md
+++ b/docs/development/synapse_architecture/cancellation.md
@@ -284,6 +284,7 @@ await wait_for_room("!aAAaaAaaaAAAaAaAA:matrix.org")
 await wait_for_room("!aAAaaAaaaAAAaAaAA:matrix.org")
 ```
 </td>
+</tr>
 </table>
 
 ### Uncancelled processing

--- a/docs/openid.md
+++ b/docs/openid.md
@@ -140,7 +140,7 @@ The synapse config will look like this:
 3. Add a rule with any name to add the `preferred_username` claim. 
 (See https://auth0.com/docs/customize/rules/create-rules for more information on how to create rules.)
    
-   <details>
+  <details>
     <summary>Code sample</summary>
 
     ```js

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -4078,7 +4078,7 @@ Parts of this section are required if enabling the `consent` resource under [`li
 
 This setting has the following sub-options:
 
-* `template_dir` (string): Gives the location of the templates for the HTML forms. This directory should contain one subdirectory per language (eg, `en`, `fr`), and each language directory should contain the policy document (named as `<version>.html`) and a success page (success.html).
+* `template_dir` (string): Gives the location of the templates for the HTML forms. This directory should contain one subdirectory per language (eg, `en`, `fr`), and each language directory should contain the policy document (named as <version>.html) and a success page (success.html).
 
 * `version` (number): Specifies the "current" version of the policy document. It defines the version to be served by the consent resource if there is no `v` parameter.
 

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -4078,7 +4078,7 @@ Parts of this section are required if enabling the `consent` resource under [`li
 
 This setting has the following sub-options:
 
-* `template_dir` (string): Gives the location of the templates for the HTML forms. This directory should contain one subdirectory per language (eg, `en`, `fr`), and each language directory should contain the policy document (named as <version>.html) and a success page (success.html).
+* `template_dir` (string): Gives the location of the templates for the HTML forms. This directory should contain one subdirectory per language (eg, `en`, `fr`), and each language directory should contain the policy document (named as `<version>.html`) and a success page (success.html).
 
 * `version` (number): Specifies the "current" version of the policy document. It defines the version to be served by the consent resource if there is no `v` parameter.
 


### PR DESCRIPTION
`mdbook build` was emitting the following warnings:

```
$ mdbook build
 INFO Running the html backend
 WARN unclosed HTML tag `<version>` found in `usage/configuration/config_documentation.md` while exiting Paragraph
HTML tags must be closed before exiting a markdown element.
 WARN unclosed HTML tag `<details>` found in `openid.md` while exiting Item
HTML tags must be closed before exiting a markdown element.
 WARN unexpected HTML end tag `</details>` found in `openid.md`
Check that the HTML tags are properly balanced.
 WARN unexpected HTML end tag `</table>` found in `development/synapse_architecture/cancellation.md`
Check that the HTML tags are properly balanced.
 WARN unclosed HTML tag `<tr>` found in `development/synapse_architecture/cancellation.md`
 WARN unclosed HTML tag `<table>` found in `development/synapse_architecture/cancellation.md`
 INFO HTML book written to `/home/runner/work/synapse/synapse/book`
```

which made reading the output cumbersome. This PR fixes them up.

I briefly thought about promoting these warnings to errors, but mdbook [does not offer such an option yet](https://github.com/rust-lang/mdBook/issues/2493).

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
